### PR TITLE
refactor(§3.34): TMS heuristic library reverts to TMS-local

### DIFF
--- a/backend/app/services/powell/broker_routing_trm.py
+++ b/backend/app/services/powell/broker_routing_trm.py
@@ -96,10 +96,10 @@ class BrokerRoutingTRM:
         self.config_id = config_id
         self._model = None
 
-        from azirella_data_model.powell.tms.heuristic_library.dispatch import (
+        from app.services.powell.tms_heuristic_library.dispatch import (
             compute_tms_decision,
         )
-        from azirella_data_model.powell.tms.heuristic_library.base import (
+        from app.services.powell.tms_heuristic_library.base import (
             BrokerRoutingState,
         )
         self._compute_decision = compute_tms_decision

--- a/backend/app/services/powell/capacity_buffer_trm.py
+++ b/backend/app/services/powell/capacity_buffer_trm.py
@@ -96,10 +96,10 @@ class CapacityBufferTRM:
         self.config_id = config_id
         self._model = None
 
-        from azirella_data_model.powell.tms.heuristic_library.dispatch import (
+        from app.services.powell.tms_heuristic_library.dispatch import (
             compute_tms_decision,
         )
-        from azirella_data_model.powell.tms.heuristic_library.base import (
+        from app.services.powell.tms_heuristic_library.base import (
             CapacityBufferState,
         )
         self._compute_decision = compute_tms_decision

--- a/backend/app/services/powell/capacity_promise_trm.py
+++ b/backend/app/services/powell/capacity_promise_trm.py
@@ -66,10 +66,10 @@ class CapacityPromiseTRM:
         self.config_id = config_id
         self._model = None
 
-        from azirella_data_model.powell.tms.heuristic_library.dispatch import (
+        from app.services.powell.tms_heuristic_library.dispatch import (
             compute_tms_decision,
         )
-        from azirella_data_model.powell.tms.heuristic_library.base import (
+        from app.services.powell.tms_heuristic_library.base import (
             CapacityPromiseState,
         )
         self._compute_decision = compute_tms_decision

--- a/backend/app/services/powell/demand_sensing_trm.py
+++ b/backend/app/services/powell/demand_sensing_trm.py
@@ -83,10 +83,10 @@ class DemandSensingTRM:
         self.config_id = config_id
         self._model = None
 
-        from azirella_data_model.powell.tms.heuristic_library.dispatch import (
+        from app.services.powell.tms_heuristic_library.dispatch import (
             compute_tms_decision,
         )
-        from azirella_data_model.powell.tms.heuristic_library.base import (
+        from app.services.powell.tms_heuristic_library.base import (
             DemandSensingState,
         )
         self._compute_decision = compute_tms_decision

--- a/backend/app/services/powell/dock_scheduling_trm.py
+++ b/backend/app/services/powell/dock_scheduling_trm.py
@@ -102,10 +102,10 @@ class DockSchedulingTRM:
         self.config_id = config_id
         self._model = None
 
-        from azirella_data_model.powell.tms.heuristic_library.dispatch import (
+        from app.services.powell.tms_heuristic_library.dispatch import (
             compute_tms_decision,
         )
-        from azirella_data_model.powell.tms.heuristic_library.base import (
+        from app.services.powell.tms_heuristic_library.base import (
             DockSchedulingState,
         )
         self._compute_decision = compute_tms_decision

--- a/backend/app/services/powell/equipment_reposition_trm.py
+++ b/backend/app/services/powell/equipment_reposition_trm.py
@@ -99,10 +99,10 @@ class EquipmentRepositionTRM:
         self.config_id = config_id
         self._model = None
 
-        from azirella_data_model.powell.tms.heuristic_library.dispatch import (
+        from app.services.powell.tms_heuristic_library.dispatch import (
             compute_tms_decision,
         )
-        from azirella_data_model.powell.tms.heuristic_library.base import (
+        from app.services.powell.tms_heuristic_library.base import (
             EquipmentRepositionState,
         )
         self._compute_decision = compute_tms_decision

--- a/backend/app/services/powell/exception_management_trm.py
+++ b/backend/app/services/powell/exception_management_trm.py
@@ -86,10 +86,10 @@ class ExceptionManagementTRM:
         # one-time WARNING from PolicyCache).
         self._policy = PolicyCache(tenant_id=tenant_id, config_id=config_id)
 
-        from azirella_data_model.powell.tms.heuristic_library.dispatch import (
+        from app.services.powell.tms_heuristic_library.dispatch import (
             compute_tms_decision,
         )
-        from azirella_data_model.powell.tms.heuristic_library.base import (
+        from app.services.powell.tms_heuristic_library.base import (
             ExceptionManagementState,
         )
         self._compute_decision = compute_tms_decision

--- a/backend/app/services/powell/freight_procurement_trm.py
+++ b/backend/app/services/powell/freight_procurement_trm.py
@@ -57,10 +57,10 @@ class FreightProcurementTRM:
         self._heuristic_fn = None
 
         # Import heuristic teacher
-        from azirella_data_model.powell.tms.heuristic_library.dispatch import (
+        from app.services.powell.tms_heuristic_library.dispatch import (
             compute_tms_decision,
         )
-        from azirella_data_model.powell.tms.heuristic_library.base import (
+        from app.services.powell.tms_heuristic_library.base import (
             FreightProcurementState,
         )
         self._compute_decision = compute_tms_decision

--- a/backend/app/services/powell/intermodal_transfer_trm.py
+++ b/backend/app/services/powell/intermodal_transfer_trm.py
@@ -92,10 +92,10 @@ class IntermodalTransferTRM:
         self.config_id = config_id
         self._model = None
 
-        from azirella_data_model.powell.tms.heuristic_library.dispatch import (
+        from app.services.powell.tms_heuristic_library.dispatch import (
             compute_tms_decision,
         )
-        from azirella_data_model.powell.tms.heuristic_library.base import (
+        from app.services.powell.tms_heuristic_library.base import (
             IntermodalTransferState,
         )
         self._compute_decision = compute_tms_decision

--- a/backend/app/services/powell/load_build_trm.py
+++ b/backend/app/services/powell/load_build_trm.py
@@ -96,10 +96,10 @@ class LoadBuildTRM:
         self.config_id = config_id
         self._model = None
 
-        from azirella_data_model.powell.tms.heuristic_library.dispatch import (
+        from app.services.powell.tms_heuristic_library.dispatch import (
             compute_tms_decision,
         )
-        from azirella_data_model.powell.tms.heuristic_library.base import (
+        from app.services.powell.tms_heuristic_library.base import (
             LoadBuildState,
         )
         self._compute_decision = compute_tms_decision

--- a/backend/app/services/powell/shipment_tracking_trm.py
+++ b/backend/app/services/powell/shipment_tracking_trm.py
@@ -87,10 +87,10 @@ class ShipmentTrackingTRM:
         self.config_id = config_id
         self._model = None
 
-        from azirella_data_model.powell.tms.heuristic_library.dispatch import (
+        from app.services.powell.tms_heuristic_library.dispatch import (
             compute_tms_decision,
         )
-        from azirella_data_model.powell.tms.heuristic_library.base import (
+        from app.services.powell.tms_heuristic_library.base import (
             ShipmentTrackingState,
         )
         self._compute_decision = compute_tms_decision

--- a/backend/app/services/powell/tms_heuristic_library/__init__.py
+++ b/backend/app/services/powell/tms_heuristic_library/__init__.py
@@ -1,32 +1,43 @@
-"""TMS Heuristic Library — thin re-export shim.
+"""TMS Heuristic Library — deterministic decision rules for transportation TRMs.
 
-Pure logic lives in Core at
-`azirella_data_model.powell.tms.heuristic_library`. This module keeps
-the existing `app.services.powell.tms_heuristic_library` import path
-working by re-exporting the Core symbols unchanged.
+Each TMS TRM has a corresponding heuristic that encodes industry best practice.
+The heuristic is the bootstrap policy used to seed (state, action, reward)
+trajectories for TRM training, and the deterministic fallback when the
+neural-network model is unavailable.
 
-Extracted to Core on 2026-04-18. See
-`docs/TMS_TRM_TRAINING_DATA_SPECIFICATION.md` for the algorithmic
-reference.
+The library is **single-implementation, ERP-source-agnostic** — transportation
+operations follow standard industry practice across SAP TM / Manhattan /
+Blue Yonder / Oracle TM / MercuryGate. (Contrast with SCP, where heuristics
+branch by ERP source — SAP / D365 / Odoo — because supply-chain field shapes
+diverge per system.)
+
+## Where this library used to live
+
+This module was moved here from Core (``azirella_data_model.powell.tms.heuristic_library``)
+on 2026-05-02 to satisfy the plane-module invariant in
+``Autonomy-Core/CLAUDE.md``: product repos own *only* their decision-policy
+modules; plane-specific TRMs and their heuristic policies belong in the
+product repo, not Core. See ``Autonomy-Core/docs/MIGRATION_REGISTER.md``
+§3.34 for the move-back rationale and §1.13 for the original placement-violation
+context.
 """
 
-from azirella_data_model.powell.tms.heuristic_library.base import (  # noqa: F401
-    TMSHeuristicDecision,
-    CapacityPromiseState,
-    ShipmentTrackingState,
-    DemandSensingState,
+from .base import (
+    BrokerRoutingState,
     CapacityBufferState,
+    CapacityPromiseState,
+    DemandSensingState,
+    DockSchedulingState,
+    EquipmentRepositionState,
     ExceptionManagementState,
     FreightProcurementState,
-    BrokerRoutingState,
-    DockSchedulingState,
-    LoadBuildState,
     IntermodalTransferState,
-    EquipmentRepositionState,
+    LaneVolumeForecastState,
+    LoadBuildState,
+    ShipmentTrackingState,
+    TMSHeuristicDecision,
 )
-from azirella_data_model.powell.tms.heuristic_library.dispatch import (  # noqa: F401
-    compute_tms_decision,
-)
+from .dispatch import compute_tms_decision
 
 __all__ = [
     "TMSHeuristicDecision",
@@ -41,5 +52,6 @@ __all__ = [
     "LoadBuildState",
     "IntermodalTransferState",
     "EquipmentRepositionState",
+    "LaneVolumeForecastState",
     "compute_tms_decision",
 ]

--- a/backend/app/services/powell/tms_heuristic_library/base.py
+++ b/backend/app/services/powell/tms_heuristic_library/base.py
@@ -1,21 +1,758 @@
-"""Re-export shim — pure logic now in Core.
-
-State dataclasses for TMS TRMs live in
-`azirella_data_model.powell.tms.heuristic_library.base`. This file
-preserves the local import path `from .base import ...`.
 """
-from azirella_data_model.powell.tms.heuristic_library.base import *  # noqa: F401,F403
-from azirella_data_model.powell.tms.heuristic_library.base import (  # noqa: F401
-    TMSHeuristicDecision,
-    CapacityPromiseState,
-    ShipmentTrackingState,
-    DemandSensingState,
-    CapacityBufferState,
-    ExceptionManagementState,
-    FreightProcurementState,
-    BrokerRoutingState,
-    DockSchedulingState,
-    LoadBuildState,
-    IntermodalTransferState,
-    EquipmentRepositionState,
-)
+TMS Heuristic Library — State Dataclasses and Decision Output
+
+Defines the input state for each of the 11 TMS TRM agents and the
+common output format. These mirror the SC heuristic_library/base.py
+pattern but with transportation-specific fields.
+
+Each state dataclass serves as:
+1. Input to the heuristic function (deterministic fallback)
+2. Input to the TRM neural network (when model is available)
+3. Feature vector definition for training data generation
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Any
+from datetime import datetime, date
+
+
+# ============================================================================
+# Common Decision Output
+# ============================================================================
+
+@dataclass(frozen=True)
+class TMSHeuristicDecision:
+    """Output of any TMS heuristic computation.
+
+    Mirrors HeuristicDecision from SC library but with TMS context.
+    """
+    trm_type: str                          # Which TRM produced this
+    action: int                            # Discrete action index
+    quantity: float = 0.0                  # Continuous parameter (loads, hours, etc.)
+    reasoning: str = ""                    # Human-readable explanation
+    confidence: float = 1.0               # Always 1.0 for heuristics
+    urgency: float = 0.5                  # 0-1 urgency signal
+    params_used: Dict[str, Any] = field(default_factory=dict)
+
+
+# ============================================================================
+# 1. Capacity Promise State (replaces ATPState)
+# ============================================================================
+
+@dataclass
+class CapacityPromiseState:
+    """Input state for CapacityPromiseTRM.
+
+    Evaluates whether a shipment request can be fulfilled given
+    available carrier capacity on the requested lane/date.
+    """
+    # Request
+    shipment_id: int = 0
+    lane_id: int = 0
+    requested_date: Optional[datetime] = None
+    requested_loads: int = 1
+    mode: str = "FTL"
+    priority: int = 3                      # 1=critical, 5=low
+
+    # Available capacity (from capacity buffer / committed)
+    committed_capacity: int = 0            # Loads already committed on this lane/date
+    total_capacity: int = 0                # Total carrier capacity (contracts + spot)
+    buffer_capacity: int = 0               # Buffer above forecast
+
+    # Demand context
+    forecast_loads: int = 0                # Forecasted loads for this lane/date
+    booked_loads: int = 0                  # Already booked
+
+    # Carrier context
+    primary_carrier_available: bool = True
+    backup_carriers_count: int = 0
+    spot_rate_premium_pct: float = 0.0     # How much spot exceeds contract
+
+    # Lane-level scoring (industry composite factors)
+    lane_acceptance_rate: float = 0.85     # Trailing carrier acceptance rate on this lane
+    market_tightness: float = 0.5          # 0=loose, 1=extreme (maps to OTRI)
+    primary_carrier_otp: float = 0.93      # Primary carrier on-time % trailing 90 days
+    allocation_compliance_pct: float = 1.0 # Actual/committed volume ratio for primary
+
+    def available_capacity(self) -> int:
+        return max(0, self.total_capacity - self.booked_loads)
+
+    def utilization_pct(self) -> float:
+        if self.total_capacity == 0:
+            return 1.0
+        return self.booked_loads / self.total_capacity
+
+
+# ============================================================================
+# 2. Shipment Tracking State (replaces OrderTrackingState)
+# ============================================================================
+
+@dataclass
+class ShipmentTrackingState:
+    """Input state for ShipmentTrackingTRM.
+
+    Evaluates shipment progress and detects exceptions based on
+    tracking events from p44, carrier EDI, or manual updates.
+    """
+    shipment_id: int = 0
+    shipment_status: str = "IN_TRANSIT"
+
+    # Timing
+    planned_pickup: Optional[datetime] = None
+    actual_pickup: Optional[datetime] = None
+    planned_delivery: Optional[datetime] = None
+    current_eta: Optional[datetime] = None
+    eta_p10: Optional[datetime] = None     # Conformal early bound
+    eta_p90: Optional[datetime] = None     # Conformal late bound
+
+    # Position
+    current_lat: float = 0.0
+    current_lon: float = 0.0
+    last_update_hours_ago: float = 0.0     # Hours since last tracking event
+
+    # Route context
+    total_miles: float = 0.0
+    miles_remaining: float = 0.0
+    pct_complete: float = 0.0
+
+    # Carrier performance
+    carrier_otp_pct: float = 0.95          # Carrier's on-time performance
+    carrier_reliability_score: float = 0.8
+
+    # Exception context
+    active_exceptions_count: int = 0
+    is_temperature_sensitive: bool = False
+    current_temp: Optional[float] = None
+    temp_min: Optional[float] = None
+    temp_max: Optional[float] = None
+
+    # Mode context (for mode-aware thresholds)
+    transport_mode: str = "FTL"             # FTL, LTL, FCL, AIR_STD, etc.
+
+    def hours_to_delivery(self) -> Optional[float]:
+        if self.current_eta:
+            delta = self.current_eta - datetime.utcnow()
+            return delta.total_seconds() / 3600
+        return None
+
+    def is_late(self) -> bool:
+        if self.planned_delivery and self.current_eta:
+            return self.current_eta > self.planned_delivery
+        return False
+
+
+# ============================================================================
+# 3. Demand Sensing State (replaces ForecastAdjustmentState)
+# ============================================================================
+
+@dataclass
+class DemandSensingState:
+    """Input state for DemandSensingTRM.
+
+    Evaluates whether shipping volume forecasts need adjustment
+    based on signals, patterns, and external data.
+    """
+    lane_id: int = 0
+    period_start: Optional[date] = None
+    period_days: int = 7                   # Weekly by default
+
+    # Current forecast
+    forecast_loads: float = 0.0
+    forecast_method: str = "CONFORMAL"
+    forecast_mape: float = 0.0             # Mean absolute percentage error
+
+    # Actuals / trend
+    actual_loads_current: float = 0.0
+    actual_loads_prior: float = 0.0
+    week_over_week_change_pct: float = 0.0
+    rolling_4wk_avg: float = 0.0
+
+    # Signals
+    signal_type: str = ""                  # VOLUME_SURGE, SEASONAL_SHIFT, etc.
+    signal_magnitude: float = 0.0
+    signal_confidence: float = 0.0
+
+    # Context
+    seasonal_index: float = 1.0
+    is_peak_season: bool = False
+    day_of_week_pattern: List[float] = field(default_factory=list)
+
+    # Order pipeline (strongest demand sensing signal)
+    order_pipeline_loads_24h: float = 0.0   # Orders placed in last 24h
+    order_pipeline_loads_prior_24h: float = 0.0  # Same window last week
+    cumulative_forecast_error: float = 0.0  # Running sum of (forecast - actual)
+    cumulative_mad: float = 1.0             # Running mean absolute deviation
+
+    def forecast_bias(self) -> float:
+        """Positive = over-forecasting, negative = under."""
+        if self.forecast_loads == 0:
+            return 0.0
+        return (self.forecast_loads - self.actual_loads_current) / self.forecast_loads
+
+
+# ============================================================================
+# 4. Capacity Buffer State (replaces InventoryBufferState)
+# ============================================================================
+
+@dataclass
+class CapacityBufferState:
+    """Input state for CapacityBufferTRM.
+
+    Evaluates whether to increase or decrease the capacity buffer
+    (extra committed loads above forecast) on a lane.
+    """
+    lane_id: int = 0
+    mode: str = "FTL"
+
+    # Current buffer
+    baseline_buffer_loads: int = 0         # Current buffer level
+    buffer_policy: str = "PCT_FORECAST"    # FIXED, PCT_FORECAST, CONFORMAL
+
+    # Forecast
+    forecast_loads: int = 0
+    forecast_p10: int = 0
+    forecast_p90: int = 0
+
+    # Capacity
+    committed_loads: int = 0
+    contract_capacity: int = 0
+    spot_availability: int = 0
+
+    # Performance
+    recent_tender_reject_rate: float = 0.0
+    recent_capacity_miss_count: int = 0
+    avg_spot_premium_pct: float = 0.0
+
+    # Demand context
+    demand_cv: float = 0.0                 # Coefficient of variation
+    demand_trend: float = 0.0              # +1 growing, -1 declining
+    is_peak_season: bool = False
+
+    def gap_loads(self) -> int:
+        return max(0, self.forecast_loads - self.committed_loads)
+
+    def buffer_ratio(self) -> float:
+        if self.forecast_loads == 0:
+            return 0.0
+        return self.baseline_buffer_loads / self.forecast_loads
+
+
+# ============================================================================
+# 5. Exception Management State (replaces QualityState)
+# ============================================================================
+
+@dataclass
+class ExceptionManagementState:
+    """Input state for ExceptionManagementTRM.
+
+    Evaluates the appropriate response to a shipment exception:
+    re-tender, reroute, escalate, or accept delay.
+    """
+    exception_id: int = 0
+    shipment_id: int = 0
+    exception_type: str = ""               # ExceptionType enum value
+    severity: str = "MEDIUM"               # LOW, MEDIUM, HIGH, CRITICAL
+    hours_since_detected: float = 0.0
+
+    # Impact
+    estimated_delay_hrs: float = 0.0
+    estimated_cost_impact: float = 0.0
+    revenue_at_risk: float = 0.0
+
+    # Shipment context
+    shipment_priority: int = 3
+    is_temperature_sensitive: bool = False
+    is_hazmat: bool = False
+    delivery_window_remaining_hrs: float = 0.0
+
+    # Carrier context
+    carrier_id: int = 0
+    carrier_reliability_score: float = 0.8
+    carrier_response_time_hrs: float = 2.0
+
+    # Resolution options
+    can_retender: bool = True
+    alternate_carriers_available: int = 0
+    can_reroute: bool = False
+    can_partial_deliver: bool = False
+
+    # Financial context (for cost-benefit triage)
+    shipment_value: float = 0.0            # Freight value
+    penalty_exposure: float = 0.0          # SLA penalty if missed
+    expedite_cost_estimate: float = 0.0    # Cost of premium service
+    appointment_buffer_hrs: float = 2.0    # Tolerance window at receiver
+
+    # Cascade context
+    downstream_shipments_affected: int = 0 # Shipments sharing resources
+    customer_tier: int = 3                 # 1=strategic, 5=transactional
+
+    def is_critical_path(self) -> bool:
+        return self.shipment_priority <= 2 or self.severity == "CRITICAL"
+
+
+# ============================================================================
+# 6. Freight Procurement State (replaces ReplenishmentState)
+# ============================================================================
+
+@dataclass
+class FreightProcurementState:
+    """Input state for FreightProcurementTRM.
+
+    Evaluates carrier selection and tender timing for a load.
+    Implements carrier waterfall logic.
+    """
+    load_id: int = 0
+    lane_id: int = 0
+    mode: str = "FTL"
+    required_equipment: str = "DRY_VAN"
+
+    # Load details
+    weight: float = 0.0
+    pallet_count: int = 0
+    is_hazmat: bool = False
+    is_temperature_sensitive: bool = False
+
+    # Timing
+    pickup_date: Optional[datetime] = None
+    delivery_date: Optional[datetime] = None
+    lead_time_hours: float = 48.0          # Hours until pickup
+
+    # Carrier waterfall
+    primary_carrier_id: Optional[int] = None
+    primary_carrier_rate: float = 0.0
+    primary_carrier_acceptance_pct: float = 0.85
+    backup_carriers: List[Dict[str, Any]] = field(default_factory=list)
+    # Each: {"id": int, "rate": float, "acceptance_pct": float, "priority": int}
+
+    # Market context
+    spot_rate: float = 0.0
+    contract_rate: float = 0.0
+    market_tightness: float = 0.5          # 0=loose, 1=very tight
+    dat_benchmark_rate: float = 0.0
+
+    # Tender context
+    tender_attempt: int = 1                # Which attempt (waterfall position)
+    max_tender_attempts: int = 3
+    hours_to_tender_deadline: float = 24.0
+
+    def rate_vs_benchmark(self) -> float:
+        if self.dat_benchmark_rate == 0:
+            return 0.0
+        return (self.primary_carrier_rate - self.dat_benchmark_rate) / self.dat_benchmark_rate
+
+
+# ============================================================================
+# 7. Broker Routing State (replaces SubcontractingState)
+# ============================================================================
+
+@dataclass
+class BrokerRoutingState:
+    """Input state for BrokerRoutingTRM.
+
+    Evaluates when to escalate to a broker after carrier waterfall
+    exhaustion, and which broker to select.
+    """
+    load_id: int = 0
+    lane_id: int = 0
+    mode: str = "FTL"
+
+    # Waterfall context
+    tender_attempts_exhausted: int = 0
+    all_contract_carriers_declined: bool = False
+    hours_to_pickup: float = 24.0
+
+    # Broker options
+    available_brokers: List[Dict[str, Any]] = field(default_factory=list)
+    # Each: {"id": int, "name": str, "rate": float, "reliability": float, "coverage_score": float}
+
+    # Cost context
+    contract_rate: float = 0.0
+    spot_rate: float = 0.0
+    broker_rate_premium_pct: float = 0.15  # Typical broker markup
+    budget_remaining: float = 0.0
+
+    # Urgency
+    shipment_priority: int = 3
+    is_customer_committed: bool = False    # Customer expecting specific delivery
+
+    # Market context
+    market_tightness: float = 0.5          # 0=loose, 1=extreme (OTRI proxy)
+    dat_benchmark_rate: float = 0.0        # DAT lane benchmark
+
+    def should_broker(self) -> bool:
+        """Simple rule: broker if all carriers declined and time is short."""
+        return self.all_contract_carriers_declined and self.hours_to_pickup < 48
+
+
+# ============================================================================
+# 8. Dock Scheduling State (replaces MaintenanceState)
+# ============================================================================
+
+@dataclass
+class DockSchedulingState:
+    """Input state for DockSchedulingTRM.
+
+    Evaluates dock door assignment, appointment timing, and
+    identifies congestion / detention risks.
+    """
+    facility_id: int = 0
+    appointment_id: int = 0
+    appointment_type: str = "DELIVERY"     # PICKUP, DELIVERY, CROSS_DOCK, etc.
+
+    # Facility capacity
+    total_dock_doors: int = 10
+    available_dock_doors: int = 5
+    yard_spots_total: int = 50
+    yard_spots_available: int = 20
+
+    # Time slots
+    requested_time: Optional[datetime] = None
+    earliest_available_slot: Optional[datetime] = None
+    latest_acceptable_slot: Optional[datetime] = None
+
+    # Current load
+    appointments_in_window: int = 0        # Other appointments in same 2hr window
+    avg_dwell_time_minutes: float = 45.0
+    current_queue_depth: int = 0           # Trucks waiting
+
+    # Shipment context
+    shipment_priority: int = 3
+    is_live_load: bool = True              # vs drop-trailer
+    estimated_load_time_minutes: float = 60.0
+
+    # Detention risk
+    free_time_minutes: float = 120.0       # Before detention charges start
+    detention_rate_per_hour: float = 75.0
+    carrier_avg_dwell_minutes: float = 90.0
+
+    # Door compatibility (for equipment-door matching)
+    required_door_type: str = "BOTH"       # INBOUND, OUTBOUND, BOTH
+    equipment_type: str = "DRY_VAN"        # DRY_VAN, REEFER, FLATBED
+    is_hazmat: bool = False
+    commodity_type: str = ""               # For commodity segregation check
+
+    def utilization_pct(self) -> float:
+        if self.total_dock_doors == 0:
+            return 1.0
+        return 1.0 - (self.available_dock_doors / self.total_dock_doors)
+
+    def detention_risk_score(self) -> float:
+        """0-1 score of detention likelihood."""
+        if self.carrier_avg_dwell_minutes <= self.free_time_minutes:
+            return 0.0
+        overage = self.carrier_avg_dwell_minutes - self.free_time_minutes
+        return min(1.0, overage / 120.0)
+
+
+# ============================================================================
+# 9. Load Build State (replaces MOExecutionState)
+# ============================================================================
+
+@dataclass
+class LoadBuildState:
+    """Input state for LoadBuildTRM.
+
+    Evaluates shipment consolidation into loads for optimal
+    equipment utilization and cost efficiency.
+    """
+    # Candidate shipments
+    shipment_ids: List[int] = field(default_factory=list)
+    lane_id: int = 0
+    mode: str = "FTL"
+    equipment_type: str = "DRY_VAN"
+
+    # Capacity limits
+    max_weight: float = 44000.0            # lbs (FTL standard)
+    max_volume: float = 2700.0             # cuft (53ft trailer)
+    max_pallets: int = 26
+
+    # Current utilization
+    total_weight: float = 0.0
+    total_volume: float = 0.0
+    total_pallets: int = 0
+    shipment_count: int = 0
+
+    # Compatibility
+    has_hazmat_conflict: bool = False
+    has_temp_conflict: bool = False
+    has_destination_conflict: bool = False
+    max_stops: int = 3                     # Multi-stop tolerance
+
+    # Timing
+    earliest_pickup: Optional[datetime] = None
+    latest_pickup: Optional[datetime] = None
+    consolidation_window_hours: float = 24.0
+
+    # Cost
+    ftl_rate: float = 0.0
+    ltl_rate_sum: float = 0.0             # Sum of individual LTL rates
+    consolidation_savings: float = 0.0
+
+    # Multi-stop context
+    stop_count: int = 1                    # Current stops in proposed load
+    stop_off_charge_per_stop: float = 75.0 # $/stop industry standard
+    delivery_windows_compatible: bool = True
+    avg_weight_per_shipment: float = 0.0   # For FTL/LTL crossover check
+
+    # LTL economics
+    ltl_class_rate_per_cwt: float = 0.0    # NMFC class-rated $/cwt
+    volume_ltl_rate: float = 0.0           # Volume LTL / partial TL rate
+
+    def weight_utilization(self) -> float:
+        if self.max_weight == 0:
+            return 0.0
+        return self.total_weight / self.max_weight
+
+    def volume_utilization(self) -> float:
+        if self.max_volume == 0:
+            return 0.0
+        return self.total_volume / self.max_volume
+
+    def should_consolidate(self) -> bool:
+        """Simple rule: consolidate if saves money and fits."""
+        return (
+            self.consolidation_savings > 0
+            and self.weight_utilization() < 0.95
+            and self.volume_utilization() < 0.95
+            and not self.has_hazmat_conflict
+            and not self.has_temp_conflict
+        )
+
+
+# ============================================================================
+# 10. Intermodal Transfer State (replaces TOExecutionState)
+# ============================================================================
+
+@dataclass
+class IntermodalTransferState:
+    """Input state for IntermodalTransferTRM.
+
+    Evaluates mode shift opportunities: truck↔rail, truck↔ocean,
+    and manages transload operations at terminals.
+    """
+    shipment_id: int = 0
+    current_mode: str = "FTL"
+    candidate_mode: str = "RAIL_INTERMODAL"
+
+    # Route
+    origin_to_ramp_miles: float = 0.0      # Drayage to rail ramp
+    ramp_to_ramp_miles: float = 0.0        # Rail linehaul
+    ramp_to_dest_miles: float = 0.0        # Drayage from rail ramp
+    total_truck_miles: float = 0.0         # All-truck alternative
+
+    # Cost comparison
+    truck_rate: float = 0.0
+    intermodal_rate: float = 0.0           # Rail + drayage both ends
+    drayage_rate_origin: float = 0.0
+    drayage_rate_dest: float = 0.0
+
+    # Transit time
+    truck_transit_days: float = 0.0
+    intermodal_transit_days: float = 0.0
+    delivery_window_days: float = 0.0      # How much slack exists
+
+    # Capacity
+    rail_capacity_available: bool = True
+    ramp_congestion_level: float = 0.0     # 0=clear, 1=congested
+
+    # Risk
+    intermodal_reliability_pct: float = 0.85
+    weather_risk_score: float = 0.0
+
+    # Commodity eligibility
+    is_hazmat: bool = False
+    is_temperature_controlled: bool = False
+    commodity_value_per_lb: float = 0.0     # For inventory carrying cost
+
+    # Ramp proximity
+    origin_ramp_distance_miles: float = 0.0  # Distance from origin to nearest ramp
+    dest_ramp_distance_miles: float = 0.0
+
+    def cost_savings_pct(self) -> float:
+        if self.truck_rate == 0:
+            return 0.0
+        return (self.truck_rate - self.intermodal_rate) / self.truck_rate
+
+    def transit_time_penalty_days(self) -> float:
+        return max(0, self.intermodal_transit_days - self.truck_transit_days)
+
+    def has_time_for_intermodal(self) -> bool:
+        return self.transit_time_penalty_days() <= self.delivery_window_days
+
+
+# ============================================================================
+# 11. Equipment Reposition State (replaces RebalancingState)
+# ============================================================================
+
+@dataclass
+class EquipmentRepositionState:
+    """Input state for EquipmentRepositionTRM.
+
+    Evaluates empty equipment repositioning to balance fleet
+    across the network. Minimizes deadhead miles while ensuring
+    equipment availability at high-demand sites.
+    """
+    equipment_type: str = "DRY_VAN"
+
+    # Source (where equipment is)
+    source_facility_id: int = 0
+    source_equipment_count: int = 0
+    source_demand_next_7d: int = 0         # Expected loads needing this equipment
+
+    # Target (where equipment is needed)
+    target_facility_id: int = 0
+    target_equipment_count: int = 0
+    target_demand_next_7d: int = 0
+
+    # Reposition details
+    reposition_miles: float = 0.0
+    reposition_cost: float = 0.0
+    reposition_transit_hours: float = 0.0
+
+    # Network context
+    network_surplus_locations: int = 0
+    network_deficit_locations: int = 0
+    total_fleet_size: int = 0
+    fleet_utilization_pct: float = 0.0
+
+    # Economics
+    cost_of_not_repositioning: float = 0.0  # Spot rate premium if no equipment
+    breakeven_loads: int = 1                 # Loads needed to justify reposition
+
+    def source_surplus(self) -> int:
+        return max(0, self.source_equipment_count - self.source_demand_next_7d)
+
+    def target_deficit(self) -> int:
+        return max(0, self.target_demand_next_7d - self.target_equipment_count)
+
+    def reposition_roi(self) -> float:
+        """ROI of repositioning: avoided spot premium / reposition cost."""
+        if self.reposition_cost == 0:
+            return float('inf') if self.cost_of_not_repositioning > 0 else 0.0
+        return self.cost_of_not_repositioning / self.reposition_cost
+
+
+# ============================================================================
+# 12. Lane Volume Forecast State (NEW — Execution-tier orchestrator)
+# ============================================================================
+
+@dataclass
+class LaneVolumeForecastState:
+    """Input state for LaneVolumeForecastTRM (Execution-tier orchestrator).
+
+    Decides how to forecast outbound lane volume on a customer-facing lane:
+    which model family to use (Holt-Winters / LightGBM / Croston / TSB /
+    AutoETS cold-start), and whether to ACCEPT, MODIFY (signal overlay),
+    ESCALATE (low confidence / human review), or DEFER (insufficient data)
+    the proposed forecast.
+
+    This is the lane-grain analogue of SCP's Forecast Baseline TRM. Unlike
+    SCP's SKU-level forecaster, the unit here is *lane × time-bucket* and
+    only fires on lanes whose volume must be statistically forecast —
+    customer-facing outbound. Internal-transfer and inbound lanes inherit
+    volume from the upstream supply / transfer plan and never invoke this
+    TRM (gated at provisioning).
+
+    The model-selection logic uses Syntetos-Boylan demand classification:
+        SMOOTH        ADI < 1.32, CV² < 0.49     → HoltWinters / LightGBM
+        ERRATIC       ADI < 1.32, CV² ≥ 0.49     → HoltWinters
+        INTERMITTENT  ADI ≥ 1.32, CV² < 0.49     → Croston
+        LUMPY         ADI ≥ 1.32, CV² ≥ 0.49     → TSB
+    Plus:
+        NEW           weeks_of_history < 8       → AutoETS cold-start (escalate)
+        DECLINING     trend < 0 & last_actual < mean × 0.5 → escalate (EOL signal)
+    """
+    # Lane identity
+    lane_id: int = 0
+    period_start: Optional[date] = None
+    period_days: int = 7                       # Weekly bucket by default
+
+    # ── History characteristics (Syntetos-Boylan classification inputs) ─
+    weeks_of_history: int = 0
+    mean_demand: float = 0.0                   # Mean over non-zero periods
+    demand_std: float = 0.0
+    avg_demand_interval: float = 1.0           # ADI: mean periods between non-zero
+    squared_cv: float = 0.0                    # CV² of non-zero demand
+    nonzero_period_pct: float = 1.0            # Fraction of periods with demand > 0
+
+    # ── Trend / seasonality ────────────────────────────────────────────
+    trend_slope: float = 0.0                   # Linear trend coefficient (per period)
+    seasonal_strength: float = 0.0             # 0–1, strength of seasonal pattern
+    is_peak_season: bool = False
+
+    # ── Recent forecast performance ────────────────────────────────────
+    forecast_method_in_use: str = ""           # "" if no prior forecast
+    trailing_mape: float = 0.0                 # Trailing 8-week MAPE
+    trailing_wape: float = 0.0                 # Trailing 8-week WAPE
+    forecast_bias: float = 0.0                 # Mean (forecast − actual) / actual
+    conformal_coverage_p80: float = 0.80       # Empirical coverage of P10–P90 band
+
+    # ── Covariate availability (for LightGBM eligibility) ─────────────
+    has_rate_covariate: bool = False           # DAT/contract rate signal joined
+    has_market_signal: bool = False            # OTRI / market tightness joined
+    has_calendar_features: bool = True         # Always have day/week/month
+
+    # ── External signal overlay (promo / NPI / EOL / event / market) ──
+    signal_type: str = ""                      # PROMO_LIFT / NPI / EOL / EVENT / MARKET_SHIFT
+    signal_magnitude: float = 0.0              # Multiplier (e.g., 0.20 = +20%)
+    signal_confidence: float = 0.0             # 0–1
+
+    # ── Proposed forecast (from upstream pipeline; TRM ships or gates) ─
+    proposed_forecast_p50: float = 0.0
+    proposed_forecast_p10: float = 0.0
+    proposed_forecast_p90: float = 0.0
+    proposed_method: str = "HoltWinters"       # Method the heuristic would route to
+
+    # ── Recent volume context ──────────────────────────────────────────
+    last_period_actual: float = 0.0            # Most recent observed volume
+
+    # ── Confidence / uncertainty ───────────────────────────────────────
+    forecast_interval_width_pct: float = 0.0   # (P90 − P10) / P50; 0 if P50 = 0
+
+    def adi(self) -> float:
+        return max(1.0, self.avg_demand_interval)
+
+    def cv_squared(self) -> float:
+        return max(0.0, self.squared_cv)
+
+    def syntetos_boylan_class(self) -> str:
+        """Classify the lane's demand pattern.
+
+        Returns one of: SMOOTH / ERRATIC / INTERMITTENT / LUMPY / NEW / DECLINING.
+        Cold-start (NEW) takes precedence over all classes; DECLINING takes
+        precedence over the four steady-state classes.
+        """
+        if self.weeks_of_history < 8:
+            return "NEW"
+        # Declining: persistent negative trend + recent actual well below mean
+        if (
+            self.trend_slope < -0.05
+            and self.mean_demand > 0
+            and self.last_period_actual < self.mean_demand * 0.5
+        ):
+            return "DECLINING"
+        adi = self.adi()
+        cv2 = self.cv_squared()
+        if adi < 1.32 and cv2 < 0.49:
+            return "SMOOTH"
+        if adi < 1.32:
+            return "ERRATIC"
+        if cv2 < 0.49:
+            return "INTERMITTENT"
+        return "LUMPY"
+
+    def recommended_model(self) -> str:
+        """Map demand class + covariate availability to model family."""
+        cls = self.syntetos_boylan_class()
+        if cls == "NEW":
+            return "AutoETS_coldstart"
+        if cls == "DECLINING":
+            return "TSB"                       # TSB handles taper better than Croston
+        if cls == "INTERMITTENT":
+            return "Croston"
+        if cls == "LUMPY":
+            return "TSB"
+        # Smooth / Erratic — covariates promote LightGBM
+        if self.has_rate_covariate or self.has_market_signal:
+            return "LightGBM"
+        return "HoltWinters"

--- a/backend/app/services/powell/tms_heuristic_library/dispatch.py
+++ b/backend/app/services/powell/tms_heuristic_library/dispatch.py
@@ -1,9 +1,1476 @@
-"""Re-export shim — pure logic now in Core.
-
-TMS heuristic dispatcher lives in
-`azirella_data_model.powell.tms.heuristic_library.dispatch`.
 """
-from azirella_data_model.powell.tms.heuristic_library.dispatch import *  # noqa: F401,F403
-from azirella_data_model.powell.tms.heuristic_library.dispatch import (  # noqa: F401
-    compute_tms_decision,
+TMS Heuristic Dispatch — Transportation Decision Rules
+
+Deterministic fallback logic for all 11 TMS TRMs when neural network
+models are unavailable. Encodes industry best practices for:
+- Carrier waterfall tendering
+- Load consolidation
+- Dock door optimization
+- Exception triage
+- Equipment rebalancing
+
+Unlike the SC library which dispatches by ERP source (SAP/D365/Odoo),
+TMS heuristics are universal — transportation operations follow standard
+industry practices regardless of source system.
+"""
+
+import logging
+import math
+from typing import Any, Dict, List
+
+from .base import (
+    TMSHeuristicDecision,
+    CapacityPromiseState,
+    ShipmentTrackingState,
+    DemandSensingState,
+    CapacityBufferState,
+    ExceptionManagementState,
+    FreightProcurementState,
+    BrokerRoutingState,
+    DockSchedulingState,
+    LoadBuildState,
+    IntermodalTransferState,
+    EquipmentRepositionState,
+    LaneVolumeForecastState,
 )
+
+logger = logging.getLogger(__name__)
+
+
+# ── Action Constants ────────────────────────────────────────────────────
+# Discrete action indices used across TRMs
+
+class Actions:
+    ACCEPT = 0
+    REJECT = 1
+    DEFER = 2
+    ESCALATE = 3
+    MODIFY = 4
+    RETENDER = 5
+    REROUTE = 6
+    CONSOLIDATE = 7
+    SPLIT = 8
+    REPOSITION = 9
+    HOLD = 10
+
+
+# ============================================================================
+# Main Dispatch
+# ============================================================================
+
+def compute_tms_decision(trm_type: str, state: Any) -> TMSHeuristicDecision:
+    """
+    Compute a deterministic decision for any TMS TRM.
+
+    Args:
+        trm_type: TRM canonical name (e.g., "capacity_promise")
+        state: Corresponding state dataclass
+
+    Returns:
+        TMSHeuristicDecision with action, reasoning, and parameters
+    """
+    dispatch_map = {
+        "capacity_promise": _compute_capacity_promise,
+        "shipment_tracking": _compute_shipment_tracking,
+        "demand_sensing": _compute_demand_sensing,
+        "capacity_buffer": _compute_capacity_buffer,
+        "exception_management": _compute_exception_management,
+        "freight_procurement": _compute_freight_procurement,
+        "broker_routing": _compute_broker_routing,
+        "dock_scheduling": _compute_dock_scheduling,
+        "load_build": _compute_load_build,
+        "intermodal_transfer": _compute_intermodal_transfer,
+        "equipment_reposition": _compute_equipment_reposition,
+        "lane_volume_forecast": _compute_lane_volume_forecast,
+    }
+
+    func = dispatch_map.get(trm_type)
+    if not func:
+        logger.warning(f"No heuristic for TRM type '{trm_type}'")
+        return TMSHeuristicDecision(
+            trm_type=trm_type, action=Actions.HOLD,
+            reasoning=f"No heuristic available for {trm_type}",
+        )
+
+    return func(state)
+
+
+# ============================================================================
+# 1. Capacity Promise
+# ============================================================================
+
+def _compute_capacity_promise(state: CapacityPromiseState) -> TMSHeuristicDecision:
+    """
+    Evaluate whether to promise capacity for a shipment request.
+
+    Industry algorithm: lane-level composite scoring (Oracle OTM / SAP TM
+    pattern). The promise decision considers capacity, carrier quality,
+    market tightness, and allocation compliance — not just availability.
+
+    Composite promise confidence score (0–1):
+        0.35 × capacity_factor       (available/requested, capped at 1)
+      + 0.25 × service_factor        (primary carrier OTP)
+      + 0.20 × acceptance_factor     (lane trailing acceptance rate)
+      + 0.10 × compliance_factor     (allocation compliance %)
+      + 0.10 × market_factor         (1 - market_tightness)
+
+    P1–P2 priority overrides: always promise (consume buffer).
+    Score > 0.6: ACCEPT. Score 0.35–0.6: DEFER. Score < 0.35: REJECT.
+    """
+    available = state.available_capacity()
+
+    # Priority override — critical freight always gets capacity
+    if state.priority <= 2:
+        if available >= state.requested_loads or state.buffer_capacity > 0:
+            return TMSHeuristicDecision(
+                trm_type="capacity_promise", action=Actions.ACCEPT,
+                quantity=state.requested_loads,
+                reasoning=f"High priority (P{state.priority}): committed from {'buffer' if available < state.requested_loads else 'available capacity'}",
+                urgency=0.8,
+                params_used={"override": "priority", "priority": state.priority},
+            )
+
+    # Composite promise confidence score
+    cap_factor = min(1.0, available / max(1, state.requested_loads))
+    svc_factor = state.primary_carrier_otp
+    acc_factor = state.lane_acceptance_rate
+    comp_factor = min(1.0, state.allocation_compliance_pct)
+    mkt_factor = 1.0 - state.market_tightness
+
+    score = (0.35 * cap_factor
+             + 0.25 * svc_factor
+             + 0.20 * acc_factor
+             + 0.10 * comp_factor
+             + 0.10 * mkt_factor)
+
+    scoring_detail = {
+        "composite_score": round(score, 3),
+        "capacity_factor": round(cap_factor, 3),
+        "service_factor": round(svc_factor, 3),
+        "acceptance_factor": round(acc_factor, 3),
+        "compliance_factor": round(comp_factor, 3),
+        "market_factor": round(mkt_factor, 3),
+    }
+
+    if score >= 0.60:
+        # Sufficient confidence to promise
+        # Check spot premium if primary capacity is insufficient
+        if available < state.requested_loads and state.spot_rate_premium_pct >= 0.20:
+            return TMSHeuristicDecision(
+                trm_type="capacity_promise", action=Actions.DEFER,
+                quantity=state.requested_loads,
+                reasoning=f"Score {score:.2f} but spot premium {state.spot_rate_premium_pct*100:.0f}% exceeds threshold; deferring",
+                urgency=0.5,
+                params_used=scoring_detail,
+            )
+        return TMSHeuristicDecision(
+            trm_type="capacity_promise", action=Actions.ACCEPT,
+            quantity=state.requested_loads,
+            reasoning=f"Promise confidence {score:.2f} (cap={cap_factor:.2f} svc={svc_factor:.2f} acc={acc_factor:.2f} mkt={mkt_factor:.2f})",
+            urgency=0.3,
+            params_used=scoring_detail,
+        )
+
+    if score >= 0.35:
+        # Marginal — defer to procurement for carrier sourcing
+        return TMSHeuristicDecision(
+            trm_type="capacity_promise", action=Actions.DEFER,
+            quantity=state.requested_loads,
+            reasoning=f"Marginal confidence {score:.2f}; deferring to procurement (acc={acc_factor:.2f} mkt={mkt_factor:.2f})",
+            urgency=0.6,
+            params_used=scoring_detail,
+        )
+
+    # Low confidence — reject
+    return TMSHeuristicDecision(
+        trm_type="capacity_promise", action=Actions.REJECT,
+        quantity=0,
+        reasoning=f"Low confidence {score:.2f}: capacity={cap_factor:.2f} acceptance={acc_factor:.2f} market={mkt_factor:.2f}",
+        urgency=0.9,
+        params_used=scoring_detail,
+    )
+
+
+# ============================================================================
+# 2. Shipment Tracking
+# ============================================================================
+
+def _compute_shipment_tracking(state: ShipmentTrackingState) -> TMSHeuristicDecision:
+    """
+    Shipment tracking with mode-aware thresholds + conformal intervals +
+    carrier-reliability-weighted ETA assessment.
+
+    Industry algorithm (project44 / FourKites pattern):
+    - Mode-aware silence thresholds (truck 4h, LTL 8h, ocean 24h, air 2h)
+    - Conformal prediction intervals when available (P10/P90 bounds)
+    - Carrier reliability weighting on ETA confidence
+    - Temperature excursion always escalates (food safety)
+    """
+    # Mode-aware tracking-lost thresholds
+    silence_thresholds = {
+        "FTL": 4.0, "LTL": 8.0, "PARCEL": 12.0,
+        "FCL": 24.0, "LCL": 24.0, "BULK_OCEAN": 48.0,
+        "AIR_STD": 2.0, "AIR_EXPRESS": 1.0,
+        "RAIL_INTERMODAL": 12.0, "RAIL_CARLOAD": 24.0,
+    }
+    silence_limit = silence_thresholds.get(state.transport_mode, 4.0)
+
+    tracking_detail = {
+        "mode": state.transport_mode,
+        "silence_threshold_hrs": silence_limit,
+        "carrier_reliability": state.carrier_reliability_score,
+        "pct_complete": state.pct_complete,
+    }
+
+    # Tracking lost — mode-aware
+    if (state.last_update_hours_ago > silence_limit
+            and state.shipment_status == "IN_TRANSIT"):
+        return TMSHeuristicDecision(
+            trm_type="shipment_tracking", action=Actions.ESCALATE,
+            reasoning=f"Tracking lost: no update for {state.last_update_hours_ago:.1f}h (threshold {silence_limit:.0f}h for {state.transport_mode})",
+            urgency=0.7,
+            params_used=tracking_detail,
+        )
+
+    # Temperature excursion — immediate, mode-independent
+    if (state.is_temperature_sensitive
+            and state.current_temp is not None
+            and state.temp_min is not None
+            and state.temp_max is not None):
+        if state.current_temp < state.temp_min or state.current_temp > state.temp_max:
+            return TMSHeuristicDecision(
+                trm_type="shipment_tracking", action=Actions.ESCALATE,
+                quantity=state.current_temp,
+                reasoning=f"Temperature {state.current_temp}°F outside [{state.temp_min}, {state.temp_max}]",
+                urgency=0.95,
+                params_used=tracking_detail,
+            )
+
+    # Late delivery — with conformal interval awareness
+    if state.is_late():
+        hours_late = 0.0
+        if state.planned_delivery and state.current_eta:
+            hours_late = (state.current_eta - state.planned_delivery).total_seconds() / 3600
+        # If conformal P90 is still within window, lower urgency
+        p90_late = False
+        if state.eta_p90 and state.planned_delivery:
+            p90_late = state.eta_p90 > state.planned_delivery
+        confidence_note = ""
+        if state.eta_p90 and not p90_late:
+            confidence_note = " (P90 still within window — may self-correct)"
+            urgency = min(0.7, 0.4 + hours_late / 24)
+        else:
+            urgency = min(1.0, 0.5 + hours_late / 24)
+        # Discount urgency by carrier reliability (reliable carrier → more likely self-correction)
+        urgency *= (1.1 - state.carrier_reliability_score * 0.2)
+        return TMSHeuristicDecision(
+            trm_type="shipment_tracking", action=Actions.ESCALATE,
+            quantity=hours_late,
+            reasoning=f"ETA {hours_late:.1f}h late{confidence_note}",
+            urgency=min(1.0, urgency),
+            params_used={**tracking_detail, "hours_late": round(hours_late, 2),
+                         "p90_also_late": p90_late},
+        )
+
+    # At-risk — behind expected progress curve
+    hours_remaining = state.hours_to_delivery()
+    if hours_remaining and hours_remaining > 0 and state.pct_complete < 0.5:
+        expected_pct = 1.0 - (hours_remaining / max(1, hours_remaining / max(0.01, 1.0 - state.pct_complete)))
+        if state.pct_complete < expected_pct - 0.10:
+            return TMSHeuristicDecision(
+                trm_type="shipment_tracking", action=Actions.MODIFY,
+                reasoning=f"At-risk: {state.pct_complete*100:.0f}% complete, expected {expected_pct*100:.0f}%, {hours_remaining:.0f}h remaining",
+                urgency=0.5,
+                params_used=tracking_detail,
+            )
+
+    return TMSHeuristicDecision(
+        trm_type="shipment_tracking", action=Actions.ACCEPT,
+        reasoning=f"Nominal ({state.pct_complete*100:.0f}% complete, last update {state.last_update_hours_ago:.1f}h ago)",
+        urgency=0.1,
+        params_used=tracking_detail,
+    )
+
+
+# ============================================================================
+# 3. Demand Sensing
+# ============================================================================
+
+def _compute_demand_sensing(state: DemandSensingState) -> TMSHeuristicDecision:
+    """
+    Demand sensing with Trigg's tracking signal + order pipeline velocity +
+    asymmetric loss (under-forecasting costs more than over-forecasting).
+
+    Industry algorithm (E2open / Terra Technology pattern):
+    1. Tracking signal = cumulative_error / MAD. If |TS| > 4 → structural bias
+    2. Order pipeline velocity (24h bookings vs. prior period) — strongest signal
+    3. Asymmetric correction: under-forecast adjusted 60%, over-forecast 40%
+    4. Signal-type-specific magnitude applied when available
+    5. Peak season + high MAPE → precautionary buffer
+    """
+    bias = state.forecast_bias()
+
+    # Trigg's tracking signal — cumulative bias detection
+    tracking_signal = 0.0
+    if state.cumulative_mad > 0:
+        tracking_signal = state.cumulative_forecast_error / state.cumulative_mad
+
+    sensing_detail = {
+        "bias": round(bias, 3),
+        "tracking_signal": round(tracking_signal, 2),
+        "mape": state.forecast_mape,
+        "pipeline_velocity": state.order_pipeline_loads_24h,
+        "is_peak": state.is_peak_season,
+    }
+
+    # Order pipeline velocity — strongest signal (E2open research)
+    if state.order_pipeline_loads_24h > 0 and state.order_pipeline_loads_prior_24h > 0:
+        pipeline_change = ((state.order_pipeline_loads_24h - state.order_pipeline_loads_prior_24h)
+                           / state.order_pipeline_loads_prior_24h)
+        if abs(pipeline_change) > 0.15:
+            # Asymmetric: under-forecast (positive pipeline surge) gets larger correction
+            correction_factor = 0.60 if pipeline_change > 0 else 0.40
+            adjustment = pipeline_change * state.forecast_loads * correction_factor
+            return TMSHeuristicDecision(
+                trm_type="demand_sensing", action=Actions.MODIFY,
+                quantity=adjustment,
+                reasoning=f"Order pipeline {pipeline_change*100:+.0f}% vs prior (asymmetric correction {correction_factor:.0%})",
+                urgency=0.6 + abs(pipeline_change) * 0.3,
+                params_used={**sensing_detail, "pipeline_change": round(pipeline_change, 3),
+                             "correction_factor": correction_factor},
+            )
+
+    # Structural bias via tracking signal (Trigg's method)
+    if abs(tracking_signal) > 4.0:
+        direction = "down" if tracking_signal > 0 else "up"
+        # Asymmetric: larger correction for under-forecasting (TS < -4)
+        correction = 0.60 if tracking_signal < 0 else 0.40
+        adjustment = -bias * state.forecast_loads * correction
+        return TMSHeuristicDecision(
+            trm_type="demand_sensing", action=Actions.MODIFY,
+            quantity=adjustment,
+            reasoning=f"Tracking signal {tracking_signal:.1f} (threshold ±4): structural bias, adjusting {direction} {correction:.0%}",
+            urgency=0.7,
+            params_used=sensing_detail,
+        )
+
+    # Signal-type-specific adjustment
+    if state.signal_type and state.signal_magnitude > 0 and state.signal_confidence > 0.5:
+        adjustment = state.signal_magnitude * state.forecast_loads * state.signal_confidence * 0.5
+        return TMSHeuristicDecision(
+            trm_type="demand_sensing", action=Actions.MODIFY,
+            quantity=adjustment,
+            reasoning=f"Signal {state.signal_type}: magnitude {state.signal_magnitude:.2f} × confidence {state.signal_confidence:.2f}",
+            urgency=0.4 + state.signal_confidence * 0.2,
+            params_used=sensing_detail,
+        )
+
+    # Simple bias correction with asymmetric loss
+    if abs(bias) > 0.15:
+        direction = "down" if bias > 0 else "up"
+        correction = 0.60 if bias < 0 else 0.40  # Larger correction for under-forecast
+        adjustment = -bias * state.forecast_loads * correction
+        return TMSHeuristicDecision(
+            trm_type="demand_sensing", action=Actions.MODIFY,
+            quantity=adjustment,
+            reasoning=f"Bias {bias*100:.0f}%: adjusting {direction} (asymmetric {correction:.0%})",
+            urgency=0.5 + abs(bias),
+            params_used=sensing_detail,
+        )
+
+    # WoW volume shift
+    if abs(state.week_over_week_change_pct) > 0.20:
+        return TMSHeuristicDecision(
+            trm_type="demand_sensing", action=Actions.MODIFY,
+            quantity=state.week_over_week_change_pct * state.forecast_loads * 0.3,
+            reasoning=f"WoW change {state.week_over_week_change_pct*100:+.0f}%",
+            urgency=0.4,
+            params_used=sensing_detail,
+        )
+
+    # Peak season precautionary buffer
+    if state.is_peak_season and state.forecast_mape > 0.20:
+        return TMSHeuristicDecision(
+            trm_type="demand_sensing", action=Actions.MODIFY,
+            quantity=state.forecast_loads * 0.10,
+            reasoning=f"Peak season with {state.forecast_mape*100:.0f}% MAPE; +10% buffer",
+            urgency=0.4,
+            params_used=sensing_detail,
+        )
+
+    return TMSHeuristicDecision(
+        trm_type="demand_sensing", action=Actions.ACCEPT,
+        reasoning=f"Forecast OK (bias {bias*100:.0f}%, TS {tracking_signal:.1f}, MAPE {state.forecast_mape*100:.0f}%)",
+        urgency=0.1,
+        params_used=sensing_detail,
+    )
+
+
+# ============================================================================
+# 4. Capacity Buffer
+# ============================================================================
+
+def _compute_capacity_buffer(state: CapacityBufferState) -> TMSHeuristicDecision:
+    """
+    Capacity buffer sizing with conformal P90-P50 integration.
+
+    Industry algorithm (newsvendor-inspired):
+    1. If conformal forecast intervals available (P10/P90), use P90-P50
+       as the volatility signal — this is distribution-free and handles
+       heavy-tailed freight demand better than Gaussian CV.
+    2. Tender reject rate as primary capacity-side signal.
+    3. Market tightness via recent capacity misses.
+    4. Peak season calendar adjustment.
+    5. Consistent oversupply → reduce buffer.
+    """
+    multiplier = 1.0
+    reasons = []
+
+    # Conformal interval: use P90-P50 spread when available (best signal)
+    conformal_spread = 0.0
+    if state.forecast_p90 > 0 and state.forecast_loads > 0:
+        conformal_spread = (state.forecast_p90 - state.forecast_loads) / max(1, state.forecast_loads)
+        if conformal_spread > 0.10:
+            # Conformal interval says demand could be 10%+ above P50
+            multiplier *= (1.0 + conformal_spread)
+            reasons.append(f"conformal P90 spread {conformal_spread*100:.0f}%")
+
+    # Tender reject rate (primary capacity signal)
+    if state.recent_tender_reject_rate > 0.15:
+        # Minimum buffer to absorb rejections: forecast × r / (1-r)
+        reject_multiplier = 1.0 + state.recent_tender_reject_rate / max(0.01, 1.0 - state.recent_tender_reject_rate)
+        multiplier *= min(1.5, reject_multiplier)  # Cap at 1.5×
+        reasons.append(f"tender reject rate {state.recent_tender_reject_rate*100:.0f}%")
+
+    # Demand CV fallback (when conformal not available)
+    if conformal_spread <= 0.10 and state.demand_cv > 0.3:
+        multiplier *= (1.0 + state.demand_cv * 0.5)
+        reasons.append(f"demand volatility CV={state.demand_cv:.2f}")
+
+    if state.is_peak_season:
+        multiplier *= 1.2
+        reasons.append("peak season")
+
+    if state.demand_trend > 0.1:
+        multiplier *= (1.0 + state.demand_trend * 0.2)
+        reasons.append(f"demand trend {state.demand_trend:+.2f}")
+
+    if state.recent_capacity_miss_count >= 3:
+        multiplier *= 1.25
+        reasons.append(f"{state.recent_capacity_miss_count} capacity misses")
+
+    # Reduce if consistently oversupplied
+    if (state.recent_tender_reject_rate < 0.05
+            and state.demand_cv < 0.15
+            and not state.is_peak_season
+            and state.recent_capacity_miss_count == 0
+            and conformal_spread < 0.05):
+        multiplier = 0.85
+        reasons = ["consistently oversupplied"]
+
+    adjusted_buffer = max(1, int(state.baseline_buffer_loads * multiplier))
+    action = Actions.MODIFY if abs(multiplier - 1.0) > 0.05 else Actions.ACCEPT
+
+    return TMSHeuristicDecision(
+        trm_type="capacity_buffer", action=action,
+        quantity=adjusted_buffer,
+        reasoning=f"Buffer {'adjusted' if action == Actions.MODIFY else 'maintained'}: {'; '.join(reasons) or 'nominal'}",
+        urgency=0.3 + abs(multiplier - 1.0) * 0.5,
+        params_used={
+            "multiplier": round(multiplier, 3),
+            "baseline": state.baseline_buffer_loads,
+            "conformal_spread": round(conformal_spread, 3),
+            "reject_rate": state.recent_tender_reject_rate,
+        },
+    )
+
+
+# ============================================================================
+# 5. Exception Management
+# ============================================================================
+
+def _exception_priority_score(state: ExceptionManagementState) -> float:
+    """
+    Composite priority score per industry MCDA standard.
+    Higher = more urgent. Range roughly 0–1.
+
+        0.25 × severity_factor
+      + 0.20 × financial_factor
+      + 0.30 × time_criticality   (dominant — determines if resolution is feasible)
+      + 0.15 × customer_factor
+      + 0.10 × cascade_factor
+    """
+    import math
+    severity_map = {"LOW": 0.15, "MEDIUM": 0.40, "HIGH": 0.70, "CRITICAL": 1.0}
+    sev_f = severity_map.get(state.severity, 0.40)
+
+    # Financial: normalized against penalty + shipment value
+    total_exposure = state.penalty_exposure + state.estimated_cost_impact
+    fin_f = min(1.0, total_exposure / max(1.0, state.shipment_value + state.penalty_exposure))
+
+    # Time criticality: sigmoid ramp as delivery window shrinks
+    if state.delivery_window_remaining_hrs <= 0:
+        time_f = 1.0
+    else:
+        # Exponential urgency: approaches 1.0 as window → 0
+        time_f = 1.0 - math.exp(-2.0 / max(0.1, state.delivery_window_remaining_hrs))
+
+    # Customer tier: strategic=1.0, transactional=0.3
+    cust_f = max(0.2, 1.0 - (state.customer_tier - 1) * 0.2)
+
+    # Cascade: more downstream impact = more urgent
+    cascade_f = min(1.0, state.downstream_shipments_affected / 5.0)
+
+    return (0.25 * sev_f + 0.20 * fin_f + 0.30 * time_f
+            + 0.15 * cust_f + 0.10 * cascade_f)
+
+
+def _compute_exception_management(state: ExceptionManagementState) -> TMSHeuristicDecision:
+    """
+    Exception triage and resolution strategy selection.
+
+    Industry algorithm (Oracle OTM / SAP TM pattern):
+    1. Compute composite priority score (severity, financial, time, customer, cascade)
+    2. Auto-resolve within tolerance window (delay < appointment buffer)
+    3. Select resolution strategy from cost-ordered waterfall:
+       accept → carrier intervention → re-tender → reroute → expedite → escalate
+    4. Financial gating: don't expedite if expedite_cost > penalty_exposure
+
+    Temperature excursion always escalates immediately (food safety).
+    """
+    # Temperature excursion — immediate, no scoring needed (food safety / regulatory)
+    if state.exception_type == "TEMPERATURE_EXCURSION":
+        return TMSHeuristicDecision(
+            trm_type="exception_management", action=Actions.ESCALATE,
+            reasoning="Temperature excursion — immediate escalation (food safety)",
+            urgency=1.0,
+            params_used={"override": "temperature_safety"},
+        )
+
+    priority = _exception_priority_score(state)
+    scoring = {
+        "priority_score": round(priority, 3),
+        "severity": state.severity,
+        "financial_exposure": state.estimated_cost_impact + state.penalty_exposure,
+        "delivery_window_hrs": state.delivery_window_remaining_hrs,
+        "customer_tier": state.customer_tier,
+        "cascade_count": state.downstream_shipments_affected,
+    }
+
+    # Auto-resolve: delay within appointment buffer tolerance (SAP TM "tolerance-based auto-close")
+    if (state.estimated_delay_hrs <= state.appointment_buffer_hrs
+            and state.severity in ("LOW", "MEDIUM")
+            and state.downstream_shipments_affected == 0):
+        return TMSHeuristicDecision(
+            trm_type="exception_management", action=Actions.ACCEPT,
+            reasoning=f"Delay {state.estimated_delay_hrs:.1f}h within {state.appointment_buffer_hrs:.0f}h buffer — auto-absorb (score {priority:.2f})",
+            urgency=priority,
+            params_used=scoring,
+        )
+
+    # Resolution waterfall (cost-ordered), gated by priority score
+    if priority >= 0.75:
+        # High urgency: re-tender immediately if possible
+        if state.can_retender and state.alternate_carriers_available > 0:
+            return TMSHeuristicDecision(
+                trm_type="exception_management", action=Actions.RETENDER,
+                reasoning=f"High priority {priority:.2f}: re-tendering to {state.alternate_carriers_available} alternates ({state.exception_type})",
+                urgency=priority,
+                params_used=scoring,
+            )
+        # No re-tender → escalate for manual intervention
+        return TMSHeuristicDecision(
+            trm_type="exception_management", action=Actions.ESCALATE,
+            reasoning=f"High priority {priority:.2f} but no re-tender options — escalating ({state.exception_type})",
+            urgency=priority,
+            params_used=scoring,
+        )
+
+    if priority >= 0.50:
+        # Medium urgency: try reroute if available, else re-tender
+        if state.can_reroute and state.delivery_window_remaining_hrs > 4:
+            return TMSHeuristicDecision(
+                trm_type="exception_management", action=Actions.REROUTE,
+                reasoning=f"Medium priority {priority:.2f}: rerouting with {state.delivery_window_remaining_hrs:.0f}h window ({state.exception_type})",
+                urgency=priority,
+                params_used=scoring,
+            )
+        if state.can_retender and state.alternate_carriers_available > 0:
+            # Financial gate: only re-tender if penalty justifies it
+            retender_cost = state.estimated_cost_impact * 0.3  # Estimated re-tender premium
+            if state.penalty_exposure > retender_cost or state.customer_tier <= 2:
+                return TMSHeuristicDecision(
+                    trm_type="exception_management", action=Actions.RETENDER,
+                    reasoning=f"Medium priority {priority:.2f}: re-tender justified (penalty ${state.penalty_exposure:.0f} > re-tender cost ${retender_cost:.0f})",
+                    urgency=priority,
+                    params_used=scoring,
+                )
+        # Escalate for review
+        return TMSHeuristicDecision(
+            trm_type="exception_management", action=Actions.ESCALATE,
+            reasoning=f"Medium priority {priority:.2f}: escalating for review ({state.exception_type}, delay {state.estimated_delay_hrs:.1f}h)",
+            urgency=priority,
+            params_used=scoring,
+        )
+
+    # Low urgency: accept and monitor
+    return TMSHeuristicDecision(
+        trm_type="exception_management", action=Actions.ACCEPT,
+        reasoning=f"Low priority {priority:.2f}: monitoring ({state.exception_type}, {state.estimated_delay_hrs:.1f}h delay, {state.severity})",
+        urgency=priority,
+        params_used=scoring,
+    )
+
+
+# ============================================================================
+# 6. Freight Procurement
+# ============================================================================
+
+def _score_carrier(carrier: Dict[str, Any], benchmark_rate: float) -> float:
+    """
+    Composite carrier score per industry standard (Oracle OTM / SAP TM).
+    Higher = better candidate.
+
+        0.35 × cost_factor      (benchmark / rate — lower rate = higher score)
+      + 0.25 × otp_factor       (on-time performance)
+      + 0.20 × acceptance_factor (historical acceptance rate)
+      + 0.10 × compliance_factor (allocation compliance)
+      + 0.10 × capacity_factor   (available equipment indicator)
+    """
+    rate = carrier.get("rate", 0)
+    cost_f = min(1.0, benchmark_rate / rate) if rate > 0 and benchmark_rate > 0 else 0.5
+    otp_f = carrier.get("otp_pct", 0.90)
+    acc_f = carrier.get("acceptance_pct", 0.80)
+    comp_f = min(1.0, carrier.get("allocation_compliance", 1.0))
+    cap_f = 1.0 if carrier.get("has_capacity", True) else 0.3
+    return 0.35 * cost_f + 0.25 * otp_f + 0.20 * acc_f + 0.10 * comp_f + 0.10 * cap_f
+
+
+def _compute_freight_procurement(state: FreightProcurementState) -> TMSHeuristicDecision:
+    """
+    Carrier waterfall tendering with composite scoring + market adjustment.
+
+    Industry algorithm (Oracle OTM Carrier Selection Workbench pattern):
+    1. Lead-time fast-path: if <4h to pickup, skip waterfall → spot
+    2. Acceptance-rate gating: skip carriers with <50% trailing acceptance
+    3. Composite scoring: rank by cost+OTP+acceptance+compliance, not just priority
+    4. Market adjustment: tight market (OTRI > 0.15) → shorten waterfall depth
+    5. DAT benchmark gating: spot rate vs. benchmark, not just vs. contract
+
+    EDI flow: 204 (tender) → 990 (accept/decline).
+    """
+    benchmark = state.dat_benchmark_rate or state.contract_rate or state.primary_carrier_rate
+
+    # Lead-time fast-path: very short lead time → skip to spot
+    if state.lead_time_hours < 4:
+        if state.spot_rate > 0:
+            premium = ((state.spot_rate - benchmark) / benchmark) if benchmark > 0 else 0
+            return TMSHeuristicDecision(
+                trm_type="freight_procurement", action=Actions.ACCEPT,
+                quantity=state.spot_rate,
+                reasoning=f"Short lead time ({state.lead_time_hours:.0f}h): direct to spot at ${state.spot_rate:.2f} ({premium*100:+.0f}% vs benchmark)",
+                urgency=0.7,
+                params_used={"rate_type": "spot_fast_path", "lead_time_hours": state.lead_time_hours},
+            )
+        return TMSHeuristicDecision(
+            trm_type="freight_procurement", action=Actions.ESCALATE,
+            reasoning=f"Short lead time ({state.lead_time_hours:.0f}h) with no spot rate; escalating to broker",
+            urgency=0.9,
+        )
+
+    # Market-adjusted waterfall depth: tight market → fewer contract attempts
+    effective_max_attempts = state.max_tender_attempts
+    if state.market_tightness > 0.6:
+        effective_max_attempts = max(2, state.max_tender_attempts - 1)
+
+    # Attempt 1: primary carrier (with acceptance-rate gate)
+    if state.tender_attempt == 1 and state.primary_carrier_id:
+        if state.primary_carrier_acceptance_pct < 0.50:
+            # Known decliner — skip to backups
+            pass
+        else:
+            primary_score = _score_carrier({
+                "rate": state.primary_carrier_rate,
+                "acceptance_pct": state.primary_carrier_acceptance_pct,
+                "otp_pct": 0.93,
+                "allocation_compliance": 1.0,
+            }, benchmark)
+            return TMSHeuristicDecision(
+                trm_type="freight_procurement", action=Actions.ACCEPT,
+                quantity=state.primary_carrier_rate,
+                reasoning=f"Primary carrier score {primary_score:.2f} at ${state.primary_carrier_rate:.2f} (accept rate {state.primary_carrier_acceptance_pct*100:.0f}%)",
+                urgency=0.3,
+                params_used={
+                    "carrier_id": state.primary_carrier_id,
+                    "rate_type": "contract",
+                    "composite_score": round(primary_score, 3),
+                    "market_tightness": state.market_tightness,
+                },
+            )
+
+    # Subsequent attempts: composite-scored backups with acceptance gating
+    if state.tender_attempt <= effective_max_attempts and state.backup_carriers:
+        eligible = [c for c in state.backup_carriers
+                    if c.get("acceptance_pct", 0.80) >= 0.50]
+        if eligible:
+            scored = [(c, _score_carrier(c, benchmark)) for c in eligible]
+            scored.sort(key=lambda x: x[1], reverse=True)
+            best_carrier, best_score = scored[0]
+            return TMSHeuristicDecision(
+                trm_type="freight_procurement", action=Actions.ACCEPT,
+                quantity=best_carrier.get("rate", 0),
+                reasoning=f"Backup carrier score {best_score:.2f} at ${best_carrier.get('rate', 0):.2f} (attempt {state.tender_attempt}, {len(eligible)} eligible of {len(state.backup_carriers)})",
+                urgency=0.5,
+                params_used={
+                    "carrier_id": best_carrier.get("id"),
+                    "rate_type": "contract_backup",
+                    "composite_score": round(best_score, 3),
+                    "carriers_skipped_low_acceptance": len(state.backup_carriers) - len(eligible),
+                },
+            )
+
+    # Spot market: gate against DAT benchmark, not just contract rate
+    if state.spot_rate > 0 and benchmark > 0:
+        premium_vs_benchmark = (state.spot_rate - benchmark) / benchmark
+        # Tight market: widen acceptance threshold
+        spot_threshold = 0.25 if state.market_tightness < 0.4 else 0.35
+        if premium_vs_benchmark < spot_threshold:
+            return TMSHeuristicDecision(
+                trm_type="freight_procurement", action=Actions.ACCEPT,
+                quantity=state.spot_rate,
+                reasoning=f"Spot at ${state.spot_rate:.2f} ({premium_vs_benchmark*100:+.0f}% vs DAT benchmark, threshold {spot_threshold*100:.0f}%)",
+                urgency=0.6,
+                params_used={
+                    "rate_type": "spot",
+                    "premium_vs_benchmark": round(premium_vs_benchmark, 3),
+                    "market_tightness": state.market_tightness,
+                    "threshold_used": spot_threshold,
+                },
+            )
+
+    # Waterfall exhausted → broker
+    return TMSHeuristicDecision(
+        trm_type="freight_procurement", action=Actions.ESCALATE,
+        reasoning=f"Waterfall exhausted after {state.tender_attempt} attempts (market tightness {state.market_tightness:.2f}); escalating to broker",
+        urgency=0.8,
+        params_used={"market_tightness": state.market_tightness},
+    )
+
+
+# ============================================================================
+# 7. Broker Routing
+# ============================================================================
+
+def _compute_broker_routing(state: BrokerRoutingState) -> TMSHeuristicDecision:
+    """
+    Broker selection with time-urgency scaling + market-adjusted premium
+    threshold + DAT benchmark anchoring.
+
+    Industry algorithm (CH Robinson / XPO / Uber Freight pattern):
+    - P1-P2: most reliable broker regardless of cost
+    - Time-urgency: widen premium threshold 10%/hr as pickup approaches
+    - Market-adjusted: tight market widens threshold from 25% to 40%
+    - DAT benchmark anchoring (not contract rate) for premium calculation
+    - Reliability-adjusted cost scoring with fallthrough rate
+    """
+    if not state.available_brokers:
+        return TMSHeuristicDecision(
+            trm_type="broker_routing", action=Actions.ESCALATE,
+            reasoning="No brokers available; manual intervention required",
+            urgency=1.0,
+        )
+
+    benchmark = state.dat_benchmark_rate or state.contract_rate
+    if benchmark <= 0:
+        benchmark = min(b.get("rate", float("inf")) for b in state.available_brokers) * 0.85
+
+    if state.shipment_priority <= 2:
+        best = max(state.available_brokers, key=lambda b: b.get("reliability", 0))
+        return TMSHeuristicDecision(
+            trm_type="broker_routing", action=Actions.ACCEPT,
+            quantity=best.get("rate", 0),
+            reasoning=f"Critical (P{state.shipment_priority}): broker {best.get('name', 'N/A')} (reliability {best.get('reliability', 0)*100:.0f}%)",
+            urgency=0.8,
+            params_used={"broker_id": best.get("id"), "selection": "reliability_priority_override"},
+        )
+
+    # Score brokers: reliability-adjusted cost with fallthrough penalty
+    scored = []
+    for broker in state.available_brokers:
+        rate = broker.get("rate", float("inf"))
+        reliability = broker.get("reliability", 0.5)
+        fallthrough = broker.get("fallthrough_rate", 1.0 - reliability)
+        rebooking_premium = 0.25
+        expected_cost = rate * (1.0 + fallthrough * rebooking_premium)
+        scored.append((expected_cost, broker))
+    scored.sort(key=lambda x: x[0])
+    _, best_broker = scored[0]
+    best_rate = best_broker.get("rate", 0)
+
+    # Premium threshold: base + market adjustment + time-urgency scaling
+    base_threshold = 0.25
+    # Market tightness widens threshold
+    market_adj = state.market_tightness * 0.15  # up to +15% in extreme market
+    # Time urgency: widen 10%/hr when <6h to pickup
+    time_adj = 0.0
+    if state.hours_to_pickup < 6:
+        time_adj = max(0, (6 - state.hours_to_pickup) * 0.10)
+    effective_threshold = base_threshold + market_adj + time_adj
+
+    premium_vs_benchmark = (best_rate - benchmark) / benchmark if benchmark > 0 else 0
+
+    broker_detail = {
+        "broker_id": best_broker.get("id"),
+        "broker_name": best_broker.get("name"),
+        "reliability": best_broker.get("reliability"),
+        "premium_vs_benchmark": round(premium_vs_benchmark, 3),
+        "effective_threshold": round(effective_threshold, 3),
+        "market_adj": round(market_adj, 3),
+        "time_adj": round(time_adj, 3),
+        "hours_to_pickup": state.hours_to_pickup,
+    }
+
+    if premium_vs_benchmark > effective_threshold:
+        return TMSHeuristicDecision(
+            trm_type="broker_routing", action=Actions.ESCALATE,
+            quantity=best_rate,
+            reasoning=f"Broker ${best_rate:.0f} is {premium_vs_benchmark*100:+.0f}% vs benchmark (threshold {effective_threshold*100:.0f}%); needs approval",
+            urgency=0.7,
+            params_used=broker_detail,
+        )
+
+    return TMSHeuristicDecision(
+        trm_type="broker_routing", action=Actions.ACCEPT,
+        quantity=best_rate,
+        reasoning=f"Broker {best_broker.get('name', 'N/A')}: ${best_rate:.0f} ({premium_vs_benchmark*100:+.0f}% vs benchmark, threshold {effective_threshold*100:.0f}%)",
+        urgency=0.5,
+        params_used=broker_detail,
+    )
+
+
+# ============================================================================
+# 8. Dock Scheduling
+# ============================================================================
+
+def _compute_dock_scheduling(state: DockSchedulingState) -> TMSHeuristicDecision:
+    """
+    Dock scheduling with equipment-door compatibility + detention cost
+    awareness + yard capacity check + congestion-driven mode switching.
+
+    Industry algorithm (SAP EWM / Manhattan WMS pattern):
+    1. Priority override: P1-P2 always accommodate
+    2. Compatibility: check equipment type vs. door type (reefer/dry/hazmat)
+    3. Yard capacity: if yard is full, recommend drop-trailer offsite
+    4. Detention cost: compute projected detention $ and prioritize accordingly
+    5. Queue congestion: switch live-load → drop-trailer when queue > 3
+    6. Utilization management: defer low-priority when utilization > 85%
+    """
+    util = state.utilization_pct()
+    detention_risk = state.detention_risk_score()
+
+    # Projected detention cost
+    projected_overage_min = max(0, state.carrier_avg_dwell_minutes - state.free_time_minutes)
+    projected_detention_cost = (projected_overage_min / 60.0) * state.detention_rate_per_hour
+
+    dock_detail = {
+        "utilization": round(util, 3),
+        "detention_risk": round(detention_risk, 3),
+        "projected_detention_cost": round(projected_detention_cost, 2),
+        "queue_depth": state.current_queue_depth,
+        "yard_available": state.yard_spots_available,
+        "equipment_type": state.equipment_type,
+        "door_type_required": state.required_door_type,
+    }
+
+    # Priority override
+    if state.shipment_priority <= 2:
+        return TMSHeuristicDecision(
+            trm_type="dock_scheduling", action=Actions.ACCEPT,
+            quantity=state.estimated_load_time_minutes,
+            reasoning=f"Priority P{state.shipment_priority}: dock assigned immediately",
+            urgency=0.7,
+            params_used=dock_detail,
+        )
+
+    # Equipment-door compatibility check (reefer needs reefer-capable door)
+    if state.equipment_type == "REEFER" and state.available_dock_doors == 0:
+        return TMSHeuristicDecision(
+            trm_type="dock_scheduling", action=Actions.DEFER,
+            reasoning=f"No compatible {state.equipment_type} dock doors available; deferring",
+            urgency=0.6,
+            params_used=dock_detail,
+        )
+
+    # Yard capacity — if no spots, recommend offsite hold
+    if state.yard_spots_available <= 0 and not state.is_live_load:
+        return TMSHeuristicDecision(
+            trm_type="dock_scheduling", action=Actions.DEFER,
+            reasoning=f"Yard full ({state.yard_spots_total} spots, 0 available); hold trailer offsite",
+            urgency=0.5,
+            params_used={**dock_detail, "recommendation": "hold_offsite"},
+        )
+
+    # Detention cost trigger: if projected detention > $150, prioritize turnaround
+    if projected_detention_cost > 150:
+        return TMSHeuristicDecision(
+            trm_type="dock_scheduling", action=Actions.MODIFY,
+            reasoning=f"Detention risk: ${projected_detention_cost:.0f} projected (avg dwell {state.carrier_avg_dwell_minutes:.0f}min vs {state.free_time_minutes:.0f}min free)",
+            urgency=0.8,
+            params_used={**dock_detail, "recommendation": "expedite_turnaround"},
+        )
+
+    # Queue congestion → switch to drop-trailer
+    if state.current_queue_depth > 3 and state.is_live_load:
+        return TMSHeuristicDecision(
+            trm_type="dock_scheduling", action=Actions.MODIFY,
+            reasoning=f"Queue depth {state.current_queue_depth}: convert live-load to drop-trailer",
+            urgency=0.6,
+            params_used={**dock_detail, "recommendation": "drop_trailer"},
+        )
+
+    # Basic detention risk (below $150 but still elevated)
+    if detention_risk > 0.5:
+        return TMSHeuristicDecision(
+            trm_type="dock_scheduling", action=Actions.MODIFY,
+            reasoning=f"Elevated detention risk {detention_risk:.0%}: monitoring turnaround",
+            urgency=0.5,
+            params_used={**dock_detail, "recommendation": "monitor_turnaround"},
+        )
+
+    # High utilization — defer low-priority
+    if util > 0.85 and state.shipment_priority >= 4:
+        return TMSHeuristicDecision(
+            trm_type="dock_scheduling", action=Actions.DEFER,
+            reasoning=f"Utilization {util*100:.0f}%, deferring P{state.shipment_priority}",
+            urgency=0.4,
+            params_used=dock_detail,
+        )
+
+    return TMSHeuristicDecision(
+        trm_type="dock_scheduling", action=Actions.ACCEPT,
+        quantity=state.estimated_load_time_minutes,
+        reasoning=f"Dock available (util {util*100:.0f}%, queue {state.current_queue_depth}, detention risk {detention_risk:.0%})",
+        urgency=0.2,
+        params_used=dock_detail,
+    )
+
+
+# ============================================================================
+# 9. Load Build
+# ============================================================================
+
+def _ftl_ltl_crossover(state: LoadBuildState) -> str:
+    """
+    Industry FTL vs. LTL crossover decision.
+
+    Standard thresholds (Oracle OTM, Manhattan Associates):
+    - < 8,000 lbs and < 10 pallets: LTL is typically cheaper
+    - 8,000–12,000 lbs: volume LTL / partial truckload zone
+    - > 12,000 lbs or > 12 pallets: FTL is almost always cheaper
+
+    When both LTL rate sum and FTL rate are available, use direct cost
+    comparison. Otherwise fall back to weight/pallet thresholds.
+    """
+    # Direct cost comparison when rates are available
+    if state.ftl_rate > 0 and state.ltl_rate_sum > 0:
+        if state.ftl_rate < state.ltl_rate_sum:
+            return "FTL"
+        # Check volume LTL as middle option
+        if state.volume_ltl_rate > 0 and state.volume_ltl_rate < state.ftl_rate:
+            return "VOLUME_LTL"
+        return "LTL"
+
+    # Threshold fallback
+    if state.total_weight >= 12000 or state.total_pallets >= 12:
+        return "FTL"
+    if state.total_weight >= 8000 or state.total_pallets >= 10:
+        return "VOLUME_LTL"
+    return "LTL"
+
+
+def _multi_stop_savings(state: LoadBuildState) -> float:
+    """
+    Clarke-Wright inspired savings estimate for multi-stop loads.
+
+    Savings = sum of individual FTL costs - (multi-stop FTL + stop-off charges).
+    Simplified: approximate individual cost as proportional to shipment count.
+    """
+    if state.shipment_count <= 1 or state.stop_count <= 1:
+        return 0.0
+    if state.ftl_rate <= 0:
+        return 0.0
+    # Individual shipment cost ≈ FTL rate each (worst case, all separate trucks)
+    individual_total = state.ftl_rate * state.shipment_count
+    # Multi-stop cost = one FTL + stop-off charges
+    multi_stop_cost = state.ftl_rate + (state.stop_count - 1) * state.stop_off_charge_per_stop
+    return max(0.0, individual_total - multi_stop_cost)
+
+
+def _compute_load_build(state: LoadBuildState) -> TMSHeuristicDecision:
+    """
+    Load consolidation with FTL/LTL crossover economics + multi-stop savings.
+
+    Industry algorithm (Oracle OTM / Manhattan Associates pattern):
+    1. Reject: hazmat or temperature conflict
+    2. Over-capacity: split
+    3. FTL/LTL crossover: determine optimal mode by weight/cost threshold
+    4. Multi-stop evaluation: savings from Clarke-Wright vs. stop-off charges
+    5. Underutilized single shipment: hold for consolidation window
+    6. Otherwise: accept current load plan
+
+    Key thresholds:
+    - FTL breakeven: ~8,000–12,000 lbs or 10–12 pallets
+    - Max multi-stop: 3–5 stops (state.max_stops)
+    - Consolidation savings target: 15–35% vs. individual LTL
+    """
+    w_util = state.weight_utilization()
+    v_util = state.volume_utilization()
+
+    # Hard constraint: compatibility conflicts
+    if state.has_hazmat_conflict or state.has_temp_conflict:
+        return TMSHeuristicDecision(
+            trm_type="load_build", action=Actions.REJECT,
+            reasoning=f"Cannot consolidate: {'hazmat' if state.has_hazmat_conflict else 'temperature'} conflict",
+            urgency=0.3,
+        )
+
+    # Over-capacity: must split
+    if w_util > 0.95 or v_util > 0.95:
+        return TMSHeuristicDecision(
+            trm_type="load_build", action=Actions.SPLIT,
+            reasoning=f"Exceeds capacity: weight {w_util*100:.0f}%, volume {v_util*100:.0f}%",
+            urgency=0.5,
+        )
+
+    # Delivery window conflict for multi-stop
+    if state.stop_count > 1 and not state.delivery_windows_compatible:
+        return TMSHeuristicDecision(
+            trm_type="load_build", action=Actions.SPLIT,
+            reasoning=f"Delivery windows incompatible across {state.stop_count} stops",
+            urgency=0.4,
+        )
+
+    # FTL/LTL crossover analysis
+    optimal_mode = _ftl_ltl_crossover(state)
+    ms_savings = _multi_stop_savings(state) if state.shipment_count > 1 else 0.0
+    total_savings = state.consolidation_savings + ms_savings
+
+    mode_detail = {
+        "optimal_mode": optimal_mode,
+        "weight_util": round(w_util, 3),
+        "volume_util": round(v_util, 3),
+        "consolidation_savings": state.consolidation_savings,
+        "multi_stop_savings": round(ms_savings, 2),
+        "total_savings": round(total_savings, 2),
+        "stop_count": state.stop_count,
+    }
+
+    # Consolidation justified: savings positive AND physically feasible
+    if total_savings > 0 and state.should_consolidate():
+        # Check multi-stop limit
+        if state.stop_count > state.max_stops:
+            return TMSHeuristicDecision(
+                trm_type="load_build", action=Actions.SPLIT,
+                reasoning=f"Consolidation saves ${total_savings:.0f} but {state.stop_count} stops exceeds max {state.max_stops}",
+                urgency=0.4,
+                params_used=mode_detail,
+            )
+        savings_pct = (total_savings / max(1, state.ltl_rate_sum)) * 100 if state.ltl_rate_sum > 0 else 0
+        return TMSHeuristicDecision(
+            trm_type="load_build", action=Actions.CONSOLIDATE,
+            quantity=state.shipment_count,
+            reasoning=f"Consolidate {state.shipment_count} shipments as {optimal_mode}: ${total_savings:.0f} savings ({savings_pct:.0f}%), {w_util*100:.0f}% weight, {v_util*100:.0f}% volume",
+            urgency=0.4,
+            params_used=mode_detail,
+        )
+
+    # LTL crossover: if weight is below FTL breakeven and no savings from consolidation
+    if optimal_mode == "LTL" and state.shipment_count == 1:
+        return TMSHeuristicDecision(
+            trm_type="load_build", action=Actions.ACCEPT,
+            quantity=1,
+            reasoning=f"Single shipment {state.total_weight:.0f} lbs / {state.total_pallets} pallets — route as LTL (below FTL breakeven)",
+            urgency=0.2,
+            params_used=mode_detail,
+        )
+
+    # Underutilized: hold for consolidation window
+    if w_util < 0.50 and state.shipment_count == 1:
+        return TMSHeuristicDecision(
+            trm_type="load_build", action=Actions.DEFER,
+            reasoning=f"Underutilized ({w_util*100:.0f}% weight): hold for {state.consolidation_window_hours:.0f}h consolidation window",
+            urgency=0.3,
+            params_used=mode_detail,
+        )
+
+    # Accept current load plan
+    return TMSHeuristicDecision(
+        trm_type="load_build", action=Actions.ACCEPT,
+        quantity=state.shipment_count,
+        reasoning=f"Load accepted as {optimal_mode}: {state.shipment_count} shipments, {w_util*100:.0f}% weight, {v_util*100:.0f}% volume",
+        urgency=0.2,
+        params_used=mode_detail,
+    )
+
+
+# ============================================================================
+# 10. Intermodal Transfer
+# ============================================================================
+
+def _compute_intermodal_transfer(state: IntermodalTransferState) -> TMSHeuristicDecision:
+    """
+    Mode shift with commodity gating + ramp proximity filter + drayage
+    decomposition + inventory carrying cost.
+
+    Industry algorithm (Oracle OTM / J.B. Hunt 360 pattern):
+    1. Commodity eligibility: hazmat and temperature-controlled → reject
+    2. Ramp proximity: >100 miles from origin or dest ramp → reject
+    3. Distance filter: <500 miles total → reject
+    4. Ramp congestion: >0.7 → reject
+    5. Transit feasibility: delivery window must accommodate penalty
+    6. All-in cost with drayage decomposition + inventory carrying cost
+    7. Savings threshold: 8% minimum (5% on long-haul >800mi)
+    """
+    savings = state.cost_savings_pct()
+    has_time = state.has_time_for_intermodal()
+
+    intermodal_detail = {
+        "savings_pct": round(savings, 3),
+        "truck_rate": state.truck_rate,
+        "intermodal_rate": state.intermodal_rate,
+        "drayage_origin": state.drayage_rate_origin,
+        "drayage_dest": state.drayage_rate_dest,
+        "origin_ramp_miles": state.origin_ramp_distance_miles,
+        "dest_ramp_miles": state.dest_ramp_distance_miles,
+        "total_truck_miles": state.total_truck_miles,
+        "transit_penalty_days": state.transit_time_penalty_days(),
+    }
+
+    # Commodity eligibility gate — hazmat and reefer typically ineligible for rail
+    if state.is_hazmat:
+        return TMSHeuristicDecision(
+            trm_type="intermodal_transfer", action=Actions.REJECT,
+            reasoning="Hazmat freight ineligible for intermodal",
+            urgency=0.1,
+            params_used={**intermodal_detail, "gate": "hazmat"},
+        )
+    if state.is_temperature_controlled:
+        return TMSHeuristicDecision(
+            trm_type="intermodal_transfer", action=Actions.REJECT,
+            reasoning="Temperature-controlled freight — limited intermodal reefer availability",
+            urgency=0.1,
+            params_used={**intermodal_detail, "gate": "temperature"},
+        )
+
+    # Ramp proximity gate — >100 miles kills drayage economics
+    if state.origin_ramp_distance_miles > 100 or state.dest_ramp_distance_miles > 100:
+        far_end = "origin" if state.origin_ramp_distance_miles > 100 else "destination"
+        far_miles = max(state.origin_ramp_distance_miles, state.dest_ramp_distance_miles)
+        return TMSHeuristicDecision(
+            trm_type="intermodal_transfer", action=Actions.REJECT,
+            reasoning=f"{far_end.title()} ramp {far_miles:.0f}mi away (>100mi threshold); drayage kills economics",
+            urgency=0.1,
+            params_used={**intermodal_detail, "gate": "ramp_proximity"},
+        )
+
+    # Distance filter — intermodal rarely viable <500 miles
+    if state.total_truck_miles < 500:
+        return TMSHeuristicDecision(
+            trm_type="intermodal_transfer", action=Actions.REJECT,
+            reasoning=f"Lane {state.total_truck_miles:.0f}mi — below 500mi intermodal threshold",
+            urgency=0.1,
+            params_used={**intermodal_detail, "gate": "distance"},
+        )
+
+    # Ramp congestion
+    if state.ramp_congestion_level > 0.7:
+        return TMSHeuristicDecision(
+            trm_type="intermodal_transfer", action=Actions.REJECT,
+            reasoning=f"Ramp congestion {state.ramp_congestion_level*100:.0f}%; staying on truck",
+            urgency=0.3,
+            params_used=intermodal_detail,
+        )
+
+    # Transit feasibility
+    if not has_time:
+        return TMSHeuristicDecision(
+            trm_type="intermodal_transfer", action=Actions.REJECT,
+            reasoning=f"Transit penalty {state.transit_time_penalty_days():.1f}d exceeds window ({state.delivery_window_days:.1f}d)",
+            urgency=0.2,
+            params_used=intermodal_detail,
+        )
+
+    # Reliability + tight window
+    if state.intermodal_reliability_pct < 0.80 and state.delivery_window_days < 2:
+        return TMSHeuristicDecision(
+            trm_type="intermodal_transfer", action=Actions.REJECT,
+            reasoning=f"Reliability {state.intermodal_reliability_pct*100:.0f}% too low for {state.delivery_window_days:.1f}d window",
+            urgency=0.3,
+            params_used=intermodal_detail,
+        )
+
+    # Inventory carrying cost adjustment for high-value freight
+    carrying_cost = 0.0
+    if state.commodity_value_per_lb > 0 and state.truck_rate > 0:
+        # Annual carrying rate ~10%, daily = 10%/365
+        daily_carry = state.commodity_value_per_lb * 44000 * (0.10 / 365.0)
+        carrying_cost = daily_carry * state.transit_time_penalty_days()
+
+    # All-in savings including carrying cost
+    effective_savings = state.truck_rate - state.intermodal_rate - carrying_cost
+    effective_savings_pct = effective_savings / state.truck_rate if state.truck_rate > 0 else 0
+
+    # Threshold: 8% normally, 5% on long-haul >800mi
+    threshold = 0.05 if state.total_truck_miles > 800 else 0.08
+
+    intermodal_detail["carrying_cost"] = round(carrying_cost, 2)
+    intermodal_detail["effective_savings_pct"] = round(effective_savings_pct, 3)
+    intermodal_detail["threshold"] = threshold
+
+    if effective_savings_pct >= threshold and has_time:
+        return TMSHeuristicDecision(
+            trm_type="intermodal_transfer", action=Actions.ACCEPT,
+            quantity=state.intermodal_rate,
+            reasoning=f"Mode shift {state.current_mode}→{state.candidate_mode}: {effective_savings_pct*100:.0f}% net savings (${effective_savings:.0f}), +{state.transit_time_penalty_days():.1f}d",
+            urgency=0.4,
+            params_used=intermodal_detail,
+        )
+
+    return TMSHeuristicDecision(
+        trm_type="intermodal_transfer", action=Actions.REJECT,
+        reasoning=f"Net savings {effective_savings_pct*100:.0f}% below {threshold*100:.0f}% threshold (carrying cost ${carrying_cost:.0f})",
+        urgency=0.1,
+        params_used=intermodal_detail,
+    )
+
+
+# ============================================================================
+# 11. Equipment Reposition
+# ============================================================================
+
+def _compute_equipment_reposition(state: EquipmentRepositionState) -> TMSHeuristicDecision:
+    """
+    Equipment repositioning (deadhead management).
+
+    Rules:
+    - Source surplus + target deficit: reposition
+    - ROI > 1.5: economically justified
+    - Fleet utilization >90% and deficit exists: urgent reposition
+    - No surplus or no deficit: hold
+    """
+    surplus = state.source_surplus()
+    deficit = state.target_deficit()
+    roi = state.reposition_roi()
+
+    if surplus == 0:
+        return TMSHeuristicDecision(
+            trm_type="equipment_reposition", action=Actions.HOLD,
+            reasoning=f"No surplus at source ({state.source_equipment_count} equipment, {state.source_demand_next_7d} needed)",
+            urgency=0.1,
+        )
+
+    if deficit == 0:
+        return TMSHeuristicDecision(
+            trm_type="equipment_reposition", action=Actions.HOLD,
+            reasoning=f"No deficit at target ({state.target_equipment_count} equipment, {state.target_demand_next_7d} needed)",
+            urgency=0.1,
+        )
+
+    if state.fleet_utilization_pct > 0.90 and deficit > 0:
+        qty = min(surplus, deficit)
+        return TMSHeuristicDecision(
+            trm_type="equipment_reposition", action=Actions.REPOSITION,
+            quantity=qty,
+            reasoning=f"Urgent: fleet {state.fleet_utilization_pct*100:.0f}% utilized, repositioning {qty} {state.equipment_type} units ({state.reposition_miles:.0f}mi)",
+            urgency=0.8,
+        )
+
+    if roi > 1.5:
+        qty = min(surplus, deficit, state.breakeven_loads)
+        return TMSHeuristicDecision(
+            trm_type="equipment_reposition", action=Actions.REPOSITION,
+            quantity=qty,
+            reasoning=f"ROI {roi:.1f}x: reposition {qty} units, cost ${state.reposition_cost:.0f} vs ${state.cost_of_not_repositioning:.0f} spot premium avoided",
+            urgency=0.5,
+            params_used={"roi": roi, "miles": state.reposition_miles},
+        )
+
+    if roi > 1.0 and state.reposition_miles < 200:
+        qty = min(surplus, deficit)
+        return TMSHeuristicDecision(
+            trm_type="equipment_reposition", action=Actions.REPOSITION,
+            quantity=qty,
+            reasoning=f"Short reposition ({state.reposition_miles:.0f}mi, ROI {roi:.1f}x)",
+            urgency=0.3,
+        )
+
+    return TMSHeuristicDecision(
+        trm_type="equipment_reposition", action=Actions.HOLD,
+        reasoning=f"Reposition ROI {roi:.1f}x below threshold (1.5x) for {state.reposition_miles:.0f}mi move",
+        urgency=0.2,
+    )
+
+
+# ============================================================================
+# 12. Lane Volume Forecast (NEW — Execution-tier orchestrator)
+# ============================================================================
+
+def _compute_lane_volume_forecast(state: LaneVolumeForecastState) -> TMSHeuristicDecision:
+    """
+    Lane-volume forecast orchestrator. Decides which model family to route to
+    (Holt-Winters / LightGBM / Croston / TSB / AutoETS cold-start) via
+    Syntetos-Boylan classification, then commits a publish action.
+
+    Action semantics (TMS Execution-tier, sub-10ms):
+      ACCEPT    — proposed forecast is reliable, ship it
+      MODIFY    — apply external signal overlay (promo / event / market shift)
+                  or peak-season precautionary buffer; reasoning records
+                  the overlay magnitude
+      ESCALATE  — low confidence (cold start, declining trend, large
+                  trailing MAPE, or wide conformal interval); flag for
+                  human review before publishing
+      DEFER     — insufficient history (< 4 weeks) — cannot forecast yet,
+                  fall back to upstream supply / transfer plan or
+                  customer-supplied volume
+
+    Industry pattern: mirrors SCP's Forecast Baseline TRM but at lane grain.
+    Model selection is heuristic-internal (Syntetos-Boylan + covariate
+    eligibility); the TRM's surfaced action is whether to commit the
+    resulting forecast.
+
+    Gating reminder: this TRM is provisioned only on shipper facilities
+    and only invoked at runtime for lanes with `has_external_endpoint=True`.
+    Internal-transfer and inbound lanes inherit volume from the upstream
+    supply / transfer plan and never reach this heuristic.
+    """
+    cls = state.syntetos_boylan_class()
+    method = state.recommended_model()
+
+    detail = {
+        "demand_class": cls,
+        "recommended_method": method,
+        "weeks_history": state.weeks_of_history,
+        "adi": round(state.adi(), 2),
+        "cv2": round(state.cv_squared(), 2),
+        "trailing_mape": round(state.trailing_mape, 3),
+        "interval_width_pct": round(state.forecast_interval_width_pct, 3),
+    }
+
+    # ── DEFER: insufficient data to forecast ─────────────────────────
+    if state.weeks_of_history < 4:
+        return TMSHeuristicDecision(
+            trm_type="lane_volume_forecast", action=Actions.DEFER,
+            quantity=0.0,
+            reasoning=(
+                f"Insufficient history ({state.weeks_of_history}w < 4w required); "
+                f"defer — fall back to upstream plan or customer-supplied volume"
+            ),
+            urgency=0.3, confidence=0.5,
+            params_used=detail,
+        )
+
+    # ── ESCALATE: cold start (NEW class) — needs human eyes ─────────
+    if cls == "NEW":
+        return TMSHeuristicDecision(
+            trm_type="lane_volume_forecast", action=Actions.ESCALATE,
+            quantity=state.proposed_forecast_p50,
+            reasoning=(
+                f"Cold-start lane ({state.weeks_of_history}w history < 8w threshold); "
+                f"AutoETS cold-start fit, confidence low — flag for review"
+            ),
+            urgency=0.6, confidence=0.4,
+            params_used=detail,
+        )
+
+    # ── ESCALATE: declining lane (potential EOL / churn signal) ─────
+    if cls == "DECLINING":
+        return TMSHeuristicDecision(
+            trm_type="lane_volume_forecast", action=Actions.ESCALATE,
+            quantity=state.proposed_forecast_p50,
+            reasoning=(
+                f"Declining lane (slope {state.trend_slope:+.3f}, last {state.last_period_actual:.1f} "
+                f"vs mean {state.mean_demand:.1f}); flag EOL / customer-churn risk"
+            ),
+            urgency=0.6, confidence=0.5,
+            params_used=detail,
+        )
+
+    # ── ESCALATE: trailing MAPE blown out ────────────────────────────
+    if state.trailing_mape > 0.40:
+        return TMSHeuristicDecision(
+            trm_type="lane_volume_forecast", action=Actions.ESCALATE,
+            quantity=state.proposed_forecast_p50,
+            reasoning=(
+                f"Trailing MAPE {state.trailing_mape*100:.0f}% > 40% — model performance "
+                f"degraded; class {cls}, currently {state.forecast_method_in_use or 'untrained'}"
+            ),
+            urgency=0.7, confidence=0.4,
+            params_used=detail,
+        )
+
+    # ── ESCALATE: very wide conformal interval (uncertainty) ────────
+    if state.forecast_interval_width_pct > 1.5:
+        return TMSHeuristicDecision(
+            trm_type="lane_volume_forecast", action=Actions.ESCALATE,
+            quantity=state.proposed_forecast_p50,
+            reasoning=(
+                f"P10–P90 interval width {state.forecast_interval_width_pct*100:.0f}% of P50 "
+                f"(>150% threshold); class {cls}, method {method}"
+            ),
+            urgency=0.5, confidence=0.4,
+            params_used=detail,
+        )
+
+    # ── ESCALATE: poor conformal coverage (calibration drift) ───────
+    if state.conformal_coverage_p80 < 0.60:
+        return TMSHeuristicDecision(
+            trm_type="lane_volume_forecast", action=Actions.ESCALATE,
+            quantity=state.proposed_forecast_p50,
+            reasoning=(
+                f"Conformal coverage {state.conformal_coverage_p80*100:.0f}% < 60% target; "
+                f"calibration drift on {method}"
+            ),
+            urgency=0.5, confidence=0.5,
+            params_used=detail,
+        )
+
+    # ── MODIFY: signal overlay (promo / NPI / EOL / event / market) ─
+    if state.signal_type and state.signal_magnitude > 0 and state.signal_confidence > 0.5:
+        adjustment = state.signal_magnitude * state.proposed_forecast_p50 * state.signal_confidence
+        return TMSHeuristicDecision(
+            trm_type="lane_volume_forecast", action=Actions.MODIFY,
+            quantity=adjustment,
+            reasoning=(
+                f"Signal {state.signal_type}: magnitude {state.signal_magnitude:+.2f} × "
+                f"confidence {state.signal_confidence:.2f}; class {cls}, method {method}"
+            ),
+            urgency=0.5, confidence=state.signal_confidence,
+            params_used={**detail, "signal_type": state.signal_type,
+                         "signal_magnitude": state.signal_magnitude},
+        )
+
+    # ── MODIFY: peak season + degraded MAPE → precautionary buffer ──
+    if state.is_peak_season and state.trailing_mape > 0.20:
+        adjustment = state.proposed_forecast_p50 * 0.10
+        return TMSHeuristicDecision(
+            trm_type="lane_volume_forecast", action=Actions.MODIFY,
+            quantity=adjustment,
+            reasoning=(
+                f"Peak season + MAPE {state.trailing_mape*100:.0f}% > 20%: +10% precautionary "
+                f"buffer on top of {method} P50"
+            ),
+            urgency=0.4, confidence=0.6,
+            params_used=detail,
+        )
+
+    # ── ACCEPT: ship the proposed forecast ──────────────────────────
+    return TMSHeuristicDecision(
+        trm_type="lane_volume_forecast", action=Actions.ACCEPT,
+        quantity=state.proposed_forecast_p50,
+        reasoning=(
+            f"Class {cls}, method {method}, MAPE {state.trailing_mape*100:.0f}%, "
+            f"coverage {state.conformal_coverage_p80*100:.0f}% — publish forecast"
+        ),
+        urgency=0.2, confidence=0.85,
+        params_used=detail,
+    )

--- a/backend/scripts/pretraining/generate_tms_corpus.py
+++ b/backend/scripts/pretraining/generate_tms_corpus.py
@@ -50,10 +50,10 @@ except ImportError:
 # GPU image has torch installed, so normal imports work fine.
 # CPU-only environments without torch need the installed package to have
 # torch stubbed or optional — for now this script targets the GPU container.
-from azirella_data_model.powell.tms.heuristic_library.dispatch import (
+from app.services.powell.tms_heuristic_library.dispatch import (
     compute_tms_decision, Actions,
 )
-from azirella_data_model.powell.tms.heuristic_library.base import (
+from app.services.powell.tms_heuristic_library.base import (
     CapacityPromiseState,
     ShipmentTrackingState,
     DemandSensingState,

--- a/backend/tests/integration/test_bsc_shadow_composition.py
+++ b/backend/tests/integration/test_bsc_shadow_composition.py
@@ -30,10 +30,10 @@ import dataclasses
 import sys
 from typing import Optional
 
-from azirella_data_model.powell.tms.heuristic_library.base import (
+from app.services.powell.tms_heuristic_library.base import (
     IntermodalTransferState,
 )
-from azirella_data_model.powell.tms.heuristic_library.dispatch import (
+from app.services.powell.tms_heuristic_library.dispatch import (
     compute_tms_decision,
 )
 from azirella_data_model.intersections.supply_transport.shadow_prices import (

--- a/docs/TMS_TRM_HEURISTIC_REFERENCE.md
+++ b/docs/TMS_TRM_HEURISTIC_REFERENCE.md
@@ -1,7 +1,7 @@
 # TMS TRM Heuristic Reference — Implemented Logic, Algorithms & Sources
 
-**Version:** 2.0 (post P1–P4 upgrade, 2026-04-19)
-**Location:** `azirella_data_model.powell.tms.heuristic_library` (Autonomy-Core)
+**Version:** 2.1 (heuristic library moved back to TMS, 2026-05-02)
+**Location:** `app.services.powell.tms_heuristic_library` (this repo)
 **Purpose:** Definitive reference for the deterministic heuristics that serve as
 (a) cold-start fallback logic for live TMS agents, and (b) teacher policy for
 TRM behavioral-cloning training. Every TRM's logic is documented here with

--- a/docs/internal/plans/CAPACITY_PROMISE_TRM_DESIGN.md
+++ b/docs/internal/plans/CAPACITY_PROMISE_TRM_DESIGN.md
@@ -14,11 +14,11 @@ bounds, not a carrier selection.
 
 **Core substrate already in place:**
 
-- `azirella_data_model.powell.tms.heuristic_library.base.CapacityPromiseState` —
+- `app.services.powell.tms_heuristic_library.base.CapacityPromiseState` —
   the input dataclass (lane, requested_date, requested_loads, priority,
   committed/total/buffer capacity, forecast/booked, primary carrier context,
   lane acceptance rate, market tightness, allocation compliance).
-- `azirella_data_model.powell.tms.heuristic_library.dispatch._compute_capacity_promise` —
+- `app.services.powell.tms_heuristic_library.dispatch._compute_capacity_promise` —
   the deterministic teacher (composite score with 5 weighted factors; priority
   overrides; 0.6 / 0.35 thresholds for ACCEPT / DEFER / REJECT).
 - `azirella_data_model.powell.tms.agent_capabilities["capacity_promise"]` —


### PR DESCRIPTION
## Summary

Mirror PR for [Autonomy-Core #46](https://github.com/azirella-ltd/Autonomy-Core/pull/46) (already merged). Reverses the 2026-04-17 extraction of `tms_heuristic_library` to Core. Per CLAUDE.md plane-module invariant, TMS-specific TRM heuristics belong in this repo, not in Core.

- **Files**: `app.services.powell.tms_heuristic_library/{base.py, dispatch.py, __init__.py}` are now the real implementation (758 + 1,476 + 50 = 2,284 lines), copied byte-for-byte from the deleted Core copy.
- **26 import sites retargeted** in the same commit: 11 TRMs (`broker_routing`, `capacity_buffer`, `capacity_promise`, `demand_sensing`, `dock_scheduling`, `equipment_reposition`, `exception_management`, `freight_procurement`, `intermodal_transfer`, `load_build`, `shipment_tracking`) + `generate_tms_corpus.py` + `test_bsc_shadow_composition.py`.
- **Doc cross-references updated** in `TMS_TRM_HEURISTIC_REFERENCE.md` (v2.0 → v2.1) and `internal/plans/CAPACITY_PROMISE_TRM_DESIGN.md`.

## Test plan

- [x] Import-site retargeting verified by grep — no `azirella_data_model.powell.tms.heuristic_library` references remain in any `.py` file.
- [x] `core-placement-auditor` already passed on the Core-side deletion.
- [x] Byte-for-byte parity between the moved files and the deleted Core copies (verified via `diff -q`).

## Cross-references

- Core PR #46 (merged): https://github.com/azirella-ltd/Autonomy-Core/pull/46
- Autonomy-Core MIGRATION_REGISTER §3.34 — full rationale + lesson framing.
- Autonomy-Core CONSUMER_ADOPTION_LOG — TMS adoption status (consumed in this same PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)