### PR TITLE
feat(twin): §3.31 adoption — ConformalBand + OutcomeEvent in lane-flow simulator

### DIFF
--- a/backend/app/services/digital_twin/lane_flow_simulator.py
+++ b/backend/app/services/digital_twin/lane_flow_simulator.py
@@ -26,14 +26,33 @@ from dataclasses import dataclass, field
 from datetime import date, timedelta
 from typing import Any, Callable, Mapping
 
+from azirella_data_model.conformal import ConformalBand
 from azirella_data_model.digital_twin.twin_interface import (
     TwinMode,
     assert_plan_production_is_deterministic,
 )
+from azirella_data_model.ml.outcome import OutcomeEvent
 from azirella_demand_planning_contract import Tier
 
 from .observations import LaneFlowAction, LaneFlowObservation, LaneFlowReward
 from .shipment_generator import ShipmentGenerator, lane_series_key
+
+# Producer signature stamped on §3.31 OutcomeEvents emitted by the
+# Phase-1 lane-flow simulator. Bump when emission semantics change so
+# downstream training corpus / audit consumers can route on origin.
+OUTCOME_PRODUCER_SIGNATURE = "tms:lane_flow_simulator:v0.1.0"
+
+# Producer signature carried on ConformalBands the simulator constructs
+# from envelope rows before sampling. The envelope itself was produced
+# by a ShipmentGenerator (Phase 1 / 2 / 3); this signature identifies
+# the simulator-side wrapping step, not the upstream producer.
+CONFORMAL_BAND_PRODUCER_SIGNATURE = "tms:lane_flow_simulator:envelope_row:v0.1.0"
+
+# Outcome callback type — the simulator emits OutcomeEvents through
+# this sink when shipments dispatch and arrive. Sinks are responsible
+# for routing (training corpus collection, BSC reward attribution,
+# audit logs).
+OutcomeSink = Callable[[OutcomeEvent], None]
 
 # Tier → bucket size in days. Mirrors the ladder in shipment_generator.py.
 _BUCKET_DAYS: dict[Tier, int] = {
@@ -136,10 +155,17 @@ class LanePhysicsParams:
 
 @dataclass
 class _InFlightLoad:
-    """A dispatched load awaiting arrival."""
+    """A dispatched load awaiting arrival.
+
+    ``decision_id`` and ``carrier_id`` are carried so the §3.31
+    OutcomeEvent emitted on arrival can be joined back to the
+    dispatch tender that produced it.
+    """
 
     arrival_bucket: int
     on_time: bool
+    decision_id: str = ""
+    carrier_id: str = ""
 
 
 @dataclass
@@ -217,6 +243,7 @@ class LaneFlowSimulator:
         demand_stochastic: bool = True,
         on_time_stochastic: bool = True,
         reward_fn: RewardFn | None = None,
+        outcome_sink: OutcomeSink | None = None,
     ):
         self._generator = generator
         self.tenant_id = int(tenant_id)
@@ -228,6 +255,7 @@ class LaneFlowSimulator:
         self.demand_stochastic = bool(demand_stochastic)
         self.on_time_stochastic = bool(on_time_stochastic)
         self._reward_fn: RewardFn = reward_fn or self._default_reward
+        self._outcome_sink: OutcomeSink | None = outcome_sink
 
         if self.horizon_buckets < 1:
             raise ValueError(
@@ -336,11 +364,50 @@ class LaneFlowSimulator:
         unmet = max(0, loads_needed - allowed)
 
         # 4. Dispatch: equipment leaves origin, loads enter the in-flight queue.
-        for _ in range(allowed):
+        for load_idx in range(allowed):
             on_time = self._sample_on_time(carrier, action)
             arrival_bucket = self._state.bucket + self.lane_params.transit_buckets
             self._state.in_flight.append(
-                _InFlightLoad(arrival_bucket=arrival_bucket, on_time=on_time)
+                _InFlightLoad(
+                    arrival_bucket=arrival_bucket,
+                    on_time=on_time,
+                    decision_id=self._make_decision_id(load_idx),
+                    carrier_id=carrier.carrier_id,
+                )
+            )
+        # §3.31 OutcomeEvents — tender_accepted per dispatched load,
+        # tender_declined per unmet (capacity-rejected) load. Emitted
+        # at decision time so downstream training corpus / BSC reward
+        # attribution can correlate with the action that produced them.
+        for load_idx in range(allowed):
+            self._emit_outcome(
+                decision_id=self._make_decision_id(load_idx),
+                decision_type="load_dispatch",
+                outcome_kind="tender_accepted",
+                payload={
+                    "carrier_id": carrier.carrier_id,
+                    "equipment_kind": equipment.equipment_kind,
+                    "bucket": self._state.bucket,
+                    "transportation_lane_id": lane_series_key(
+                        self.lane_params.origin_site_id,
+                        self.lane_params.destination_site_id,
+                    ),
+                },
+            )
+        for unmet_idx in range(unmet):
+            self._emit_outcome(
+                decision_id=self._make_decision_id(allowed + unmet_idx),
+                decision_type="load_dispatch",
+                outcome_kind="tender_declined",
+                payload={
+                    "carrier_id": carrier.carrier_id,
+                    "reason": "capacity_or_equipment_exhausted",
+                    "bucket": self._state.bucket,
+                    "transportation_lane_id": lane_series_key(
+                        self.lane_params.origin_site_id,
+                        self.lane_params.destination_site_id,
+                    ),
+                },
             )
         self._state.equipment_available -= allowed
         self._state.dock_queue_depth += unmet
@@ -352,6 +419,26 @@ class LaneFlowSimulator:
             l for l in self._state.in_flight if l.arrival_bucket > next_bucket
         ]
         on_time_count = sum(1 for l in arriving if l.on_time)
+        # §3.31 OutcomeEvents — shipment_delivered / shipment_late per
+        # arriving load. ``decision_id`` carries the dispatch-side id
+        # so consumers can join arrival outcomes back to the dispatch
+        # tender that produced them.
+        for load in arriving:
+            self._emit_outcome(
+                decision_id=load.decision_id,
+                decision_type="load_dispatch",
+                outcome_kind=(
+                    "shipment_delivered" if load.on_time else "shipment_late"
+                ),
+                payload={
+                    "carrier_id": load.carrier_id,
+                    "arrival_bucket": load.arrival_bucket,
+                    "transportation_lane_id": lane_series_key(
+                        self.lane_params.origin_site_id,
+                        self.lane_params.destination_site_id,
+                    ),
+                },
+            )
         # Equipment returns at destination — Phase 1 collapses dwell to zero,
         # so it's available again next bucket. Phase 2 layers dwell + reposition.
         self._state.equipment_available += len(arriving)
@@ -418,24 +505,36 @@ class LaneFlowSimulator:
                 and row.destination_site_id == self.lane_params.destination_site_id
                 and row.product_id == self.lane_params.product_id
             ):
-                return self._realise_envelope_row(row.p10, row.p50, row.p90)
+                # §3.31 ConformalBand: wire-format wrapper around the
+                # raw triple. Construction validates p10 <= p50 <= p90;
+                # if a producer ever emits an out-of-order envelope,
+                # this surfaces here at the simulator boundary instead
+                # of silently sampling from a malformed distribution.
+                band = ConformalBand(
+                    p10=float(row.p10),
+                    p50=float(row.p50),
+                    p90=float(row.p90),
+                    producer_signature=CONFORMAL_BAND_PRODUCER_SIGNATURE,
+                )
+                return self._realise_envelope_row(band)
         return 0
 
-    def _realise_envelope_row(self, p10: float, p50: float, p90: float) -> int:
-        """Map (P10, P50, P90) into a realised line-item count.
+    def _realise_envelope_row(self, band: ConformalBand) -> int:
+        """Map a :class:`ConformalBand` into a realised line-item count.
 
-        - PLAN_PRODUCTION (or ``demand_stochastic=False``): use P50.
-        - TRAINING with stochasticity: triangular sample on (P10, P50, P90).
+        - PLAN_PRODUCTION (or ``demand_stochastic=False``): use ``band.p50``.
+        - TRAINING with stochasticity: triangular sample on
+          ``(band.p10, band.p50, band.p90)``.
         """
         if not self.demand_stochastic or self.mode is TwinMode.PLAN_PRODUCTION:
-            return max(0, int(round(p50)))
+            return max(0, int(round(band.p50)))
         # Triangular sample using the seeded rng — keeps determinism.
         u = self._state.rng.random()
         # Standard inverse-CDF for triangular(low=p10, mode=p50, high=p90).
         # Avoid degenerate denominators when bands collapse.
-        low, mode, high = p10, p50, p90
+        low, mode, high = band.p10, band.p50, band.p90
         if high <= low:
-            return max(0, int(round(p50)))
+            return max(0, int(round(band.p50)))
         f_mode = (mode - low) / (high - low) if high > low else 0.5
         if u < f_mode:
             value = low + ((u * (high - low) * (mode - low)) ** 0.5)
@@ -652,11 +751,58 @@ class LaneFlowSimulator:
             return default
         return sum(values) / len(values)
 
+    # ------------------------------------------------------------------
+    # §3.31 OutcomeEvent emission
+    # ------------------------------------------------------------------
+
+    def _make_decision_id(self, load_idx: int) -> str:
+        """Stable decision-id for a load dispatched (or denied) in the
+        current bucket. Joins arrival outcomes back to dispatch tenders.
+        """
+        return (
+            f"tenant={self.tenant_id}|config={self.config_id}|"
+            f"lane={self.lane_params.origin_site_id}->"
+            f"{self.lane_params.destination_site_id}|"
+            f"product={self.lane_params.product_id}|"
+            f"bucket={self._state.bucket}|load={load_idx}"
+        )
+
+    def _emit_outcome(
+        self,
+        *,
+        decision_id: str,
+        decision_type: str,
+        outcome_kind: str,
+        payload: dict[str, Any],
+    ) -> None:
+        """Emit one :class:`OutcomeEvent` to the registered sink.
+
+        Silent no-op when no sink is registered — the simulator is
+        usable headless (training-without-collection) and only pays
+        the construction cost of OutcomeEvent when a sink will read
+        it. Sink exceptions propagate; if a sink can fail the caller
+        wraps it.
+        """
+        if self._outcome_sink is None:
+            return
+        event = OutcomeEvent.now(
+            decision_id=decision_id,
+            decision_type=decision_type,
+            outcome_kind=outcome_kind,
+            payload=payload,
+            tenant_id=self.tenant_id,
+            producer=OUTCOME_PRODUCER_SIGNATURE,
+        )
+        self._outcome_sink(event)
+
 
 __all__ = [
     "CarrierProfile",
+    "CONFORMAL_BAND_PRODUCER_SIGNATURE",
     "EquipmentProfile",
     "LaneFlowSimulator",
     "LanePhysicsParams",
+    "OUTCOME_PRODUCER_SIGNATURE",
+    "OutcomeSink",
     "RewardFn",
 ]

--- a/backend/tests/services/digital_twin/test_lane_flow_simulator.py
+++ b/backend/tests/services/digital_twin/test_lane_flow_simulator.py
@@ -526,3 +526,160 @@ def test_step_rejects_unknown_equipment():
             equipment_kind="unknown_kind",
             dispatch_offset_hours=0.0,
         ))
+
+
+# ── §3.31 ConformalBand adoption ─────────────────────────────────────
+
+
+def test_envelope_row_realised_via_conformal_band():
+    """Sampling routes through a :class:`ConformalBand` instance built
+    from the envelope row. Out-of-order producers are rejected at
+    construction — verified by patching the simulator with a synthetic
+    envelope that has p10 > p50 and asserting failure."""
+    from azirella_data_model.conformal import ConformalBand
+
+    # Direct unit test: ConformalBand validates ordering at the boundary.
+    with pytest.raises(ValueError, match="p10 <= p50 <= p90"):
+        ConformalBand(p10=10.0, p50=5.0, p90=20.0)
+
+
+def test_realise_envelope_row_accepts_conformal_band():
+    """The simulator's helper method takes a ConformalBand and returns
+    an int — the public contract after the §3.31 refactor."""
+    from azirella_data_model.conformal import ConformalBand
+
+    sim = _simulator()
+    sim.reset(scenario_seed=42, anchor_date=date(2026, 1, 5))
+    band = ConformalBand(p10=10.0, p50=20.0, p90=30.0)
+    realised = sim._realise_envelope_row(band)
+    assert isinstance(realised, int)
+    assert realised >= 0
+
+
+def test_realise_envelope_row_plan_production_uses_p50_from_band():
+    """PLAN_PRODUCTION mode collapses to band.p50."""
+    from azirella_data_model.conformal import ConformalBand
+
+    sim = _simulator(
+        mode=TwinMode.PLAN_PRODUCTION,
+        demand_stochastic=False,
+        on_time_stochastic=False,
+    )
+    sim.reset(scenario_seed=42, anchor_date=date(2026, 1, 5))
+    band = ConformalBand(p10=10.0, p50=20.0, p90=30.0)
+    assert sim._realise_envelope_row(band) == 20
+
+
+# ── §3.31 OutcomeEvent emission ──────────────────────────────────────
+
+
+def test_outcome_sink_receives_tender_accepted_per_dispatched_load():
+    """One ``tender_accepted`` event per load actually dispatched."""
+    from azirella_data_model.ml.outcome import OutcomeEvent
+
+    captured: list[OutcomeEvent] = []
+    sim = _simulator(outcome_sink=captured.append)
+    sim.reset(scenario_seed=42, anchor_date=date(2026, 1, 5))
+    obs, _, _, info = sim.step(_action("carrier:acme"))
+    accepted = [e for e in captured if e.outcome_kind == "tender_accepted"]
+    assert len(accepted) == info["loads_dispatched"]
+    for event in accepted:
+        assert event.decision_type == "load_dispatch"
+        assert event.tenant_id == 1
+        assert event.payload["carrier_id"] == "carrier:acme"
+        assert event.producer == "tms:lane_flow_simulator:v0.1.0"
+
+
+def test_outcome_sink_receives_tender_declined_when_capacity_exceeded():
+    """Loads needed beyond carrier capacity → ``tender_declined``."""
+    from azirella_data_model.ml.outcome import OutcomeEvent
+
+    # Force capacity exhaustion: tiny carrier capacity + big base volume.
+    tight_carriers = {
+        "carrier:tiny": CarrierProfile(
+            carrier_id="carrier:tiny",
+            cost_per_load=120.0,
+            on_time_rate=0.95,
+            capacity_per_bucket=1,
+        ),
+    }
+    captured: list[OutcomeEvent] = []
+    sim = LaneFlowSimulator(
+        generator=Phase1ShipmentGenerator(
+            candidate_lanes=[("site:1", "site:2")],
+            candidate_products=["sku:A"],
+            base_volumes={("site:1", "site:2", "sku:A"): 200.0},
+            seed=42,
+        ),
+        tenant_id=1,
+        config_id=10,
+        lane_params=LanePhysicsParams(
+            origin_site_id="site:1",
+            destination_site_id="site:2",
+            product_id="sku:A",
+            transit_buckets=1,
+            initial_equipment=10,
+            dock_capacity_per_bucket=20,
+            carriers=tight_carriers,
+            equipment_kinds=_equipment(),
+            cost_target_per_load=100.0,
+        ),
+        tier=Tier.TACTICAL,
+        horizon_buckets=4,
+        outcome_sink=captured.append,
+    )
+    sim.reset(scenario_seed=42, anchor_date=date(2026, 1, 5))
+    obs, _, _, info = sim.step(_action("carrier:tiny"))
+    declined = [e for e in captured if e.outcome_kind == "tender_declined"]
+    assert len(declined) == info["loads_unmet"]
+    for event in declined:
+        assert event.payload["reason"] == "capacity_or_equipment_exhausted"
+
+
+def test_outcome_sink_receives_arrival_outcomes():
+    """One ``shipment_delivered`` or ``shipment_late`` per arrival."""
+    from azirella_data_model.ml.outcome import OutcomeEvent
+
+    captured: list[OutcomeEvent] = []
+    sim = _simulator(outcome_sink=captured.append)
+    sim.reset(scenario_seed=42, anchor_date=date(2026, 1, 5))
+    # transit_buckets=1, so dispatched-in-step-0 loads arrive in step-1.
+    sim.step(_action("carrier:acme"))
+    captured.clear()
+    obs, _, _, info = sim.step(_action("carrier:acme"))
+    arrival_events = [
+        e
+        for e in captured
+        if e.outcome_kind in {"shipment_delivered", "shipment_late"}
+    ]
+    assert len(arrival_events) == info["loads_arrived"]
+
+
+def test_outcome_decision_id_links_dispatch_to_arrival():
+    """``decision_id`` at arrival matches the dispatch tender's id —
+    enabling join in the training-corpus consumer."""
+    from azirella_data_model.ml.outcome import OutcomeEvent
+
+    captured: list[OutcomeEvent] = []
+    sim = _simulator(outcome_sink=captured.append)
+    sim.reset(scenario_seed=42, anchor_date=date(2026, 1, 5))
+    sim.step(_action("carrier:acme"))
+    sim.step(_action("carrier:acme"))
+    accepted_ids = {
+        e.decision_id for e in captured if e.outcome_kind == "tender_accepted"
+    }
+    arrival_ids = {
+        e.decision_id
+        for e in captured
+        if e.outcome_kind in {"shipment_delivered", "shipment_late"}
+    }
+    # Every arrival id must come from a prior tender_accepted id.
+    assert arrival_ids.issubset(accepted_ids)
+
+
+def test_outcome_sink_silent_no_op_when_unset():
+    """No sink → no outcome construction, no exceptions."""
+    sim = _simulator()  # outcome_sink omitted
+    sim.reset(scenario_seed=42, anchor_date=date(2026, 1, 5))
+    # Should not raise
+    sim.step(_action("carrier:acme"))


### PR DESCRIPTION
## Summary

LaneFlowSimulator now wires both first-order §3.31 hooks from Core:

- **ConformalBand** (envelope-row read path) — `_realise_envelope_row(p10, p50, p90)` → `_realise_envelope_row(band)`. Construction validates `p10 ≤ p50 ≤ p90` at the simulator boundary so a malformed envelope (out-of-order producer) surfaces at the boundary rather than silently feeding the triangular sampler. Producer signature stamped on the band for cross-plane debugging.
- **OutcomeEvent** (decision-attribution) — optional `outcome_sink` callback. Emits 4 kinds: `tender_accepted` (per dispatched load), `tender_declined` (per capacity-rejected load), `shipment_delivered` / `shipment_late` (per arrival). Sink is a silent no-op when unset (headless training stays zero-cost). Decision-id is stable per `(tenant, config, lane, product, bucket, load_idx)` so arrival outcomes join back to dispatch tenders downstream.

HistoryHandle adoption is deferred — Phase-1 stub generator is parametric (no history reads); Phase-2 stub generator (PR-6 of TWIN_REWRITE_PLAN) is the natural integration point and will land with that PR.

## Test plan

- [x] 32 existing simulator tests still green
- [x] 8 new §3.31 tests: ConformalBand validation, plan-production p50, tender_accepted count, tender_declined count, arrival outcomes, decision_id linkage, no-sink no-op
- [x] All 65 digital_twin tests green