### PR TITLE
fix(§3.37): TacticalForecastService writes LaneVolumePlan (was ShippingForecast)

### DIFF
--- a/backend/app/services/powell/tactical_forecast_service.py
+++ b/backend/app/services/powell/tactical_forecast_service.py
@@ -4,7 +4,7 @@ The L3 Tactical Demand Potential service per ``docs/TMS_DECISION_HIERARCHY.md``
 §4.1. Phase 1 ships **heuristic-only aggregation** — the service consumes
 ``LaneVolumeForecastTRM`` outputs from L1 (per-lane forecasts with
 mode/equipment segmentation per §3.36) and writes them to the canonical
-``shipping_forecast`` table.
+``lane_volume_plan`` table.
 
 Phase 2 (deferred to a separate register entry) will add the LightGBM +
 Trigg tracking quality model that §4.1 also specifies. Phase 1 is enough to
@@ -13,7 +13,7 @@ through the canonical plan-of-record.
 
 Plane-module placement: this is TMS-plane decision policy (the *service*
 that decides how / when / what to forecast). The substrate it writes to
-(``ShippingForecast`` ORM in Core) is canonical state that any plane can
+(``LaneVolumePlan`` ORM in Core) is canonical state that any plane can
 read.
 
 Service shape:
@@ -35,7 +35,7 @@ from sqlalchemy.orm import Session
 
 from azirella_data_model.transport_plan import (
     DEFAULT_PLAN_VERSION,
-    ShippingForecast,
+    LaneVolumePlan,
 )
 
 from app.services.powell.tms_heuristic_library import (
@@ -48,7 +48,7 @@ from app.services.powell.tms_heuristic_library import (
 _NO_SEG_MODE = "ALL"
 """Mode value used when the L1 segmentation helper returns
 ``"no_segmentation"`` (history unavailable). The aggregate forecast still
-lands in ``shipping_forecast`` so consumers see *something*; the
+lands in ``lane_volume_plan`` so consumers see *something*; the
 ``segmentation_method`` column records the unhappy-path provenance."""
 
 
@@ -70,7 +70,7 @@ class PublishResult:
     """``{lane_id: count}``."""
     skipped_deferred: int
     """L1 returned DEFER (insufficient history); no row written."""
-    rows: List[ShippingForecast]
+    rows: List[LaneVolumePlan]
     """The actual ORM rows persisted (caller may want to inspect)."""
 
 
@@ -95,13 +95,13 @@ class TacticalForecastService:
         plan_version: str = DEFAULT_PLAN_VERSION,
     ) -> PublishResult:
         """Compute L1 forecasts per input, write per-mode + per-equipment
-        rows to ``shipping_forecast``.
+        rows to ``lane_volume_plan``.
 
         Returns a :class:`PublishResult` with rows-written + skipped count
         + the actual ORM rows. Caller is responsible for ``commit()``;
         the service ``add()``s and ``flush()``es but does not commit.
         """
-        rows: List[ShippingForecast] = []
+        rows: List[LaneVolumePlan] = []
         per_lane: dict = {}
         skipped_deferred = 0
 
@@ -154,8 +154,8 @@ class TacticalForecastService:
         decision_params: dict,
         produced_by: str,
         plan_version: str,
-    ) -> List[ShippingForecast]:
-        """Build ShippingForecast ORM rows for a single lane.
+    ) -> List[LaneVolumePlan]:
+        """Build LaneVolumePlan ORM rows for a single lane.
 
         Three cases driven by ``segmentation_method``:
 
@@ -183,7 +183,7 @@ class TacticalForecastService:
             plan_version=plan_version,
         )
 
-        rows: List[ShippingForecast] = []
+        rows: List[LaneVolumePlan] = []
 
         if method == "no_segmentation":
             rows.append(self._row_for_share(
@@ -290,8 +290,8 @@ class TacticalForecastService:
         weight_kg_p50: Optional[float],
         volume_m3_p50: Optional[float],
         **common: object,
-    ) -> ShippingForecast:
-        return ShippingForecast(
+    ) -> LaneVolumePlan:
+        return LaneVolumePlan(
             mode=mode,
             equipment_type=equipment_type,
             forecast_loads_p10=round(float(base_p10) * share, 4),

--- a/backend/tests/powell/test_tactical_forecast_service.py
+++ b/backend/tests/powell/test_tactical_forecast_service.py
@@ -2,7 +2,7 @@
 
 Pure-orchestration service that consumes L1 ``LaneVolumeForecastTRM``
 outputs (with §3.36 mode + equipment segmentation) and writes
-``ShippingForecast`` rows. Tests verify the fan-out math:
+``LaneVolumePlan`` rows. Tests verify the fan-out math:
 
 - 1 lane × ewma_share_history with N modes + M equipment-within-FTL →
   N + M rows (mode-level + equipment-level coexist per §3.37 schema).
@@ -25,7 +25,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from azirella_data_model.base import Base
 from azirella_data_model.transport_plan import (
     DEFAULT_PLAN_VERSION,
-    ShippingForecast,
+    LaneVolumePlan,
 )
 
 from app.services.powell.tactical_forecast_service import (
@@ -43,13 +43,13 @@ from app.services.powell.tms_heuristic_library import LaneVolumeForecastState
 
 @pytest.fixture
 def db() -> Session:
-    """In-memory SQLite session — ShippingForecast plus FK-target stubs.
+    """In-memory SQLite session — LaneVolumePlan plus FK-target stubs.
 
     Avoids the TMS conftest's full DB setup. Stubs the FK targets
     (``supply_chain_configs``, ``scenarios``) the same way Core's conftest
     stubs ``users`` / ``tenants``: minimal columns just sufficient for FK
     resolution, mapped against ``Base.metadata`` so ``create_all`` builds
-    them alongside ``shipping_forecast``.
+    them alongside ``lane_volume_plan``.
     """
     from sqlalchemy import Column, Integer
     from azirella_data_model.base import Base
@@ -75,7 +75,7 @@ def db() -> Session:
         Base.metadata.tables["supply_chain_configs"],
         Base.metadata.tables["scenarios"],
         Base.metadata.tables["transportation_lane"],
-        ShippingForecast.__table__,
+        LaneVolumePlan.__table__,
     ]
     Base.metadata.create_all(bind=engine, tables=tables)
     Sess = sessionmaker(bind=engine)
@@ -127,7 +127,7 @@ def test_no_segmentation_writes_one_mode_all_row(db) -> None:
         inputs=[_input(lane_id=1)],  # no mode_history → no_segmentation
     )
     assert result.rows_written == 1
-    row = db.query(ShippingForecast).one()
+    row = db.query(LaneVolumePlan).one()
     assert row.mode == _NO_SEG_MODE
     assert row.equipment_type is None
     assert row.segmentation_method == "no_segmentation"
@@ -148,7 +148,7 @@ def test_single_mode_passthrough_writes_one_row_at_dominant_mode(db) -> None:
         inputs=[_input(lane_id=1, mode_history={"FTL": 0.97, "LTL": 0.03})],
     )
     assert result.rows_written == 1
-    row = db.query(ShippingForecast).one()
+    row = db.query(LaneVolumePlan).one()
     assert row.mode == "FTL"
     assert row.equipment_type is None
     assert row.segmentation_method == "single_mode_passthrough"
@@ -172,7 +172,7 @@ def test_ewma_writes_per_mode_rows(db) -> None:
     )
     # 2 mode-level rows; no equipment_history → 0 equipment rows
     assert result.rows_written == 2
-    rows = db.query(ShippingForecast).order_by(ShippingForecast.mode).all()
+    rows = db.query(LaneVolumePlan).order_by(LaneVolumePlan.mode).all()
     by_mode = {r.mode: r for r in rows}
     assert set(by_mode.keys()) == {"FTL", "LTL"}
     # FTL row: 100 × 0.7 = 70
@@ -197,15 +197,15 @@ def test_ewma_writes_per_equipment_rows_within_ftl(db) -> None:
     assert result.rows_written == 4
 
     # Mode-level rows have equipment_type IS NULL
-    mode_rows = db.query(ShippingForecast).filter(
-        ShippingForecast.equipment_type.is_(None),
+    mode_rows = db.query(LaneVolumePlan).filter(
+        LaneVolumePlan.equipment_type.is_(None),
     ).all()
     assert len(mode_rows) == 2
     assert {r.mode for r in mode_rows} == {"FTL", "LTL"}
 
     # Equipment-level rows have mode='FTL' AND equipment_type IS NOT NULL
-    equip_rows = db.query(ShippingForecast).filter(
-        ShippingForecast.equipment_type.isnot(None),
+    equip_rows = db.query(LaneVolumePlan).filter(
+        LaneVolumePlan.equipment_type.isnot(None),
     ).all()
     assert len(equip_rows) == 2
     assert {r.equipment_type for r in equip_rows} == {"DRY_VAN", "REEFER"}
@@ -236,7 +236,7 @@ def test_equipment_rows_skipped_when_ltl_only(db) -> None:
     )
     # single_mode_passthrough on LTL → 1 row only
     assert result.rows_written == 1
-    rows = db.query(ShippingForecast).all()
+    rows = db.query(LaneVolumePlan).all()
     assert rows[0].mode == "LTL"
     assert rows[0].equipment_type is None
 
@@ -255,7 +255,7 @@ def test_defer_skips_persistence(db) -> None:
     )
     assert result.rows_written == 0
     assert result.skipped_deferred == 1
-    assert db.query(ShippingForecast).count() == 0
+    assert db.query(LaneVolumePlan).count() == 0
 
 
 def test_escalate_still_persists(db) -> None:
@@ -270,7 +270,7 @@ def test_escalate_still_persists(db) -> None:
         )],
     )
     assert result.rows_written == 1
-    row = db.query(ShippingForecast).one()
+    row = db.query(LaneVolumePlan).one()
     assert row.mode == "FTL"
 
 
@@ -306,7 +306,7 @@ def test_default_plan_version_used(db) -> None:
         tenant_id=1, config_id=1,
         inputs=[_input(lane_id=1, mode_history={"FTL": 1.0})],
     )
-    row = db.query(ShippingForecast).one()
+    row = db.query(LaneVolumePlan).one()
     assert row.plan_version == DEFAULT_PLAN_VERSION
     assert row.plan_version == "unconstrained_reference"
 
@@ -317,7 +317,7 @@ def test_produced_by_default(db) -> None:
         tenant_id=1, config_id=1,
         inputs=[_input(lane_id=1, mode_history={"FTL": 1.0})],
     )
-    row = db.query(ShippingForecast).one()
+    row = db.query(LaneVolumePlan).one()
     assert row.produced_by == "TacticalForecastService"
 
 
@@ -328,7 +328,7 @@ def test_produced_by_override(db) -> None:
         inputs=[_input(lane_id=1, mode_history={"FTL": 1.0})],
         produced_by="custom_l3_runner",
     )
-    row = db.query(ShippingForecast).one()
+    row = db.query(LaneVolumePlan).one()
     assert row.produced_by == "custom_l3_runner"
 
 
@@ -340,7 +340,7 @@ def test_segmentation_method_recorded_for_audit(db) -> None:
         tenant_id=1, config_id=1,
         inputs=[_input(lane_id=1, mode_history={"FTL": 0.70, "LTL": 0.30})],
     )
-    rows = db.query(ShippingForecast).all()
+    rows = db.query(LaneVolumePlan).all()
     assert len(rows) == 2
     for r in rows:
         assert r.segmentation_method == "ewma_share_history"
@@ -352,7 +352,7 @@ def test_forecast_method_and_demand_class_persisted(db) -> None:
         tenant_id=1, config_id=1,
         inputs=[_input(lane_id=1, mode_history={"FTL": 1.0})],
     )
-    row = db.query(ShippingForecast).one()
+    row = db.query(LaneVolumePlan).one()
     # SMOOTH class with covariates absent → HoltWinters
     assert row.forecast_method == "HoltWinters"
     assert row.syntetos_boylan_class == "SMOOTH"
@@ -375,8 +375,8 @@ def test_weight_and_cube_split_by_share(db) -> None:
             mean_volume_m3_per_load=70.0,
         )],
     )
-    rows = db.query(ShippingForecast).filter(
-        ShippingForecast.equipment_type.is_(None),
+    rows = db.query(LaneVolumePlan).filter(
+        LaneVolumePlan.equipment_type.is_(None),
     ).all()
     by_mode = {r.mode: r for r in rows}
     # FTL gets 70% of total weight (18000 × 100 = 1.8M × 0.7 = 1.26M)
@@ -391,6 +391,6 @@ def test_weight_and_cube_null_when_no_signal(db) -> None:
         inputs=[_input(lane_id=1, mode_history={"FTL": 1.0})],
         # no mean_weight_kg_per_load / mean_volume_m3_per_load
     )
-    row = db.query(ShippingForecast).one()
+    row = db.query(LaneVolumePlan).one()
     assert row.forecast_weight_kg_p50 is None
     assert row.forecast_volume_m3_p50 is None


### PR DESCRIPTION
## Summary

Mirror PR for [Autonomy-Core #50](https://github.com/azirella-ltd/Autonomy-Core/pull/50) (merged). The Core ORM was renamed from `ShippingForecast` → `LaneVolumePlan` to avoid collision with the pre-existing TMS-side `ShippingForecast` at `app/models/tms_planning.py`.

## What changed

- `app/services/powell/tactical_forecast_service.py` — imports, type annotations, docstrings updated.
- `tests/powell/test_tactical_forecast_service.py` — same.

The TMS-side legacy `ShippingForecast` is untouched. Distinct logical entity (live-forecast snapshots vs L3 plan-of-record); both can coexist now that the table names differ.

## Test plan

- [x] End-to-end smoke test verified: `LaneVolumePlan` ORM imports cleanly; L1 → L3 fan-out math still produces 4 rows for the canonical test (FTL p50 = 70.0, equipment p50s sum back).
- [x] No remaining `ShippingForecast` / `shipping_forecast` references in `tactical_forecast_service.py` or its test (TMS-side legacy `app/models/tms_planning.py::ShippingForecast` is intentionally untouched).

## Cross-references

- Core PR (merged): https://github.com/azirella-ltd/Autonomy-Core/pull/50
- Autonomy-Core MIGRATION_REGISTER §3.37 Erratum — full lesson recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)