### PR TITLE
refactor(§3.35): TMS Powell taxonomy shims collapse to real implementations

### DIFF
--- a/backend/app/services/powell/tms_agent_capabilities.py
+++ b/backend/app/services/powell/tms_agent_capabilities.py
@@ -1,12 +1,365 @@
-"""Re-export shim — pure logic now in Core.
-
-TMS agent capability declarations live in
-`azirella_data_model.powell.tms.agent_capabilities`. Re-exported here
-to preserve the legacy import path
-`from app.services.powell.tms_agent_capabilities import ...`.
 """
-from azirella_data_model.powell.tms.agent_capabilities import *  # noqa: F401,F403
-from azirella_data_model.powell.tms.agent_capabilities import (  # noqa: F401
-    TMS_TRM_CAPABILITIES,
-    AgentCapabilities,
-)
+TMS Agent Capabilities — 12 TRM Declarations for Transportation
+
+Maps the 11 SC TRM slots to transportation equivalents, plus an additional
+TMS-native LaneVolumeForecast TRM (analogous to SCP's ForecastBaseline TRM
+but at lane × time-bucket grain rather than SKU × site).
+
+| #  | SC TRM               | TMS TRM               | Phase    | Level     |
+|----|----------------------|------------------------|----------|-----------|
+|  1 | ATPExecutor          | CapacityPromise        | SENSE    | execution |
+|  2 | InventoryBuffer      | CapacityBuffer         | ASSESS   | tactical  |
+|  3 | POCreation           | FreightProcurement     | ACQUIRE  | execution |
+|  4 | OrderTracking        | ShipmentTracking       | SENSE    | execution |
+|  5 | MOExecution          | LoadBuild              | BUILD    | execution |
+|  6 | TOExecution          | IntermodalTransfer     | BUILD    | execution |
+|  7 | QualityDisposition   | ExceptionManagement    | ASSESS   | execution |
+|  8 | MaintenanceScheduling| DockScheduling         | PROTECT  | execution |
+|  9 | Subcontracting       | BrokerRouting          | ACQUIRE  | execution |
+| 10 | ForecastAdjustment   | DemandSensing          | SENSE    | tactical  |
+| 11 | Rebalancing          | EquipmentReposition    | REFLECT  | tactical  |
+| 12 | (TMS-native)         | LaneVolumeForecast     | SENSE    | execution |
+
+LaneVolumeForecast is the lane-grain Execution-tier orchestrator that
+selects forecasting model (Holt-Winters / LightGBM / Croston / TSB /
+AutoETS) via Syntetos-Boylan classification and decides ACCEPT / MODIFY
+/ ESCALATE / DEFER on the proposed forecast. Provisioned only on shipper
+facilities; runtime gate restricts invocation to lanes with an external
+endpoint. Internal-transfer and inbound lane volume is inherited from
+the upstream supply / transfer plan, never forecast.
+
+Each declaration specifies:
+- Signal reads/emits (TMS hive signals)
+- Decision table (for AIIO tracking)
+- Site applicability (shipper, carrier, terminal, consignee)
+- Skill escalation capability
+
+Decision cycle phases (same 6 as SC):
+  SENSE → ASSESS → ACQUIRE → PROTECT → BUILD → REFLECT
+"""
+
+from typing import Dict
+from azirella_data_model.powell.agent_contract import AgentCapabilities
+
+from app.services.powell.tms_hive_signals import TMSHiveSignalType as S
+
+
+# ============================================================================
+# TMS-Specific Agent Capabilities
+# ============================================================================
+
+TMS_TRM_CAPABILITIES: Dict[str, AgentCapabilities] = {
+
+    # ── SENSE Phase ─────────────────────────────────────────────────────
+
+    "capacity_promise": AgentCapabilities(
+        trm_type="capacity_promise",
+        display_name="Capacity Promise Agent",
+        decision_phase="SENSE",
+        decision_level="execution",
+        reads_signals=frozenset({
+            S.VOLUME_SURGE,
+            S.CAPACITY_GAP,
+            S.TENDER_REJECTED,
+            S.RATE_SPIKE,
+        }),
+        emits_signals=frozenset({
+            S.CAPACITY_GAP,
+            S.CAPACITY_SURPLUS,
+        }),
+        decision_table="powell_capacity_promise_decisions",
+        site_types=frozenset({"shipper", "terminal", "cross_dock"}),
+        has_skill_escalation=True,
+        skill_name="capacity_promise",
+    ),
+
+    "shipment_tracking": AgentCapabilities(
+        trm_type="shipment_tracking",
+        display_name="Shipment Tracking Agent",
+        decision_phase="SENSE",
+        decision_level="execution",
+        reads_signals=frozenset({
+            S.SHIPMENT_DELAYED,
+            S.TRACKING_LOST,
+            S.ETA_UPDATED,
+            S.PORT_CONGESTION,
+            S.RAIL_DELAY,
+        }),
+        emits_signals=frozenset({
+            S.SHIPMENT_PICKED_UP,
+            S.SHIPMENT_IN_TRANSIT,
+            S.SHIPMENT_DELIVERED,
+            S.SHIPMENT_DELAYED,
+            S.ETA_UPDATED,
+            S.TRACKING_LOST,
+            S.EXCEPTION_DETECTED,
+        }),
+        decision_table="powell_shipment_tracking_decisions",
+        site_types=frozenset({"shipper", "terminal", "consignee", "cross_dock"}),
+        has_skill_escalation=True,
+        skill_name="shipment_tracking",
+    ),
+
+    "demand_sensing": AgentCapabilities(
+        trm_type="demand_sensing",
+        display_name="Demand Sensing Agent",
+        decision_phase="SENSE",
+        decision_level="tactical",
+        reads_signals=frozenset({
+            S.VOLUME_SURGE,
+            S.VOLUME_DROP,
+            S.SEASONAL_SHIFT,
+            S.EXCEPTION_DETECTED,
+        }),
+        emits_signals=frozenset({
+            S.VOLUME_SURGE,
+            S.VOLUME_DROP,
+            S.SEASONAL_SHIFT,
+            S.FORECAST_ADJUSTED,
+        }),
+        decision_table="powell_demand_sensing_decisions",
+        site_types=frozenset({"shipper", "terminal", "consignee"}),
+        has_skill_escalation=False,
+    ),
+
+    "lane_volume_forecast": AgentCapabilities(
+        trm_type="lane_volume_forecast",
+        display_name="Lane Volume Forecast Agent",
+        decision_phase="SENSE",
+        decision_level="execution",
+        reads_signals=frozenset({
+            S.VOLUME_SURGE,
+            S.VOLUME_DROP,
+            S.SEASONAL_SHIFT,
+        }),
+        emits_signals=frozenset({
+            S.FORECAST_ADJUSTED,
+        }),
+        decision_table="powell_lane_volume_forecast_decisions",
+        # Provisioned only on shipper facilities; runtime gate further
+        # restricts invocation to lanes with `has_external_endpoint=True`.
+        # Internal-transfer and inbound lanes inherit volume from upstream
+        # supply / transfer plan and do not invoke this TRM.
+        site_types=frozenset({"shipper"}),
+        has_skill_escalation=True,
+        skill_name="lane_volume_forecast",
+    ),
+
+    # ── ASSESS Phase ────────────────────────────────────────────────────
+
+    "capacity_buffer": AgentCapabilities(
+        trm_type="capacity_buffer",
+        display_name="Capacity Buffer Agent",
+        decision_phase="ASSESS",
+        decision_level="tactical",
+        reads_signals=frozenset({
+            S.VOLUME_SURGE,
+            S.VOLUME_DROP,
+            S.FORECAST_ADJUSTED,
+            S.CAPACITY_GAP,
+            S.TENDER_REJECTED,
+            S.CARRIER_SUSPENDED,
+        }),
+        emits_signals=frozenset({
+            S.CAPACITY_GAP,
+            S.CAPACITY_SURPLUS,
+        }),
+        decision_table="powell_capacity_buffer_decisions",
+        site_types=frozenset({"shipper", "terminal"}),
+        has_skill_escalation=True,
+        skill_name="capacity_buffer",
+    ),
+
+    "exception_management": AgentCapabilities(
+        trm_type="exception_management",
+        display_name="Exception Management Agent",
+        decision_phase="ASSESS",
+        decision_level="execution",
+        reads_signals=frozenset({
+            S.EXCEPTION_DETECTED,
+            S.SHIPMENT_DELAYED,
+            S.LATE_PICKUP,
+            S.LATE_DELIVERY,
+            S.TEMPERATURE_EXCURSION,
+            S.DAMAGE_REPORTED,
+            S.CUSTOMS_HOLD,
+        }),
+        emits_signals=frozenset({
+            S.EXCEPTION_ESCALATED,
+            S.EXCEPTION_RESOLVED,
+            S.TENDER_SENT,  # Re-tender on carrier failure
+        }),
+        decision_table="powell_exception_decisions",
+        site_types=frozenset({"shipper", "terminal", "consignee", "cross_dock"}),
+        has_skill_escalation=True,
+        skill_name="exception_management",
+    ),
+
+    # ── ACQUIRE Phase ───────────────────────────────────────────────────
+
+    "freight_procurement": AgentCapabilities(
+        trm_type="freight_procurement",
+        display_name="Freight Procurement Agent",
+        decision_phase="ACQUIRE",
+        decision_level="execution",
+        reads_signals=frozenset({
+            S.CAPACITY_GAP,
+            S.TENDER_REJECTED,
+            S.TENDER_EXPIRED,
+            S.RATE_SPIKE,
+            S.CONTRACT_EXPIRING,
+            S.FORECAST_ADJUSTED,
+        }),
+        emits_signals=frozenset({
+            S.TENDER_SENT,
+            S.TENDER_ACCEPTED,
+            S.TENDER_REJECTED,
+            S.RATE_SPIKE,
+        }),
+        decision_table="powell_freight_procurement_decisions",
+        site_types=frozenset({"shipper", "terminal"}),
+        has_skill_escalation=True,
+        skill_name="freight_procurement",
+    ),
+
+    "broker_routing": AgentCapabilities(
+        trm_type="broker_routing",
+        display_name="Broker Routing Agent",
+        decision_phase="ACQUIRE",
+        decision_level="execution",
+        reads_signals=frozenset({
+            S.TENDER_REJECTED,
+            S.TENDER_EXPIRED,
+            S.CAPACITY_GAP,
+            S.RATE_SPIKE,
+            S.CARRIER_SUSPENDED,
+        }),
+        emits_signals=frozenset({
+            S.TENDER_SENT,
+            S.TENDER_ACCEPTED,
+        }),
+        decision_table="powell_broker_routing_decisions",
+        site_types=frozenset({"shipper"}),
+        has_skill_escalation=True,
+        skill_name="broker_routing",
+    ),
+
+    # ── PROTECT Phase ───────────────────────────────────────────────────
+
+    "dock_scheduling": AgentCapabilities(
+        trm_type="dock_scheduling",
+        display_name="Dock Scheduling Agent",
+        decision_phase="PROTECT",
+        decision_level="execution",
+        reads_signals=frozenset({
+            S.DOCK_CONGESTION,
+            S.APPOINTMENT_CONFLICT,
+            S.DWELL_TIME_ALERT,
+            S.DETENTION_RISK,
+            S.SHIPMENT_DELAYED,
+            S.ETA_UPDATED,
+            S.APPOINTMENT_NO_SHOW,
+        }),
+        emits_signals=frozenset({
+            S.DOCK_CONGESTION,
+            S.APPOINTMENT_CONFLICT,
+            S.DETENTION_RISK,
+        }),
+        decision_table="powell_dock_scheduling_decisions",
+        site_types=frozenset({"shipper", "terminal", "consignee", "cross_dock"}),
+        has_skill_escalation=True,
+        skill_name="dock_scheduling",
+    ),
+
+    # ── BUILD Phase ─────────────────────────────────────────────────────
+
+    "load_build": AgentCapabilities(
+        trm_type="load_build",
+        display_name="Load Build Agent",
+        decision_phase="BUILD",
+        decision_level="execution",
+        reads_signals=frozenset({
+            S.TENDER_ACCEPTED,
+            S.CAPACITY_GAP,
+            S.DOCK_CONGESTION,
+            S.UNDERUTILIZED_LOAD,
+            S.FORECAST_ADJUSTED,
+        }),
+        emits_signals=frozenset({
+            S.LOAD_CONSOLIDATED,
+            S.LOAD_SPLIT,
+            S.LOAD_OPTIMIZED,
+            S.UNDERUTILIZED_LOAD,
+        }),
+        decision_table="powell_load_build_decisions",
+        site_types=frozenset({"shipper", "terminal", "cross_dock"}),
+        has_skill_escalation=True,
+        skill_name="load_build",
+    ),
+
+    "intermodal_transfer": AgentCapabilities(
+        trm_type="intermodal_transfer",
+        display_name="Intermodal Transfer Agent",
+        decision_phase="BUILD",
+        decision_level="execution",
+        reads_signals=frozenset({
+            S.MODE_SHIFT_OPPORTUNITY,
+            S.TRANSLOAD_NEEDED,
+            S.PORT_CONGESTION,
+            S.RAIL_DELAY,
+            S.RATE_SPIKE,
+            S.LANE_DISRUPTION,
+        }),
+        emits_signals=frozenset({
+            S.MODE_SHIFT_OPPORTUNITY,
+            S.TRANSLOAD_NEEDED,
+        }),
+        decision_table="powell_intermodal_transfer_decisions",
+        site_types=frozenset({"terminal", "cross_dock"}),
+        has_skill_escalation=True,
+        skill_name="intermodal_transfer",
+    ),
+
+    # ── REFLECT Phase ───────────────────────────────────────────────────
+
+    "equipment_reposition": AgentCapabilities(
+        trm_type="equipment_reposition",
+        display_name="Equipment Reposition Agent",
+        decision_phase="REFLECT",
+        decision_level="tactical",
+        reads_signals=frozenset({
+            S.EQUIPMENT_SHORTAGE,
+            S.EQUIPMENT_AVAILABLE,
+            S.REPOSITION_NEEDED,
+            S.CAPACITY_GAP,
+            S.NETWORK_CAPACITY_TIGHT,
+            S.LANE_DISRUPTION,
+        }),
+        emits_signals=frozenset({
+            S.REPOSITION_NEEDED,
+            S.EQUIPMENT_AVAILABLE,
+            S.EQUIPMENT_SHORTAGE,
+        }),
+        decision_table="powell_equipment_reposition_decisions",
+        site_types=frozenset({"shipper", "terminal", "cross_dock"}),
+        has_skill_escalation=True,
+        skill_name="equipment_reposition",
+    ),
+}
+
+
+# ── TMS TRM Names ──────────────────────────────────────────────────────
+
+ALL_TMS_TRM_NAMES = frozenset(TMS_TRM_CAPABILITIES.keys())
+
+# Phase → TRM ordering (decision cycle execution order).
+# lane_volume_forecast runs first within SENSE because demand_sensing and
+# capacity_buffer downstream both react to the published forecast.
+TMS_TRM_PHASE_MAP = {
+    "SENSE": ["lane_volume_forecast", "capacity_promise", "shipment_tracking", "demand_sensing"],
+    "ASSESS": ["capacity_buffer", "exception_management"],
+    "ACQUIRE": ["freight_procurement", "broker_routing"],
+    "PROTECT": ["dock_scheduling"],
+    "BUILD": ["load_build", "intermodal_transfer"],
+    "REFLECT": ["equipment_reposition"],
+}

--- a/backend/app/services/powell/tms_hive_signals.py
+++ b/backend/app/services/powell/tms_hive_signals.py
@@ -1,7 +1,174 @@
-"""Re-export shim — pure logic now in Core.
-
-TMS hive signal enum lives in
-`azirella_data_model.powell.tms.hive_signals`.
 """
-from azirella_data_model.powell.tms.hive_signals import *  # noqa: F401,F403
-from azirella_data_model.powell.tms.hive_signals import TMSHiveSignalType  # noqa: F401
+TMS Hive Signal Types — Stigmergic Coordination for Transportation TRMs
+
+Extends the base HiveSignalType enum with transportation-specific signals.
+These enable the 11 TMS TRM agents to communicate asynchronously:
+  - Capacity signals: capacity constraints, tender outcomes
+  - Shipment signals: tracking events, ETA changes, exceptions
+  - Network signals: lane congestion, carrier availability
+  - Dock signals: appointment conflicts, dwell time alerts
+
+Signal flow example (freight procurement cycle):
+1. DemandSensingTRM emits VOLUME_SURGE on lane →
+2. CapacityBufferTRM reads, emits CAPACITY_GAP →
+3. FreightProcurementTRM reads, emits TENDER_SENT →
+4. ShipmentTrackingTRM reads, monitors execution →
+5. ExceptionMgmtTRM reads exceptions, emits EXCEPTION_DETECTED →
+6. EquipmentRepositionTRM reads network state, emits REPOSITION_NEEDED
+"""
+
+from enum import Enum
+
+
+class TMSHiveSignalType(str, Enum):
+    """Transportation-specific hive signals.
+
+    Organized by agent function:
+      Scout: demand sensing, volume forecasting
+      Carrier: capacity, procurement, tender
+      Tracker: shipment visibility, ETA, exceptions
+      Dock: scheduling, dwell, appointment
+      Network: lane, equipment, intermodal
+    """
+
+    # ── Scout signals (demand / volume sensing) ─────────────────────────
+    VOLUME_SURGE = "volume_surge"              # Lane volume above forecast
+    VOLUME_DROP = "volume_drop"                # Lane volume below forecast
+    SEASONAL_SHIFT = "seasonal_shift"          # Seasonal pattern detected
+    FORECAST_ADJUSTED = "tms_forecast_adjusted"  # Volume forecast revised
+
+    # ── Carrier / Capacity signals ──────────────────────────────────────
+    CAPACITY_GAP = "capacity_gap"              # Committed < required loads
+    CAPACITY_SURPLUS = "capacity_surplus"       # Excess committed capacity
+    TENDER_SENT = "tender_sent"                # Freight tender dispatched
+    TENDER_ACCEPTED = "tender_accepted"        # Carrier accepted tender
+    TENDER_REJECTED = "tender_rejected"        # Carrier declined tender
+    TENDER_EXPIRED = "tender_expired"          # Tender timed out
+    CARRIER_SUSPENDED = "carrier_suspended"    # Carrier deactivated
+    RATE_SPIKE = "rate_spike"                  # Spot rate exceeds threshold
+    CONTRACT_EXPIRING = "contract_expiring"    # Carrier contract near expiry
+
+    # ── Shipment tracking signals ───────────────────────────────────────
+    SHIPMENT_PICKED_UP = "shipment_picked_up"
+    SHIPMENT_IN_TRANSIT = "shipment_in_transit"
+    SHIPMENT_DELIVERED = "shipment_delivered"
+    SHIPMENT_DELAYED = "shipment_delayed"      # ETA slipped
+    ETA_UPDATED = "eta_updated"                # New ETA from conformal/p44
+    TRACKING_LOST = "tracking_lost"            # No updates for N hours
+
+    # ── Exception signals ───────────────────────────────────────────────
+    EXCEPTION_DETECTED = "exception_detected"  # Any shipment exception
+    EXCEPTION_ESCALATED = "exception_escalated"  # Severity upgraded
+    EXCEPTION_RESOLVED = "exception_resolved"
+    LATE_PICKUP = "late_pickup"
+    LATE_DELIVERY = "late_delivery"
+    TEMPERATURE_EXCURSION = "temperature_excursion"
+    DAMAGE_REPORTED = "damage_reported"
+    CUSTOMS_HOLD = "tms_customs_hold"
+
+    # ── Dock / Appointment signals ──────────────────────────────────────
+    DOCK_CONGESTION = "dock_congestion"        # Facility approaching capacity
+    APPOINTMENT_CONFLICT = "appointment_conflict"
+    DWELL_TIME_ALERT = "dwell_time_alert"      # Excessive wait at facility
+    DETENTION_RISK = "detention_risk"           # Approaching detention threshold
+    APPOINTMENT_NO_SHOW = "appointment_no_show"
+
+    # ── Load building signals ───────────────────────────────────────────
+    LOAD_CONSOLIDATED = "load_consolidated"    # Shipments merged into load
+    LOAD_SPLIT = "load_split"                  # Load broken apart
+    LOAD_OPTIMIZED = "load_optimized"          # Load plan improved
+    UNDERUTILIZED_LOAD = "underutilized_load"  # Load below weight/volume threshold
+
+    # ── Equipment / Reposition signals ──────────────────────────────────
+    REPOSITION_NEEDED = "reposition_needed"    # Empty equipment at wrong site
+    EQUIPMENT_SHORTAGE = "equipment_shortage"   # No available equipment at facility
+    EQUIPMENT_AVAILABLE = "equipment_available" # Equipment freed up
+
+    # ── Intermodal / Transfer signals ───────────────────────────────────
+    MODE_SHIFT_OPPORTUNITY = "mode_shift_opportunity"  # Cheaper mode available
+    TRANSLOAD_NEEDED = "transload_needed"      # Cross-dock or mode change needed
+    PORT_CONGESTION = "tms_port_congestion"    # Port delays affecting ocean legs
+    RAIL_DELAY = "rail_delay"                  # Rail segment delayed
+
+    # ── Network-level (from tGNN) ───────────────────────────────────────
+    NETWORK_CAPACITY_TIGHT = "network_capacity_tight"
+    NETWORK_CAPACITY_LOOSE = "network_capacity_loose"
+    LANE_DISRUPTION = "lane_disruption"        # Lane unavailable (weather, road closure)
+    CARRIER_NETWORK_SHIFT = "carrier_network_shift"  # Carrier coverage changed
+
+
+# ── Convenience sets for agent-based filtering ──────────────────────────
+
+SCOUT_SIGNALS = frozenset({
+    TMSHiveSignalType.VOLUME_SURGE,
+    TMSHiveSignalType.VOLUME_DROP,
+    TMSHiveSignalType.SEASONAL_SHIFT,
+    TMSHiveSignalType.FORECAST_ADJUSTED,
+})
+
+CARRIER_SIGNALS = frozenset({
+    TMSHiveSignalType.CAPACITY_GAP,
+    TMSHiveSignalType.CAPACITY_SURPLUS,
+    TMSHiveSignalType.TENDER_SENT,
+    TMSHiveSignalType.TENDER_ACCEPTED,
+    TMSHiveSignalType.TENDER_REJECTED,
+    TMSHiveSignalType.TENDER_EXPIRED,
+    TMSHiveSignalType.CARRIER_SUSPENDED,
+    TMSHiveSignalType.RATE_SPIKE,
+    TMSHiveSignalType.CONTRACT_EXPIRING,
+})
+
+TRACKING_SIGNALS = frozenset({
+    TMSHiveSignalType.SHIPMENT_PICKED_UP,
+    TMSHiveSignalType.SHIPMENT_IN_TRANSIT,
+    TMSHiveSignalType.SHIPMENT_DELIVERED,
+    TMSHiveSignalType.SHIPMENT_DELAYED,
+    TMSHiveSignalType.ETA_UPDATED,
+    TMSHiveSignalType.TRACKING_LOST,
+})
+
+EXCEPTION_SIGNALS = frozenset({
+    TMSHiveSignalType.EXCEPTION_DETECTED,
+    TMSHiveSignalType.EXCEPTION_ESCALATED,
+    TMSHiveSignalType.EXCEPTION_RESOLVED,
+    TMSHiveSignalType.LATE_PICKUP,
+    TMSHiveSignalType.LATE_DELIVERY,
+    TMSHiveSignalType.TEMPERATURE_EXCURSION,
+    TMSHiveSignalType.DAMAGE_REPORTED,
+    TMSHiveSignalType.CUSTOMS_HOLD,
+})
+
+DOCK_SIGNALS = frozenset({
+    TMSHiveSignalType.DOCK_CONGESTION,
+    TMSHiveSignalType.APPOINTMENT_CONFLICT,
+    TMSHiveSignalType.DWELL_TIME_ALERT,
+    TMSHiveSignalType.DETENTION_RISK,
+    TMSHiveSignalType.APPOINTMENT_NO_SHOW,
+})
+
+LOAD_SIGNALS = frozenset({
+    TMSHiveSignalType.LOAD_CONSOLIDATED,
+    TMSHiveSignalType.LOAD_SPLIT,
+    TMSHiveSignalType.LOAD_OPTIMIZED,
+    TMSHiveSignalType.UNDERUTILIZED_LOAD,
+})
+
+EQUIPMENT_SIGNALS = frozenset({
+    TMSHiveSignalType.REPOSITION_NEEDED,
+    TMSHiveSignalType.EQUIPMENT_SHORTAGE,
+    TMSHiveSignalType.EQUIPMENT_AVAILABLE,
+})
+
+INTERMODAL_SIGNALS = frozenset({
+    TMSHiveSignalType.MODE_SHIFT_OPPORTUNITY,
+    TMSHiveSignalType.TRANSLOAD_NEEDED,
+    TMSHiveSignalType.PORT_CONGESTION,
+    TMSHiveSignalType.RAIL_DELAY,
+})
+
+NETWORK_SIGNALS = frozenset({
+    TMSHiveSignalType.NETWORK_CAPACITY_TIGHT,
+    TMSHiveSignalType.NETWORK_CAPACITY_LOOSE,
+    TMSHiveSignalType.LANE_DISRUPTION,
+    TMSHiveSignalType.CARRIER_NETWORK_SHIFT,
+})

--- a/backend/app/services/powell/tms_site_capabilities.py
+++ b/backend/app/services/powell/tms_site_capabilities.py
@@ -1,9 +1,127 @@
-"""Re-export shim — pure logic now in Core.
-
-Facility-type → active-TRM mapping lives in
-`azirella_data_model.powell.tms.site_capabilities`.
 """
-from azirella_data_model.powell.tms.site_capabilities import *  # noqa: F401,F403
-from azirella_data_model.powell.tms.site_capabilities import (  # noqa: F401
-    get_active_tms_trms,
-)
+TMS Site Capabilities — Which TRMs Are Active at Each Facility Type
+
+In TMS context, facilities (Sites) have different physical capabilities:
+- Shipper/Origin: loads freight, needs capacity, tenders loads
+- Terminal/Cross-Dock: transfers, consolidates, stages
+- Consignee/Destination: receives freight, appointment scheduling
+- Carrier Yard: equipment staging, repositioning
+
+Each facility type activates a subset of the 11 TMS TRMs based on
+what decisions are physically meaningful at that site.
+"""
+
+from typing import FrozenSet, Optional
+
+from app.services.powell.tms_agent_capabilities import ALL_TMS_TRM_NAMES
+
+
+# ── Facility Type → Active TRMs ────────────────────────────────────────
+
+_FACILITY_TRM_MAP = {
+    # Shipper/Origin: all outbound decisions, including lane-volume
+    # forecasting for customer-facing lanes (gated further at runtime
+    # by lane.has_external_endpoint).
+    "shipper": frozenset({
+        "lane_volume_forecast", # Forecast customer-facing lane volume (Execution orchestrator)
+        "capacity_promise",     # Promise capacity to orders
+        "shipment_tracking",    # Track outbound shipments
+        "demand_sensing",       # Adjust forecasts for signals / bias
+        "capacity_buffer",      # Buffer capacity above forecast
+        "exception_management", # Handle outbound exceptions
+        "freight_procurement",  # Tender loads to carriers
+        "broker_routing",       # Fallback to brokers
+        "dock_scheduling",      # Manage loading dock
+        "load_build",           # Consolidate shipments into loads
+        "equipment_reposition", # Manage trailer pool
+    }),  # 11 of 12 (no intermodal_transfer — that's terminal)
+
+    # Terminal / Cross-Dock: intermediate handling
+    "terminal": frozenset({
+        "capacity_promise",     # Capacity through terminal
+        "shipment_tracking",    # Track in-terminal shipments
+        "demand_sensing",       # Forecast terminal throughput
+        "capacity_buffer",      # Terminal capacity buffers
+        "exception_management", # Handle transload exceptions
+        "freight_procurement",  # Outbound leg procurement
+        "dock_scheduling",      # Dock door scheduling
+        "load_build",           # Consolidation / deconsolidation
+        "intermodal_transfer",  # Mode changes (truck→rail, etc.)
+        "equipment_reposition", # Equipment management
+    }),  # 10 of 11 (no broker_routing — shipper decides)
+
+    # Cross-Dock: similar to terminal
+    "cross_dock": frozenset({
+        "capacity_promise",
+        "shipment_tracking",
+        "exception_management",
+        "dock_scheduling",
+        "load_build",
+        "intermodal_transfer",
+        "equipment_reposition",
+    }),  # 7 — lean cross-dock operations
+
+    # Consignee / Destination: inbound receiving
+    "consignee": frozenset({
+        "shipment_tracking",    # Track inbound shipments
+        "demand_sensing",       # Forecast inbound volume
+        "exception_management", # Handle delivery exceptions
+        "dock_scheduling",      # Manage receiving dock
+    }),  # 4 — receiving operations only
+
+    # Carrier Yard: equipment management
+    "carrier_yard": frozenset({
+        "equipment_reposition", # Main function: manage fleet
+        "shipment_tracking",    # Track assets in yard
+    }),  # 2 — equipment-focused
+
+    # Port / Rail Terminal: intermodal handling
+    "port": frozenset({
+        "shipment_tracking",
+        "exception_management",
+        "intermodal_transfer",
+        "dock_scheduling",
+        "equipment_reposition",
+    }),  # 5 — intermodal focus
+}
+
+
+def get_active_tms_trms(
+    facility_type: str,
+    override_trms: Optional[FrozenSet[str]] = None,
+) -> FrozenSet[str]:
+    """
+    Return the set of active TRM names for a given facility type.
+
+    Args:
+        facility_type: One of shipper, terminal, cross_dock, consignee,
+                       carrier_yard, port
+        override_trms: If provided, intersect with facility capabilities
+                       (for per-site governance restrictions)
+
+    Returns:
+        Frozen set of TRM names that should be active
+    """
+    base = _FACILITY_TRM_MAP.get(facility_type.lower(), frozenset())
+
+    if not base:
+        # Unknown facility type: return all TRMs (backward compat)
+        base = ALL_TMS_TRM_NAMES
+
+    if override_trms is not None:
+        return base & override_trms & ALL_TMS_TRM_NAMES
+
+    return base
+
+
+def get_all_facility_types() -> list:
+    """Return all known facility types."""
+    return list(_FACILITY_TRM_MAP.keys())
+
+
+def get_trm_facility_coverage(trm_name: str) -> FrozenSet[str]:
+    """Return which facility types a given TRM is active at."""
+    return frozenset(
+        ftype for ftype, trms in _FACILITY_TRM_MAP.items()
+        if trm_name in trms
+    )

--- a/backend/app/services/provisioning_service.py
+++ b/backend/app/services/provisioning_service.py
@@ -1567,7 +1567,7 @@ class ProvisioningService:
         import time
         from pathlib import Path
         from app.db.session import sync_session_factory
-        from azirella_data_model.powell.tms.site_capabilities import get_active_tms_trms
+        from app.services.powell.tms_site_capabilities import get_active_tms_trms
         from app.services.checkpoint_storage_service import checkpoint_dir
 
         def _master_type_to_facility_type(site) -> str:

--- a/docs/TMS_MIGRATION_1_13_PUNCH_LIST.md
+++ b/docs/TMS_MIGRATION_1_13_PUNCH_LIST.md
@@ -159,5 +159,5 @@ Total: ~7-8 days of focused work, probably spread across 2-3 weeks given the nee
 ## Non-goals for item 1.13
 
 - **Do NOT** rewrite `powell/__init__.py` or other broadly-imported Powell framework files to add fresh TMS functionality. Item 1.13 is pure extraction/rescope. New TMS substrate lands in other register items.
-- **Do NOT** touch `services/powell/hive_signals.py` / `site_capabilities.py` / `agent_capabilities.py` / `agent_contract.py` — these ARE canonical TMS-facing infra (see `azirella_data_model.powell.tms.*`).
+- **Do NOT** touch `services/powell/tms_hive_signals.py` / `tms_site_capabilities.py` / `tms_agent_capabilities.py` — these are now canonical TMS-facing infra (real implementations live here as of 2026-05-02 per Core §3.35; the `AgentCapabilities` dataclass shape lives in Core at `azirella_data_model.powell.agent_contract`).
 - **Do NOT** delete the canonical 11 TMS TRMs' services, endpoints, or training data.

--- a/docs/internal/plans/CAPACITY_PROMISE_TRM_DESIGN.md
+++ b/docs/internal/plans/CAPACITY_PROMISE_TRM_DESIGN.md
@@ -21,7 +21,7 @@ bounds, not a carrier selection.
 - `app.services.powell.tms_heuristic_library.dispatch._compute_capacity_promise` —
   the deterministic teacher (composite score with 5 weighted factors; priority
   overrides; 0.6 / 0.35 thresholds for ACCEPT / DEFER / REJECT).
-- `azirella_data_model.powell.tms.agent_capabilities["capacity_promise"]` —
+- `app.services.powell.tms_agent_capabilities["capacity_promise"]` —
   declares `decision_table="powell_capacity_promise_decisions"` (not yet created
   in any DB schema).
 


### PR DESCRIPTION
## Summary

Mirror PR for [Autonomy-Core #47](https://github.com/azirella-ltd/Autonomy-Core/pull/47) (merged). The thin re-export shims at `app.services.powell.tms_{agent_capabilities,hive_signals,site_capabilities}` are now the real implementations. Same pattern as TMS PR #8 (the §3.34 mirror).

- `tms_agent_capabilities.py` (364 lines) — real impl; imports `AgentCapabilities` from new Core path `azirella_data_model.powell.agent_contract`.
- `tms_hive_signals.py` (174 lines) — real impl.
- `tms_site_capabilities.py` (127 lines) — real impl; imports `ALL_TMS_TRM_NAMES` from sibling local module.
- `provisioning_service.py:1570` — only Core-namespaced caller retargeted from `azirella_data_model.powell.tms.site_capabilities` to `app.services.powell.tms_site_capabilities`.
- Doc cross-references updated in `TMS_MIGRATION_1_13_PUNCH_LIST.md` and `internal/plans/CAPACITY_PROMISE_TRM_DESIGN.md`.

## Test plan

- [x] `core-placement-auditor` PROCEED on Core-side staged diff.
- [x] Files byte-identical to the deleted Core copies, with import-line edits only.
- [x] No `azirella_data_model.powell.tms` references remain anywhere in the TMS repo (verified via grep).

## Cross-references

- Core PR #47 (merged): https://github.com/azirella-ltd/Autonomy-Core/pull/47
- Sibling: TMS PR #8 (§3.34, merged) — heuristic-library half of the same revert.
- Autonomy-Core MIGRATION_REGISTER §3.35 — full rationale.
- Autonomy-Core CONSUMER_ADOPTION_LOG — TMS adoption status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)