### PR TITLE
feat(seed): one-command regen for Food Dist (--reset-tenant)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ endif
 
 DOCKER_COMPOSE_CMD = $(strip $(COMPOSE_ENV) $(DOCKER_COMPOSE))
 
-.PHONY: up gpu-up up-dev down ps logs reload reload-backend reload-frontend seed reset-admin help init-env proxy-up proxy-down proxy-restart proxy-recreate proxy-logs proxy-url seed-default-group seed-demo-configs seed-three-fg-demo seed-variable-demo all_demo_configs build-create-users db-bootstrap db-reset rebuild-db reseed-db rebuild-gpu train-gnn llm-check generate-site-agent-data train-site-agent train-site-agent-full eval-site-agent test-powell test-engines test-site-agent test-food-dist test-food-dist-trm generate-food-dist train-and-test-food-dist train-and-test-food-dist-quick train-and-test-food-dist-gpu up-llm up-llm-ollama ollama-pull-models openclaw-setup openclaw-up openclaw-down openclaw-logs picoclaw-workspaces picoclaw-fleet picoclaw-up picoclaw-down picoclaw-logs picoclaw-status aws-init aws-plan aws-apply aws-destroy sap-start sap-stop sap-status
+.PHONY: up gpu-up up-dev down ps logs reload reload-backend reload-frontend seed reset-admin help init-env proxy-up proxy-down proxy-restart proxy-recreate proxy-logs proxy-url seed-default-group seed-demo-configs seed-three-fg-demo seed-variable-demo seed-food-dist seed-food-dist-reset all_demo_configs build-create-users db-bootstrap db-reset rebuild-db reseed-db rebuild-gpu train-gnn llm-check generate-site-agent-data train-site-agent train-site-agent-full eval-site-agent test-powell test-engines test-site-agent test-food-dist test-food-dist-trm generate-food-dist train-and-test-food-dist train-and-test-food-dist-quick train-and-test-food-dist-gpu up-llm up-llm-ollama ollama-pull-models openclaw-setup openclaw-up openclaw-down openclaw-logs picoclaw-workspaces picoclaw-fleet picoclaw-up picoclaw-down picoclaw-logs picoclaw-status aws-init aws-plan aws-apply aws-destroy sap-start sap-stop sap-status
 
 # =========================================================================
 # LOCAL LLM TARGETS (vLLM + Ollama for RAG)
@@ -373,6 +373,18 @@ seed-three-fg-demo:
 seed-variable-demo:
 	@echo "\n[+] Seeding Variable demo tenant..."; \
 	$(DOCKER_COMPOSE_CMD) exec backend python3 scripts/seed_variable_demo.py $(SEED_ARGS)
+
+seed-food-dist:
+	@echo "\n[+] Seeding Food Dist demo tenant..."; \
+	$(DOCKER_COMPOSE_CMD) exec backend python3 scripts/seed_food_dist_demo.py $(SEED_ARGS)
+
+# Wipe-then-seed: removes any existing Food Dist tenant + cascading
+# data before seeding from a clean state. Use this after a generator
+# change that requires regenerating history (e.g. the 730→1095 day
+# bump in PR #3).
+seed-food-dist-reset:
+	@echo "\n[+] Resetting + reseeding Food Dist demo tenant..."; \
+	$(DOCKER_COMPOSE_CMD) exec backend python3 scripts/seed_food_dist_demo.py --reset-tenant $(SEED_ARGS)
 
 warm-start-all:
 	@echo "\n[+] Generating warm start historical data for all configs..."; \

--- a/backend/scripts/seed_food_dist_demo.py
+++ b/backend/scripts/seed_food_dist_demo.py
@@ -15,10 +15,13 @@ Individual Role Users (for testing specific role flows):
 
 Usage:
     # Run via docker compose
-    docker compose exec backend python scripts/seed_us_foods_demo.py
+    docker compose exec backend python scripts/seed_food_dist_demo.py
 
-    # Or directly with venv
-    cd backend && python scripts/seed_us_foods_demo.py
+    # Wipe-then-seed mode — removes any existing Food Dist tenant +
+    # cascading data before seeding from a clean state. Use this after
+    # a generator change that requires regenerating history (e.g. the
+    # 730→1095 day bump in TMS PR #3).
+    docker compose exec backend python scripts/seed_food_dist_demo.py --reset-tenant
 
 Demo Flow:
     1. Login as demo@distdemo.com (password: Autonomy@2026)
@@ -27,6 +30,7 @@ Demo Flow:
     4. All Powell dashboards accessible without logout
 """
 
+import argparse
 import os
 import sys
 import asyncio
@@ -472,10 +476,80 @@ def _generate_sc_config_for_group(tenant_id: int):
     asyncio.run(_run())
 
 
+def parse_args() -> argparse.Namespace:
+    """Parse CLI flags. The script is normally invoked without
+    arguments; ``--reset-tenant`` opts into the destructive
+    "wipe-then-seed" flow used when regenerating against an existing
+    DB."""
+    p = argparse.ArgumentParser(description="Seed the Food Dist demo tenant.")
+    p.add_argument(
+        "--reset-tenant",
+        action="store_true",
+        help=(
+            "Delete the existing Food Dist tenant + all cascading data "
+            "(users, configs, transactions, hierarchies) before seeding. "
+            "Use this when a generator change requires regenerating history "
+            "— e.g. the 730→1095 day bump in TMS PR #3. Without this flag "
+            "the script reuses any existing tenant and the new transactional "
+            "rows append on top of the old ones, which is rarely what you "
+            "want."
+        ),
+    )
+    return p.parse_args()
+
+
+def reset_existing_tenant(db: Session) -> None:
+    """Delete the existing Food Dist tenant + every dependent row.
+
+    Reuses :class:`TenantService.delete_tenant` which handles the
+    multi-phase deletion (user-FK rows, config-FK rows, tenant-scoped
+    rows, scenarios, agent artifacts) with savepoints so individual
+    table failures don't abort the transaction.
+
+    Tenant lookup mirrors :func:`create_or_get_tenant` so the same
+    name-shape ambiguities ("Food Dist" / "Food Distributor" /
+    slug:food-dist) resolve consistently.
+    """
+    from sqlalchemy import or_
+    from app.services.tenant_service import TenantService
+
+    tenant = (
+        db.query(Tenant)
+        .filter(
+            or_(
+                Tenant.name == FOOD_DIST_CUSTOMER_NAME,
+                Tenant.name.ilike("Food Dist%"),
+                Tenant.name.ilike("%Food%Dist%"),
+                Tenant.slug == "food-dist",
+            )
+        )
+        .first()
+    )
+    if tenant is None:
+        print(f"  No existing Food Dist tenant to reset.")
+        return
+
+    print(f"  Resetting tenant '{tenant.name}' (id={tenant.id})...")
+    try:
+        TenantService(db).delete_tenant(tenant.id)
+        print("  Tenant deleted (cascaded user / config / tx data).")
+    except Exception as exc:
+        print(f"  TenantService.delete_tenant failed: {exc}")
+        db.rollback()
+        raise
+
+    db.commit()
+    print("  Reset complete. Re-seeding from clean state.\n")
+
+
 def main():
     """Seed Food Dist demo setup."""
+    args = parse_args()
+
     print("=" * 70)
     print("Seeding Food Dist Demo - Powell Framework Aligned Users")
+    if args.reset_tenant:
+        print("  --reset-tenant: existing tenant will be wiped before seeding")
     print("=" * 70)
 
     # Create database session
@@ -487,6 +561,10 @@ def main():
     db: Session = SyncSessionLocal()
 
     try:
+        if args.reset_tenant:
+            print("\n0. Resetting existing tenant...")
+            reset_existing_tenant(db)
+
         # Step 1: Ensure permissions are seeded
         print("\n1. Ensuring permissions are seeded...")
         seed_default_permissions(db)


### PR DESCRIPTION
## Summary
After [PR #3](https://github.com/azirella-ltd/Autonomy-TMS/pull/3) (730→1095 day bump), regenerating an existing Food Dist tenant required three manual steps: identify tenant → manual cascade delete → re-run the seed. Folds that into one command.

## Two changes
1. **`scripts/seed_food_dist_demo.py`** — adds `--reset-tenant` flag. When set, calls a new `reset_existing_tenant(db)` helper that reuses `TenantService.delete_tenant` (multi-phase savepoint cascade). Tenant lookup mirrors `create_or_get_tenant` so the same name-shape ambiguities ("Food Dist" / "Food Distributor" / slug:food-dist) resolve consistently.
2. **`Makefile`** — adds `make seed-food-dist` (normal) and `make seed-food-dist-reset` (wipe-then-seed). Updates `.PHONY`. The pre-existing `seed-food-dist-pipeline` (forecast pipeline only) target is preserved unchanged.

## Backwards compatibility
Existing call sites without the flag behave identically to before.

## Test plan
- [x] AST parse confirms `parse_args` + `reset_existing_tenant` + `main` all present, `argparse` imported.
- [x] `python -m py_compile` clean.
- [ ] Manual smoke: `make seed-food-dist-reset` against a Postgres dev with a stale Food Dist tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)