### PR TITLE
fix(food-dist): bump synthetic history default 730 → 1095 days (3 years)

### DIFF
--- a/backend/app/services/food_dist_config_generator.py
+++ b/backend/app/services/food_dist_config_generator.py
@@ -680,7 +680,13 @@ class FoodDistConfigGenerator:
 
         await self.db.commit()
 
-        # 10. Generate 2-year transactional history
+        # 10. Generate 3-year transactional history.
+        # 1095 days = two full annual cycles for the seasonal-envelope
+        # fitter (Core MIGRATION_REGISTER §3.20) plus a third cycle for
+        # cross-validation. Was 730 (2 years); bumped 2026-05 because
+        # the envelope fitter needs ≥2 cycles per series and 730 is
+        # exactly on the boundary — the third year gives the fitter
+        # genuine multi-year shape to work with.
         history_counts = {}
         try:
             from app.services.food_dist_history_generator import FoodDistHistoryGenerator
@@ -689,7 +695,7 @@ class FoodDistConfigGenerator:
                 config_id=self.sc_config.id,
                 tenant_id=self.tenant.id,
             )
-            history_counts = await history_gen.generate_history(days=730)
+            history_counts = await history_gen.generate_history(days=1095)
             logger.info(f"Generated {history_counts.get('total', 0):,} history records")
         except Exception:
             logger.exception("History generation failed — config created without history")

--- a/backend/app/services/food_dist_history_generator.py
+++ b/backend/app/services/food_dist_history_generator.py
@@ -133,7 +133,7 @@ HOLIDAY_SPIKES = [
 ]
 
 # ============================================================================
-# Customer Churn Events (day_offset thresholds over 730-day horizon)
+# Customer Churn Events (day_offset thresholds, fire within the first ~14 months)
 # ============================================================================
 
 # Gained customer: Reno Fresh Markets joins at month 10 (~day 300)
@@ -300,8 +300,11 @@ class FoodDistHistoryGenerator:
         self._promotion_events: Dict[Tuple[int, str], float] = {}
         # All customers including churn-gained ones
         self._all_customers: List[CustomerDefinition] = list(CUSTOMERS) + [CUST_RNO]
-        # Total days of history (set in generate_history, used by NPI gate)
-        self._total_days: int = 730
+        # Total days of history (set in generate_history, used by NPI gate).
+        # Default 1095 = 3 years. Two full annual cycles is the floor for
+        # the seasonal-envelope fitter (Core MIGRATION_REGISTER §3.20);
+        # three gives the fitter clean cross-validation room.
+        self._total_days: int = 1095
 
     # ------------------------------------------------------------------
     # Network loading
@@ -2459,19 +2462,25 @@ class FoodDistHistoryGenerator:
 
     async def generate_history(
         self,
-        days: int = 730,
+        days: int = 1095,
         start_date: Optional[date] = None,
         seed: int = 42,
     ) -> Dict[str, int]:
         """
-        Generate complete 2-year transactional history.
+        Generate complete 3-year transactional history.
 
         Agent evaluation uses the Digital Twin (stochastic simulation) for
         train/test split, not historical data. This history establishes
         the baseline operational data for the tenant.
 
+        The default ``days=1095`` (3 years) gives the seasonal-envelope
+        fitter (Core MIGRATION_REGISTER §3.20) two full annual cycles
+        for fitting plus a third cycle for cross-validation. Older
+        callers that explicitly pass ``days=730`` still get exactly the
+        prior behaviour.
+
         Args:
-            days: Number of days of history (default 730 = 2 years)
+            days: Number of days of history (default 1095 = 3 years)
             start_date: Start date for history (default: today - days)
             seed: Random seed for reproducibility
 


### PR DESCRIPTION
## Summary
The Food Dist seeder's docstrings have always claimed "3 years of daily transactional history"; the runtime default was 730 days (2 years). Reconcile to the documented intent.

**Why this matters now**: the seasonal-envelope fitter (Core MIGRATION_REGISTER §3.20, adopted in SCP via #305) needs ≥2 full annual cycles per series. 730 days lands exactly on that floor — fitter works, but every series sits at the minimum with no third cycle for cross-validation. 1095 gives 2 cycles for fit + 1 for held-out validation, matching `eval_on_held_out_scenarios` in TIER_3_GNN_FIRST_PLANNING.md §11.

## Three changes
1. `food_dist_history_generator.py:304` — `_total_days` default 730 → 1095.
2. `food_dist_history_generator.py:2462` — `generate_history(days=...)` default 730 → 1095, docstring "2-year" → "3-year". Existing callers passing `days=730` explicitly still get prior behaviour.
3. `food_dist_config_generator.py:692` — only call site passing `days=730` explicitly bumped to `1095`. Single seed-script entry point — threads the 3-year default through provisioning.

## Seasonality is already there (unchanged)
- `SEASON_PROFILES` (lines 83-89) — 12-month multiplier vectors per product group with distinct peaks (FRZ_DESSERT/BEV peak July at 1.40; REF_DAIRY/DRY_PANTRY peak December at 1.10/1.15; FRZ_PROTEIN peaks Jul + Dec).
- `HOLIDAY_SPIKES` (lines 116-133) — Thanksgiving 1.45×, Christmas 1.40×, Jul 4 1.35×, Super Bowl 1.30×, plus Memorial Day / Easter / back-to-school / Labor Day. 7-14 day lead-in windows.
- Applied per `(customer, product, day)` at lines 418, 425.

So the third year is genuine 365 days of seasonal + holiday-modulated demand, not a copy.

## Test plan
- [x] Re-read seasonality call sites — multipliers applied at each daily tick.
- [ ] Reviewer to confirm: customer churn day_offsets (240 / 300 / 425) still fire within the first ~14 months — they're anchored to start, so bumping total to 1095 just gives a longer pre-churn settling period at the front. (No code change needed; comment updated to reflect this.)
- [ ] Reviewer to spot-check: any test or script that pins a specific `total` row count from `generate_history` will need updating. Grep finds none today.

## Out of scope
This file is byte-identical in `Autonomy-Demo`. Mirror PR follows. The duplication itself is tech debt (synthetic-tenant generators belong in Core per MIGRATION_REGISTER §2.6); not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)