### PR TITLE
feat(§3.38 Phase 2A): MovementPlannerService cheapest-carrier selection

### DIFF
--- a/backend/app/services/powell/movement_planner_service.py
+++ b/backend/app/services/powell/movement_planner_service.py
@@ -1,39 +1,56 @@
-"""MovementPlannerService — §3.38 Phase 1 (heuristic).
+"""MovementPlannerService — §3.38 Phase 2A (carrier assignment via rate-card).
 
 The L3 Unconstrained Movement Plan service per
-``docs/TMS_DECISION_HIERARCHY.md`` §4.2. Phase 1 ships **heuristic-only
-fan-out**: read `LaneVolumePlan` rows (the §3.37 L3 Demand Potential
-output), and produce `TransportationPlan` + `TransportationPlanItem`
-rows with `plan_version='unconstrained_reference'` — one item per
-forecast load, dispatch dates distributed across the period.
+``docs/TMS_DECISION_HIERARCHY.md`` §4.2. Phase 2A adds **carrier
+assignment + cost estimation** on top of Phase 1's load fan-out:
 
-Phase 1 deliberately produces a "skeleton" plan:
+1. Read `LaneVolumePlan` rows (the §3.37 L3 Demand Potential output).
+2. Fan out one `TransportationPlanItem` per load, distributed across
+   the period (Phase 1 behaviour, unchanged).
+3. **NEW (Phase 2A)**: for each item, query Core's `RateCard` substrate
+   joined with `Contract` + `Carrier`, find candidate rate cards
+   matching the item's lane + equipment + active effective window,
+   compute estimated cost per candidate using the rate's basis +
+   distance, and pick the **cheapest** one. Set `carrier_id`,
+   `rate_id`, `estimated_cost`, `estimated_cost_per_mile`, and
+   `distance_miles` on the item.
+4. Falls back to NULL if no rate card matches (graceful degradation
+   for tenants without seeded rate-cards).
 
-- Carrier assignment is `NULL`. The GraphSAGE Movement Planner that
-  §4.2 specifies (transport-graph node features = lanes + hubs; edge
-  features = mode alternatives + rate-card + transit time) is Phase 2.
-  Phase 1's job is the data flow: read forecasts, write plan items,
-  prove the L3-tier plumbing.
-- No rate-card lookup. Cost / distance fields default to `NULL`.
-- No multi-stop optimisation. Each forecast load becomes one direct
-  origin-to-destination plan item.
-- No mode optimisation. Each `LaneVolumePlan` row's mode is preserved
-  on its plan items (no re-routing FTL → LTL even if cheaper).
+Phase 2A scope explicitly excludes:
 
-Phase 2 will replace the heuristic with the GraphSAGE planner that:
-- Optimises mode + carrier per (lane, period) given rate-card + transit
-- Re-distributes loads across the week per service-level deadlines
-- Considers multi-stop consolidations
-- Outputs cost / distance / utilisation estimates
+- **GraphSAGE network optimisation** for mode-substitution / multi-
+  stop consolidation. Phase 2A keeps the L1 forecast row's mode on
+  its plan items unchanged. Mode optimisation is Phase 3.
+- **Full lane-filter geographic resolution**. Phase 2A handles two
+  shapes: catch-all `lane_filter={}` and explicit `{"lane_id": <id>}`.
+  Geographic shapes (`origin_geo_id`, `origin_state`, `origin_zip3`,
+  etc.) are Phase 2B — they require deeper integration with Core's
+  geography hierarchy.
+- **Fuel surcharge / accessorials**. Phase 2A computes only the
+  linehaul rate × basis. Full ChargeCalculator integration with fuel
+  + accessorials is Phase 2B.
+- **Min/max charge clamps not actively used**. Phase 2A computes
+  the raw rate-basis amount; clamping happens at settlement time
+  (§3.29 Phase 3B `ChargeCalculator`).
 
-Plane-module placement: this is TMS-plane decision policy. The substrate
-it reads (`LaneVolumePlan`) and writes (`TransportationPlan` +
-`TransportationPlanItem`) is canonical state.
+Distance lookup (Phase 2A): queries TMS-side `LaneProfile.distance_miles`.
+If LaneProfile has no row for the lane, falls back to a tenant-config
+default (5 0 miles placeholder); Phase 2B will add haversine fallback
+from origin/destination site lat/lng.
 
-Schema location footnote: `TransportationPlan` + `TransportationPlanItem`
-currently live in TMS at ``app/models/tms_planning.py``. CLAUDE.md says
-`plan_*` tables belong in Core; moving them is tracked as deferred
-debt in §3.38 register entry's "What is NOT in this entry" section.
+The `optimization_method` field signals Phase 2A vs Phase 1:
+- ``HEURISTIC_PHASE_1`` — fan-out only, no carrier (deprecated; only
+  used when ``carrier_assignment_enabled=False`` for testing)
+- ``HEURISTIC_PHASE_2A`` — fan-out + cheapest-carrier from rate-card
+- ``GRAPHSAGE_UNCONSTRAINED`` — Phase 3 (deferred)
+
+Plane-module placement: this is TMS-plane decision policy (the *service*
+that decides how to plan + assign carriers). The substrate it reads
+(`LaneVolumePlan`, `RateCard`, `Contract`, `Carrier`) and writes
+(`TransportationPlan` + `TransportationPlanItem`) is canonical state.
+`LaneProfile` is TMS-internal (TMS-specific lane attributes like
+`distance_miles`).
 """
 from __future__ import annotations
 
@@ -47,9 +64,6 @@ from sqlalchemy.orm import Session
 from azirella_data_model.transport_plan import (
     DEFAULT_PLAN_VERSION,
     LaneVolumePlan,
-)
-
-from azirella_data_model.transport_plan import (
     PlanItemStatus,
     PlanStatus,
     TransportationPlan,
@@ -59,6 +73,12 @@ from azirella_data_model.transport_plan import (
 
 _PLAN_NAME_PATTERN = "L3 Unconstrained Movement Plan {period_start:%Y-%m-%d}"
 _GENERATED_BY = "MovementPlannerService"
+
+# Phase 2A default placeholders. Replace with real values once
+# LaneProfile.distance_miles + tenant-config wiring lands in §3.38 Phase 2B.
+_DEFAULT_DISTANCE_MILES_FALLBACK = 500.0
+"""Used when LaneProfile.distance_miles is unset for a lane. Phase 2B will
+add haversine fallback from origin/destination site coordinates."""
 
 
 def _is_leaf_row(row: LaneVolumePlan, all_rows: Sequence[LaneVolumePlan]) -> bool:
@@ -83,6 +103,33 @@ def _is_leaf_row(row: LaneVolumePlan, all_rows: Sequence[LaneVolumePlan]) -> boo
 
 
 @dataclass(frozen=True)
+class RateAssignment:
+    """The cheapest matching rate-card + carrier for an item.
+
+    All fields are ``None`` when no rate card matches the item's
+    (lane, mode, equipment, period) — callers should treat that as
+    "leave Phase 1's NULL fields in place."
+    """
+
+    carrier_id: Optional[int] = None
+    rate_id: Optional[int] = None
+    rate_basis: Optional[str] = None
+    """``FLAT`` / ``PER_MILE`` / ``PER_PALLET`` / ``PER_HUNDREDWEIGHT`` /
+    ``PER_HOUR``. Used by ``_compute_item_cost`` to scale the rate."""
+
+    base_rate: Optional[float] = None
+    """The rate-card's base_rate (in carrier's currency)."""
+
+    distance_miles: Optional[float] = None
+    """Lane distance used to compute the cost. Recorded so consumers
+    can audit the cost derivation."""
+
+
+_NULL_ASSIGNMENT = RateAssignment()
+"""Sentinel for "no carrier matched". Phase 1 fallback uses this."""
+
+
+@dataclass(frozen=True)
 class PlanResult:
     """Per-call summary."""
 
@@ -99,9 +146,24 @@ class PlanResult:
     """LaneVolumePlan rows with `forecast_loads_p50 < 0.5` (round → 0)
     skipped — no plan item to create."""
 
+    items_with_carrier: int = 0
+    """Phase 2A: items that got a carrier_id assigned via rate-card
+    lookup. Phase 1 (carrier_assignment_enabled=False): always 0."""
+
+    items_without_carrier: int = 0
+    """Phase 2A: items where no rate card matched and ``carrier_id``
+    stayed ``None``. Phase 1: equals ``items_written``."""
+
 
 class MovementPlannerService:
-    """L3 Unconstrained Movement Plan service — Phase 1 heuristic."""
+    """L3 Unconstrained Movement Plan service — Phase 2A heuristic.
+
+    Phase 2A adds carrier assignment + cost estimation via rate-card
+    lookup on top of Phase 1's load fan-out. Set
+    ``carrier_assignment_enabled=False`` on ``plan_movement()`` to keep
+    Phase 1's NULL-carrier behaviour (used for tests that don't seed
+    rate cards).
+    """
 
     def __init__(self, db: Session) -> None:
         self.db = db
@@ -120,14 +182,19 @@ class MovementPlannerService:
         scenario_id: Optional[int] = None,
         forecast_plan_version: str = DEFAULT_PLAN_VERSION,
         cascade_run_id: Optional[str] = None,
+        carrier_assignment_enabled: bool = True,
     ) -> PlanResult:
         """Read LaneVolumePlan rows for the given (tenant, config,
         period_start) and produce a TransportationPlan with items.
 
-        Phase 1 heuristic: one plan item per round(forecast_loads_p50)
-        load, pickup dates distributed evenly across the period. Carrier,
-        cost, distance fields are NULL — Phase 2 fills these via
-        GraphSAGE + rate-card lookup.
+        Phase 2A behaviour (default ``carrier_assignment_enabled=True``):
+        one plan item per round(forecast_loads_p50) load, pickup dates
+        distributed evenly across the period, **plus** carrier + cost +
+        distance assigned per item via cheapest-rate-card lookup.
+
+        Phase 1 fallback (``carrier_assignment_enabled=False``): keeps
+        Phase 1's NULL-carrier behaviour for tests / tenants without
+        seeded rate cards.
 
         Returns a :class:`PlanResult` with the plan id + item counts.
         Caller is responsible for `commit()`.
@@ -155,17 +222,25 @@ class MovementPlannerService:
             plan_start_date=period_start,
             plan_end_date=period_start + timedelta(days=period_days - 1),
             planning_horizon_days=period_days,
-            optimization_method="HEURISTIC_PHASE_1",
+            optimization_method=(
+                "HEURISTIC_PHASE_2A"
+                if carrier_assignment_enabled
+                else "HEURISTIC_PHASE_1"
+            ),
             generated_by="AGENT",
             cascade_run_id=cascade_run_id,
         )
         self.db.add(plan)
         self.db.flush()  # populate plan.id
 
-        # 3. Fan out leaf rows into plan items.
+        # 3. Fan out leaf rows into plan items + (Phase 2A) assign carriers.
         items_per_lane: dict = {}
         items_written = 0
         skipped_zero_loads = 0
+        items_with_carrier = 0
+        items_without_carrier = 0
+        total_estimated_cost = 0.0
+        total_distance = 0.0
 
         for row in forecast_rows:
             if not _is_leaf_row(row, forecast_rows):
@@ -177,6 +252,24 @@ class MovementPlannerService:
                 continue
 
             origin_id, destination_id = self._lane_endpoints(row.lane_id)
+
+            # Phase 2A: resolve carrier + rate + distance once per
+            # (lane, mode, equipment) — these are constant across the
+            # n_items per row, so do the lookup once and reuse.
+            distance_miles = self._lane_distance_miles(row.lane_id) if carrier_assignment_enabled else None
+            assignment = (
+                self._select_carrier_and_rate(
+                    tenant_id=tenant_id,
+                    period_start=period_start,
+                    mode=row.mode,
+                    equipment_type=row.equipment_type,
+                    lane_id=row.lane_id,
+                    distance_miles=distance_miles,
+                )
+                if carrier_assignment_enabled
+                else _NULL_ASSIGNMENT
+            )
+
             for i in range(n_items):
                 pickup_dt = self._distribute_pickup(
                     period_start=period_start,
@@ -184,10 +277,26 @@ class MovementPlannerService:
                     item_index=i,
                     total_items=n_items,
                 )
-                # Phase 1 default delivery: pickup + 1 day (placeholder).
-                # Phase 2 reads transit-time distribution from lane
-                # metadata.
                 delivery_dt = pickup_dt + timedelta(days=1)
+
+                # Per-item cost (some bases scale per-load, e.g., FLAT,
+                # and need re-application; PER_MILE is constant across
+                # items on the same lane).
+                per_item_weight = self._derive_weight(row, n_items)
+                per_item_volume = self._derive_volume(row, n_items)
+                per_item_cost = (
+                    self._compute_item_cost(
+                        assignment=assignment,
+                        weight=per_item_weight,
+                    )
+                    if carrier_assignment_enabled and assignment.rate_id is not None
+                    else None
+                )
+                cost_per_mile = (
+                    round(per_item_cost / distance_miles, 4)
+                    if per_item_cost is not None and distance_miles
+                    else None
+                )
 
                 item = TransportationPlanItem(
                     plan_id=plan.id,
@@ -197,25 +306,54 @@ class MovementPlannerService:
                     lane_id=row.lane_id,
                     mode=row.mode,
                     equipment_type=row.equipment_type,
-                    carrier_id=None,
-                    rate_id=None,
+                    carrier_id=assignment.carrier_id,
+                    rate_id=assignment.rate_id,
                     status=PlanItemStatus.PLANNED,
                     planned_pickup_date=pickup_dt,
                     planned_delivery_date=delivery_dt,
                     shipment_count=1,
-                    total_weight=self._derive_weight(row, n_items),
-                    total_volume=self._derive_volume(row, n_items),
-                    estimated_cost=None,
-                    distance_miles=None,
+                    total_weight=per_item_weight,
+                    total_volume=per_item_volume,
+                    estimated_cost=per_item_cost,
+                    estimated_cost_per_mile=cost_per_mile,
+                    distance_miles=distance_miles if carrier_assignment_enabled else None,
                     is_multi_stop=False,
                 )
                 self.db.add(item)
                 items_written += 1
                 items_per_lane[row.lane_id] = items_per_lane.get(row.lane_id, 0) + 1
+                if assignment.carrier_id is not None:
+                    items_with_carrier += 1
+                else:
+                    items_without_carrier += 1
+                if per_item_cost is not None:
+                    total_estimated_cost += per_item_cost
+                if distance_miles:
+                    total_distance += distance_miles
 
         # 4. Update plan-header summary metrics.
         plan.total_planned_loads = items_written
         plan.total_planned_shipments = items_written
+        if total_estimated_cost > 0:
+            plan.total_estimated_cost = round(total_estimated_cost, 2)
+        if total_distance > 0:
+            plan.total_estimated_miles = round(total_distance, 2)
+            if total_estimated_cost > 0:
+                plan.avg_cost_per_mile = round(
+                    total_estimated_cost / total_distance, 4,
+                )
+        if items_with_carrier > 0:
+            # Distinct carrier count for the plan summary
+            assigned_carriers = (
+                self.db.query(TransportationPlanItem.carrier_id)
+                .filter(
+                    TransportationPlanItem.plan_id == plan.id,
+                    TransportationPlanItem.carrier_id.isnot(None),
+                )
+                .distinct()
+                .count()
+            )
+            plan.carrier_count = assigned_carriers
 
         if items_written:
             self.db.flush()
@@ -225,6 +363,8 @@ class MovementPlannerService:
             items_written=items_written,
             items_per_lane=items_per_lane,
             skipped_zero_loads=skipped_zero_loads,
+            items_with_carrier=items_with_carrier,
+            items_without_carrier=items_without_carrier,
         )
 
     # ------------------------------------------------------------------
@@ -282,8 +422,227 @@ class MovementPlannerService:
             return None
         return round(float(row.forecast_volume_m3_p50) / n_items, 2)
 
+    # ------------------------------------------------------------------
+    # Phase 2A — rate-card resolver + lane distance + cost compute
+    # ------------------------------------------------------------------
+
+    def _select_carrier_and_rate(
+        self,
+        *,
+        tenant_id: int,
+        period_start: date,
+        mode: str,
+        equipment_type: Optional[str],
+        lane_id: int,
+        distance_miles: Optional[float],
+    ) -> RateAssignment:
+        """Pick the cheapest matching rate card for the (lane, equipment,
+        period) combo and return its carrier + rate id.
+
+        Phase 2A matching rules:
+
+        - ``RateCard.tenant_id == tenant_id``
+        - ``RateCard.effective_from <= period_start`` AND
+          (``effective_to IS NULL`` OR ``effective_to >= period_start``)
+        - ``RateCard.equipment_type IS NULL`` (any equipment)
+          OR ``RateCard.equipment_type == equipment_type``
+        - ``RateCard.lane_filter`` matches via :meth:`_lane_filter_matches`
+          (Phase 2A: catch-all `{}` or explicit `{"lane_id": <id>}`).
+
+        Cost ranking uses :meth:`_estimate_card_cost` with a unit weight
+        (1 lb / 1 pallet placeholder) so PER_PALLET / PER_HUNDREDWEIGHT
+        cards rank consistently against PER_MILE / FLAT cards even when
+        per-item weight isn't known yet.
+
+        Returns a :class:`RateAssignment` with NULL fields when no
+        candidate exists. Caller treats that as "leave Phase 1 NULL
+        fields in place."
+        """
+        try:
+            from azirella_data_model.settlement.entities import (
+                Contract,
+                RateCard,
+            )
+        except ImportError:
+            # Settlement substrate unavailable in this deployment;
+            # graceful no-op.
+            return _NULL_ASSIGNMENT
+
+        period_dt = datetime.combine(period_start, datetime.min.time())
+        candidates = (
+            self.db.query(RateCard)
+            .filter(
+                RateCard.tenant_id == tenant_id,
+                RateCard.effective_from <= period_dt,
+            )
+            .all()
+        )
+
+        # Filter: effective window (NULL effective_to = open-ended)
+        candidates = [
+            rc for rc in candidates
+            if rc.effective_to is None or rc.effective_to >= period_dt
+        ]
+        # Filter: equipment match
+        candidates = [
+            rc for rc in candidates
+            if rc.equipment_type is None or rc.equipment_type == equipment_type
+        ]
+        # Filter: lane filter
+        candidates = [
+            rc for rc in candidates
+            if self._lane_filter_matches(rc.lane_filter or {}, lane_id)
+        ]
+
+        if not candidates:
+            return _NULL_ASSIGNMENT
+
+        # Rank by estimated cost; pick cheapest.
+        scored = []
+        for rc in candidates:
+            cost = self._estimate_card_cost(
+                rate_basis=rc.rate_basis,
+                base_rate=float(rc.base_rate),
+                distance_miles=distance_miles,
+            )
+            if cost is None:
+                continue
+            scored.append((cost, rc))
+        if not scored:
+            return _NULL_ASSIGNMENT
+
+        scored.sort(key=lambda pair: pair[0])
+        _, best = scored[0]
+
+        # Resolve the carrier through the contract.
+        contract = (
+            self.db.query(Contract)
+            .filter(Contract.id == best.contract_id)
+            .first()
+        )
+        carrier_id = contract.carrier_id if contract else None
+
+        return RateAssignment(
+            carrier_id=carrier_id,
+            rate_id=best.id,
+            rate_basis=best.rate_basis,
+            base_rate=float(best.base_rate),
+            distance_miles=distance_miles,
+        )
+
+    @staticmethod
+    def _lane_filter_matches(lane_filter: dict, lane_id: int) -> bool:
+        """Phase 2A simple lane-filter matcher.
+
+        Returns True for catch-all empty filter or explicit lane_id
+        match. Phase 2B adds geographic shapes (origin_geo_id,
+        origin_state, origin_zip3, etc.) which require Core's geography
+        hierarchy — out of Phase 2A scope.
+        """
+        if not lane_filter:
+            return True  # catch-all
+        if lane_filter.get("lane_id") == lane_id:
+            return True
+        return False
+
+    @staticmethod
+    def _estimate_card_cost(
+        *,
+        rate_basis: str,
+        base_rate: float,
+        distance_miles: Optional[float],
+    ) -> Optional[float]:
+        """Compute a per-load cost estimate for ranking rate cards.
+
+        Phase 2A handles the 4 rate bases that don't require live
+        accessorial / fuel data:
+
+        - ``FLAT``: ``base_rate``
+        - ``PER_MILE``: ``base_rate × distance_miles`` (or None when
+          distance unknown)
+        - ``PER_HUNDREDWEIGHT``: ``base_rate × 100`` (per-1000lb
+          placeholder; real per-item weight applied in
+          ``_compute_item_cost``)
+        - ``PER_PALLET``: ``base_rate`` per pallet (1-pallet placeholder
+          for ranking; real count applied in ``_compute_item_cost``)
+        - ``PER_HOUR``: ``base_rate × 8`` (8-hour day placeholder)
+
+        Returns None if the basis can't be ranked (e.g., PER_MILE with
+        no distance). The caller filters those out.
+        """
+        if rate_basis == "FLAT":
+            return base_rate
+        if rate_basis == "PER_MILE":
+            if not distance_miles:
+                return None
+            return base_rate * distance_miles
+        if rate_basis == "PER_HUNDREDWEIGHT":
+            # Rank assuming a 1000-lb load (placeholder). Real cost
+            # uses per-item weight in _compute_item_cost.
+            return base_rate * 10.0
+        if rate_basis == "PER_PALLET":
+            # Rank assuming a 1-pallet load (placeholder).
+            return base_rate
+        if rate_basis == "PER_HOUR":
+            # Rank assuming an 8-hour load (placeholder).
+            return base_rate * 8.0
+        return None
+
+    @staticmethod
+    def _compute_item_cost(
+        *,
+        assignment: RateAssignment,
+        weight: Optional[float],
+    ) -> Optional[float]:
+        """Apply the assigned rate basis to per-item parameters.
+
+        Differs from :meth:`_estimate_card_cost` in that the per-item
+        cost uses the actual weight / count where known.
+        """
+        if assignment.rate_basis is None or assignment.base_rate is None:
+            return None
+        rb = assignment.rate_basis
+        rate = assignment.base_rate
+        if rb == "FLAT":
+            return round(rate, 2)
+        if rb == "PER_MILE":
+            if not assignment.distance_miles:
+                return None
+            return round(rate * assignment.distance_miles, 2)
+        if rb == "PER_HUNDREDWEIGHT":
+            if not weight:
+                return round(rate * 10.0, 2)  # 1000-lb placeholder
+            # weight assumed in lbs (TransportationPlanItem.total_weight)
+            return round(rate * (weight / 100.0), 2)
+        if rb == "PER_PALLET":
+            return round(rate, 2)  # 1-pallet placeholder
+        if rb == "PER_HOUR":
+            return round(rate * 8.0, 2)  # 8-hour placeholder
+        return None
+
+    def _lane_distance_miles(self, lane_id: int) -> Optional[float]:
+        """Look up `LaneProfile.distance_miles` for the lane.
+
+        Returns the configured value when present; otherwise the
+        Phase 2A fallback (``_DEFAULT_DISTANCE_MILES_FALLBACK``).
+        """
+        try:
+            from app.models.transportation_config import LaneProfile
+        except ImportError:
+            return _DEFAULT_DISTANCE_MILES_FALLBACK
+
+        profile = (
+            self.db.query(LaneProfile)
+            .filter(LaneProfile.lane_id == lane_id)
+            .first()
+        )
+        if profile is None or profile.distance_miles is None:
+            return _DEFAULT_DISTANCE_MILES_FALLBACK
+        return float(profile.distance_miles)
+
 
 __all__ = [
     "MovementPlannerService",
     "PlanResult",
+    "RateAssignment",
 ]

--- a/backend/tests/powell/test_l3_planning_services.py
+++ b/backend/tests/powell/test_l3_planning_services.py
@@ -176,7 +176,9 @@ def test_movement_plan_creates_header_and_items(db) -> None:
     plan = db.query(TransportationPlan).one()
     assert plan.plan_version == "unconstrained_reference"
     assert plan.status == PlanStatus.DRAFT
-    assert plan.optimization_method == "HEURISTIC_PHASE_1"
+    # §3.38 Phase 2A is now default; Phase 1 (no rate cards seeded) → graceful
+    # NULL carrier fallback, but optimization_method reflects the Phase 2A path.
+    assert plan.optimization_method == "HEURISTIC_PHASE_2A"
     assert plan.generated_by == "AGENT"
     assert plan.total_planned_loads == 5
 
@@ -186,7 +188,8 @@ def test_movement_plan_creates_header_and_items(db) -> None:
     assert all(item.mode == "LTL" for item in items)
     assert all(item.equipment_type is None for item in items)
     assert all(item.status == PlanItemStatus.PLANNED for item in items)
-    assert all(item.carrier_id is None for item in items)  # Phase 2 fills this
+    # No rate cards seeded → carrier_id stays None (graceful Phase 2A fallback)
+    assert all(item.carrier_id is None for item in items)
 
 
 def test_movement_plan_fans_out_per_load(db) -> None:
@@ -464,3 +467,341 @@ def test_full_l3_pipeline_end_to_end(db) -> None:
     # 5. Verify total item count = 11 per plan = 22 total
     total_items = db.query(TransportationPlanItem).count()
     assert total_items == 22
+
+
+# ===========================================================================
+# §3.38 Phase 2A — Carrier assignment via rate-card lookup
+# ===========================================================================
+
+
+def _seed_carrier_and_rate_cards(db: Session) -> None:
+    """Seed minimal Carrier + Contract + RateCard data for Phase 2A tests.
+
+    Two rate cards on the same lane (DRY_VAN, PER_MILE @ $2.50 and $3.00).
+    Phase 2A should pick the cheaper one ($2.50).
+    """
+    from datetime import datetime
+    from azirella_data_model.settlement.entities import Carrier, Contract, RateCard
+
+    db.add(Carrier(
+        id=1, tenant_id=1, scac="ABCD", display_name="Acme",
+        carrier_type="TRUCKLOAD",
+    ))
+    db.add(Carrier(
+        id=2, tenant_id=1, scac="WXYZ", display_name="Beta",
+        carrier_type="TRUCKLOAD",
+    ))
+    db.flush()
+    db.add(Contract(
+        id=1, tenant_id=1, carrier_id=1, contract_number="C-001",
+        contract_type="PRIMARY",
+        effective_from=datetime(2026, 1, 1), currency="USD",
+    ))
+    db.add(Contract(
+        id=2, tenant_id=1, carrier_id=2, contract_number="C-002",
+        contract_type="BACKUP",
+        effective_from=datetime(2026, 1, 1), currency="USD",
+    ))
+    db.flush()
+    # Cheapest: $2.50/mile from carrier 1
+    db.add(RateCard(
+        id=1, tenant_id=1, contract_id=1, lane_filter={},
+        equipment_type="DRY_VAN", rate_basis="PER_MILE", base_rate=2.50,
+        effective_from=datetime(2026, 1, 1),
+    ))
+    # More expensive: $3.00/mile from carrier 2
+    db.add(RateCard(
+        id=2, tenant_id=1, contract_id=2, lane_filter={},
+        equipment_type="DRY_VAN", rate_basis="PER_MILE", base_rate=3.00,
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.flush()
+
+
+def _seed_lane_profile(db: Session, lane_id: int = 10, distance: float = 750.0) -> None:
+    """Seed a TMS-side LaneProfile with a known distance."""
+    from app.models.transportation_config import LaneProfile
+
+    db.add(LaneProfile(
+        lane_id=lane_id, config_id=1,
+        distance_miles=distance, primary_mode="FTL",
+    ))
+    db.flush()
+
+
+def test_phase_2a_assigns_cheapest_carrier(db) -> None:
+    """Phase 2A picks the cheapest matching rate card (carrier 1, $2.50/mi)
+    over the more expensive option ($3.00/mi)."""
+    _seed_carrier_and_rate_cards(db)
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=5)
+
+    svc = MovementPlannerService(db)
+    result = svc.plan_movement(tenant_id=1, config_id=1, period_start=date(2026, 5, 4))
+
+    assert result.items_written == 5
+    assert result.items_with_carrier == 5
+    assert result.items_without_carrier == 0
+
+    plan = db.query(TransportationPlan).one()
+    assert plan.optimization_method == "HEURISTIC_PHASE_2A"
+    assert plan.total_estimated_cost == 9375.0  # 5 items × 2.50 × 750
+    assert plan.total_estimated_miles == 3750.0  # 5 items × 750
+    assert plan.avg_cost_per_mile == 2.5
+    assert plan.carrier_count == 1  # All items assigned to carrier 1
+
+    items = db.query(TransportationPlanItem).all()
+    assert all(item.carrier_id == 1 for item in items)
+    assert all(item.rate_id == 1 for item in items)  # Cheaper rate
+    assert all(item.estimated_cost == 1875.0 for item in items)
+    assert all(item.distance_miles == 750.0 for item in items)
+    assert all(item.estimated_cost_per_mile == 2.5 for item in items)
+
+
+def test_phase_2a_graceful_null_when_no_rate_card_matches(db) -> None:
+    """No matching rate card (e.g., no REEFER rate cards) → carrier_id
+    and cost stay NULL. Plan still produced with HEURISTIC_PHASE_2A."""
+    _seed_carrier_and_rate_cards(db)  # Only DRY_VAN rate cards
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="REEFER", forecast_loads_p50=3)
+
+    svc = MovementPlannerService(db)
+    result = svc.plan_movement(tenant_id=1, config_id=1, period_start=date(2026, 5, 4))
+
+    assert result.items_written == 3
+    assert result.items_with_carrier == 0
+    assert result.items_without_carrier == 3
+
+    plan = db.query(TransportationPlan).one()
+    assert plan.optimization_method == "HEURISTIC_PHASE_2A"
+    items = db.query(TransportationPlanItem).all()
+    assert all(item.carrier_id is None for item in items)
+    assert all(item.estimated_cost is None for item in items)
+
+
+def test_phase_2a_explicit_phase_1_fallback(db) -> None:
+    """Caller can opt out of Phase 2A — sets optimization_method back to
+    HEURISTIC_PHASE_1 even when rate cards exist."""
+    _seed_carrier_and_rate_cards(db)
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=2)
+
+    svc = MovementPlannerService(db)
+    result = svc.plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        carrier_assignment_enabled=False,
+    )
+
+    plan = db.query(TransportationPlan).one()
+    assert plan.optimization_method == "HEURISTIC_PHASE_1"
+    items = db.query(TransportationPlanItem).all()
+    assert all(item.carrier_id is None for item in items)
+    assert all(item.estimated_cost is None for item in items)
+    assert all(item.distance_miles is None for item in items)
+
+
+def test_phase_2a_filters_by_equipment_type(db) -> None:
+    """Rate card with equipment_type=NULL ('any equipment') is also a
+    match. equipment_type='REEFER' rate card NOT matched by DRY_VAN item."""
+    from datetime import datetime
+    from azirella_data_model.settlement.entities import Carrier, Contract, RateCard
+
+    db.add(Carrier(
+        id=1, tenant_id=1, scac="ABCD", display_name="Acme",
+        carrier_type="TRUCKLOAD",
+    ))
+    db.flush()
+    db.add(Contract(
+        id=1, tenant_id=1, carrier_id=1, contract_number="C-001",
+        contract_type="PRIMARY",
+        effective_from=datetime(2026, 1, 1), currency="USD",
+    ))
+    db.flush()
+    # REEFER-only rate card — should NOT match a DRY_VAN item
+    db.add(RateCard(
+        id=10, tenant_id=1, contract_id=1, lane_filter={},
+        equipment_type="REEFER", rate_basis="PER_MILE", base_rate=2.00,
+        effective_from=datetime(2026, 1, 1),
+    ))
+    # Equipment-agnostic rate card — should match DRY_VAN item
+    db.add(RateCard(
+        id=11, tenant_id=1, contract_id=1, lane_filter={},
+        equipment_type=None, rate_basis="PER_MILE", base_rate=3.00,
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.flush()
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=2)
+
+    svc = MovementPlannerService(db)
+    svc.plan_movement(tenant_id=1, config_id=1, period_start=date(2026, 5, 4))
+
+    items = db.query(TransportationPlanItem).all()
+    # Should pick rate card 11 (equipment-agnostic at $3); rate card 10 (REEFER)
+    # rejected even though it's cheaper.
+    assert all(item.rate_id == 11 for item in items)
+    assert all(item.estimated_cost == 2250.0 for item in items)  # 3.00 × 750
+
+
+def test_phase_2a_filters_by_effective_window(db) -> None:
+    """Rate card outside the effective window (expired or not-yet-active)
+    is not matched."""
+    from datetime import datetime
+    from azirella_data_model.settlement.entities import Carrier, Contract, RateCard
+
+    db.add(Carrier(
+        id=1, tenant_id=1, scac="ABCD", display_name="Acme",
+        carrier_type="TRUCKLOAD",
+    ))
+    db.flush()
+    db.add(Contract(
+        id=1, tenant_id=1, carrier_id=1, contract_number="C-001",
+        contract_type="PRIMARY",
+        effective_from=datetime(2025, 1, 1), currency="USD",
+    ))
+    db.flush()
+    # Expired rate card (effective_to before period_start)
+    db.add(RateCard(
+        id=20, tenant_id=1, contract_id=1, lane_filter={},
+        equipment_type="DRY_VAN", rate_basis="PER_MILE", base_rate=1.00,
+        effective_from=datetime(2025, 1, 1),
+        effective_to=datetime(2025, 12, 31),  # expired before May 2026
+    ))
+    # Active rate card
+    db.add(RateCard(
+        id=21, tenant_id=1, contract_id=1, lane_filter={},
+        equipment_type="DRY_VAN", rate_basis="PER_MILE", base_rate=2.50,
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.flush()
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=2)
+
+    svc = MovementPlannerService(db)
+    svc.plan_movement(tenant_id=1, config_id=1, period_start=date(2026, 5, 4))
+
+    items = db.query(TransportationPlanItem).all()
+    # Should pick rate card 21 (active); not 20 (expired) even though cheaper
+    assert all(item.rate_id == 21 for item in items)
+    assert all(item.estimated_cost == 1875.0 for item in items)
+
+
+def test_phase_2a_filters_by_lane_id(db) -> None:
+    """Rate card with explicit lane_id filter only matches that lane."""
+    from datetime import datetime
+    from azirella_data_model.settlement.entities import Carrier, Contract, RateCard
+
+    db.add(Carrier(
+        id=1, tenant_id=1, scac="ABCD", display_name="Acme",
+        carrier_type="TRUCKLOAD",
+    ))
+    db.flush()
+    db.add(Contract(
+        id=1, tenant_id=1, carrier_id=1, contract_number="C-001",
+        contract_type="PRIMARY",
+        effective_from=datetime(2026, 1, 1), currency="USD",
+    ))
+    db.flush()
+    # Cheap rate scoped to lane 99 ONLY (item is on lane 10 — should not match)
+    db.add(RateCard(
+        id=30, tenant_id=1, contract_id=1, lane_filter={"lane_id": 99},
+        equipment_type="DRY_VAN", rate_basis="PER_MILE", base_rate=1.00,
+        effective_from=datetime(2026, 1, 1),
+    ))
+    # Catch-all (matches lane 10)
+    db.add(RateCard(
+        id=31, tenant_id=1, contract_id=1, lane_filter={},
+        equipment_type="DRY_VAN", rate_basis="PER_MILE", base_rate=2.50,
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.flush()
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=2)
+
+    svc = MovementPlannerService(db)
+    svc.plan_movement(tenant_id=1, config_id=1, period_start=date(2026, 5, 4))
+
+    items = db.query(TransportationPlanItem).all()
+    # Should pick rate card 31 (catch-all); not 30 (lane 99 mismatch)
+    assert all(item.rate_id == 31 for item in items)
+
+
+def test_phase_2a_lane_distance_fallback_when_lane_profile_missing(db) -> None:
+    """When LaneProfile has no row for the lane, distance falls back to
+    the Phase 2A default (500 miles)."""
+    _seed_carrier_and_rate_cards(db)
+    # NO _seed_lane_profile call — distance falls back
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=2)
+
+    svc = MovementPlannerService(db)
+    svc.plan_movement(tenant_id=1, config_id=1, period_start=date(2026, 5, 4))
+
+    items = db.query(TransportationPlanItem).all()
+    assert all(item.distance_miles == 500.0 for item in items)
+    # Cost: 500 mi × $2.50/mi = $1250
+    assert all(item.estimated_cost == 1250.0 for item in items)
+
+
+def test_phase_2a_supports_flat_rate_basis(db) -> None:
+    """FLAT rate-basis: cost = base_rate (independent of distance)."""
+    from datetime import datetime
+    from azirella_data_model.settlement.entities import Carrier, Contract, RateCard
+
+    db.add(Carrier(
+        id=1, tenant_id=1, scac="ABCD", display_name="Acme",
+        carrier_type="TRUCKLOAD",
+    ))
+    db.flush()
+    db.add(Contract(
+        id=1, tenant_id=1, carrier_id=1, contract_number="C-001",
+        contract_type="PRIMARY",
+        effective_from=datetime(2026, 1, 1), currency="USD",
+    ))
+    db.flush()
+    db.add(RateCard(
+        id=40, tenant_id=1, contract_id=1, lane_filter={},
+        equipment_type="DRY_VAN", rate_basis="FLAT", base_rate=1500.00,
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.flush()
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=2)
+
+    svc = MovementPlannerService(db)
+    svc.plan_movement(tenant_id=1, config_id=1, period_start=date(2026, 5, 4))
+
+    items = db.query(TransportationPlanItem).all()
+    assert all(item.estimated_cost == 1500.0 for item in items)
+
+
+def test_phase_2a_picks_distinct_carriers_when_lanes_differ(db) -> None:
+    """Phase 2A reports `carrier_count` correctly when items span
+    multiple carriers."""
+    from datetime import datetime
+    from azirella_data_model.settlement.entities import Carrier, Contract, RateCard
+
+    db.add(Carrier(id=1, tenant_id=1, scac="C1", display_name="C1", carrier_type="TRUCKLOAD"))
+    db.add(Carrier(id=2, tenant_id=1, scac="C2", display_name="C2", carrier_type="TRUCKLOAD"))
+    db.flush()
+    db.add(Contract(id=1, tenant_id=1, carrier_id=1, contract_number="C-001",
+        contract_type="PRIMARY", effective_from=datetime(2026, 1, 1), currency="USD"))
+    db.add(Contract(id=2, tenant_id=1, carrier_id=2, contract_number="C-002",
+        contract_type="PRIMARY", effective_from=datetime(2026, 1, 1), currency="USD"))
+    db.flush()
+    # Carrier 1 cheap on lane 10; Carrier 2 cheap on lane 20
+    db.add(RateCard(id=1, tenant_id=1, contract_id=1, lane_filter={"lane_id": 10},
+        equipment_type="DRY_VAN", rate_basis="PER_MILE", base_rate=2.00,
+        effective_from=datetime(2026, 1, 1)))
+    db.add(RateCard(id=2, tenant_id=1, contract_id=2, lane_filter={"lane_id": 20},
+        equipment_type="DRY_VAN", rate_basis="PER_MILE", base_rate=2.00,
+        effective_from=datetime(2026, 1, 1)))
+    db.flush()
+    _seed_lane_profile(db, lane_id=10, distance=500)
+    _seed_lane_profile(db, lane_id=20, distance=500)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=2)
+    _seed_lane_volume_plan(db, lane_id=20, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=3)
+
+    svc = MovementPlannerService(db)
+    result = svc.plan_movement(tenant_id=1, config_id=1, period_start=date(2026, 5, 4))
+
+    plan = db.query(TransportationPlan).filter_by(id=result.plan_id).one()
+    assert plan.carrier_count == 2  # distinct carriers across lanes


### PR DESCRIPTION
## Summary

Implements §3.38 Phase 2A. `MovementPlannerService` now reads Core's `RateCard` substrate (§3.29 settlement) joined with `Contract` + `Carrier`, finds matching rate cards, and picks the cheapest one per plan item.

## What changed

- `app/services/powell/movement_planner_service.py`:
  - New `RateAssignment` dataclass — carrier + rate + base_rate + distance.
  - New `_select_carrier_and_rate()` — queries Core's `RateCard`, filters by tenant + effective window + equipment + lane filter, ranks by cost.
  - New `_lane_filter_matches()` — Phase 2A handles `{}` (catch-all) and `{"lane_id": <id>}`.
  - New `_estimate_card_cost()` — ranks 5 rate bases (FLAT / PER_MILE / PER_HUNDREDWEIGHT / PER_PALLET / PER_HOUR).
  - New `_compute_item_cost()` — per-item cost with weight when known.
  - New `_lane_distance_miles()` — TMS-side `LaneProfile.distance_miles` lookup with 500-mile fallback.
  - `plan_movement()` now sets `carrier_id`, `rate_id`, `estimated_cost`, `estimated_cost_per_mile`, `distance_miles` on each item; populates plan-summary metrics.
  - New `carrier_assignment_enabled=True` parameter (default; opt-out for Phase 1 fallback).
  - `PlanResult` extended with `items_with_carrier` + `items_without_carrier` counters.
- `tests/powell/test_l3_planning_services.py`: 8 new Phase 2A tests + 1 existing test updated.

## Test plan

- [x] 8 new pytest tests covering: cheapest selection, no-match graceful NULL, explicit Phase 1 fallback, equipment-type filtering (NULL = any; specific types reject mismatches), effective-window filtering (expired rejected), lane-id filter, distance fallback when LaneProfile missing, FLAT rate basis, distinct carrier count.
- [x] Existing Phase 1 test updated to expect `HEURISTIC_PHASE_2A` (graceful NULL fallback when no rate cards seeded preserves test semantics).
- [x] End-to-end smoke verified: 5 items at 750 mi × $2.50/mi = $1875 each = $9,375 plan total.

## Cross-references

- Companion Core PR (merged): https://github.com/azirella-ltd/Autonomy-Core/pull/54
- §3.29 settlement substrate consumed.
- §3.37 `LaneVolumePlan` substrate read.
- §3.39 `TransportationPlan` (now Core) written to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)