### PR TITLE
feat(§3.42): IntegratedBalancerService reads capacity from CarrierCapacityCommitment

### DIFF
--- a/backend/app/services/powell/integrated_balancer_service.py
+++ b/backend/app/services/powell/integrated_balancer_service.py
@@ -115,11 +115,17 @@ class BalanceResult:
 class IntegratedBalancerService:
     """L3 Constrained Balanced Plan service.
 
-    - Phase 1 (clone-only): omit ``carrier_capacity`` → 1:1 clone of
-      unconstrained plan.
-    - Phase 2B (LP-projection): pass ``carrier_capacity={carrier_id:
-      max_loads}`` → solve a transportation LP that respects per-carrier
-      capacity, minimises total cost, escalates items that don't fit.
+    - **Phase 1 (clone-only)**: omit ``carrier_capacity`` and
+      ``resolve_capacity_from_db=False`` → 1:1 clone of unconstrained plan.
+    - **Phase 2B (LP-projection, dict API)**: pass
+      ``carrier_capacity={carrier_id: max_loads}`` → solve a transportation
+      LP that respects per-carrier capacity, minimises total cost,
+      escalates items that don't fit.
+    - **§3.42 (LP-projection, DB API)**: pass
+      ``resolve_capacity_from_db=True`` → query Core's
+      :class:`~azirella_data_model.settlement.CarrierCapacityCommitment`
+      table and build the capacity dict from canonical commitment rows.
+      Production-ready replacement for the ad-hoc dict path.
     """
 
     def __init__(self, db: Session) -> None:
@@ -134,17 +140,28 @@ class IntegratedBalancerService:
         *,
         unconstrained_plan_id: int,
         carrier_capacity: Optional[Dict[int, float]] = None,
+        resolve_capacity_from_db: bool = False,
         cascade_run_id: Optional[str] = None,
         escalation_penalty: float = _DEFAULT_ESCALATION_PENALTY,
     ) -> BalanceResult:
         """Project the unconstrained plan onto the carrier-capacity
         constraint set.
 
-        - ``carrier_capacity is None`` → Phase 1 clone-only stub
+        - ``carrier_capacity is None`` AND ``resolve_capacity_from_db
+          is False`` → Phase 1 clone-only stub
           (``optimization_method='CLONE_PHASE_1'``).
-        - ``carrier_capacity`` provided → Phase 2B LP-projection.
+        - ``carrier_capacity`` provided → Phase 2B LP-projection (dict API).
+        - ``resolve_capacity_from_db=True`` → §3.42 LP-projection. Reads
+          ``CarrierCapacityCommitment`` rows for the source plan's
+          (tenant, period_start, period_end) window, builds the capacity
+          dict, then runs the same LP. Empty result → clone fallback.
         - LP solve fails → fall back to clone with
           ``optimization_method='LP_INFEASIBLE_FALLBACK'``.
+
+        Both ``carrier_capacity`` and ``resolve_capacity_from_db``
+        provided is supported: the dict OVERRIDES the DB query (useful
+        for tests / what-if scenarios where the operator wants to override
+        a specific carrier's commitment).
 
         Caller commits.
         """
@@ -169,6 +186,27 @@ class IntegratedBalancerService:
             .filter(TransportationPlanItem.plan_id == unconstrained_plan_id)
             .all()
         )
+
+        # §3.42 — DB-resolved capacity. Runs first so an explicit
+        # `carrier_capacity` dict can override specific carriers (test
+        # / what-if pattern). Resolved rows merge with the override:
+        # the override dict takes precedence per carrier_id.
+        if resolve_capacity_from_db:
+            db_capacity = self._resolve_capacity_from_db(
+                tenant_id=source_plan.tenant_id,
+                period_start=source_plan.plan_start_date,
+                period_end=source_plan.plan_end_date,
+            )
+            if db_capacity:
+                if carrier_capacity is not None:
+                    # Override merge: dict wins per carrier_id
+                    merged = dict(db_capacity)
+                    merged.update(carrier_capacity)
+                    carrier_capacity = merged
+                else:
+                    carrier_capacity = db_capacity
+            # If db_capacity is empty AND no dict override → fall through
+            # to the Phase 1 clone path below (no capacity = no LP).
 
         # Phase 1 fallback: no capacity → clone-only stub.
         if carrier_capacity is None:
@@ -542,6 +580,81 @@ class IntegratedBalancerService:
         }
 
         return assignments, escalated, utilisation
+
+    # ------------------------------------------------------------------
+    # §3.42 — DB-resolved capacity from CarrierCapacityCommitment
+    # ------------------------------------------------------------------
+
+    def _resolve_capacity_from_db(
+        self,
+        *,
+        tenant_id: int,
+        period_start,
+        period_end,
+    ) -> Dict[int, float]:
+        """Build the ``{carrier_id: max_loads}`` dict by querying
+        ``CarrierCapacityCommitment`` rows that overlap the plan's
+        ``[period_start, period_end]`` window.
+
+        Resolution rules (Phase 1 of §3.42):
+
+        - Match rows where ``commitment.period_start <= plan.period_end``
+          AND ``commitment.period_end >= plan.period_start`` (overlap).
+        - Match rows where ``effective_from <= today`` AND
+          ``effective_to IS NULL OR effective_to >= today``.
+        - Per ``contract.id``, sum ``commit_volume`` across all matching
+          rows. The carrier id resolves through ``Contract.carrier_id``.
+        - Multiple commitments for the same carrier across different
+          contracts roll up additively (carrier may serve multiple
+          contracts; each contract's commitment is independent).
+
+        Returns empty dict when no commitments match. Caller treats
+        that as "no capacity data → fall through to clone-only path".
+
+        Phase 2 of §3.42 will add:
+        - Per-period-granularity prorating (``WEEKLY`` commitments
+          should slice their contribution to the plan's actual week
+          coverage; today we sum the full ``commit_volume``).
+        - Lane-filter resolution (Phase 1 ignores ``lane_filter``;
+          all rows for the contract roll up into the carrier total).
+        - Equipment-filter resolution (Phase 1 ignores ``equipment_type``).
+        """
+        try:
+            from azirella_data_model.settlement import (
+                CarrierCapacityCommitment,
+                Contract,
+            )
+        except ImportError:
+            return {}
+
+        from datetime import datetime
+        now = datetime.utcnow()
+
+        rows = (
+            self.db.query(CarrierCapacityCommitment, Contract.carrier_id)
+            .join(Contract, Contract.id == CarrierCapacityCommitment.contract_id)
+            .filter(
+                CarrierCapacityCommitment.tenant_id == tenant_id,
+                # Period overlap: commitment ends after plan starts AND
+                # commitment starts before plan ends.
+                CarrierCapacityCommitment.period_end >= period_start,
+                CarrierCapacityCommitment.period_start <= period_end,
+                # Effective-window check.
+                CarrierCapacityCommitment.effective_from <= now,
+            )
+            .all()
+        )
+
+        capacity: Dict[int, float] = {}
+        for commitment, carrier_id in rows:
+            if commitment.effective_to is not None and commitment.effective_to < now:
+                continue
+            if carrier_id is None:
+                continue
+            volume = float(commitment.commit_volume)
+            capacity[carrier_id] = capacity.get(carrier_id, 0.0) + volume
+
+        return capacity
 
 
 __all__ = [

--- a/backend/tests/powell/test_l3_planning_services.py
+++ b/backend/tests/powell/test_l3_planning_services.py
@@ -877,6 +877,148 @@ def test_phase_2b_falls_back_to_clone_when_capacity_omitted(db) -> None:
 
 
 # ===========================================================================
+# §3.42 — DB-resolved carrier capacity from CarrierCapacityCommitment
+# ===========================================================================
+
+
+def _seed_capacity_commitments(db: Session, period_start, period_end) -> None:
+    """Seed CarrierCapacityCommitment rows for §3.42 DB-resolution tests.
+
+    Carrier 1 (the cheap one from `_seed_two_carriers_with_capacity_test_setup`)
+    gets a 4-load commitment; carrier 2 gets 100. Same shape as the dict
+    that Phase 2B tests pass directly.
+    """
+    from datetime import datetime
+    from azirella_data_model.settlement import CarrierCapacityCommitment
+
+    db.add(CarrierCapacityCommitment(
+        tenant_id=1, contract_id=1, lane_filter={}, equipment_type="DRY_VAN",
+        period_start=period_start, period_end=period_end,
+        period_granularity="WEEKLY",
+        commit_volume=4, currency="USD",
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.add(CarrierCapacityCommitment(
+        tenant_id=1, contract_id=2, lane_filter={}, equipment_type="DRY_VAN",
+        period_start=period_start, period_end=period_end,
+        period_granularity="WEEKLY",
+        commit_volume=100, currency="USD",
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.flush()
+
+
+def test_phase_3_42_db_resolved_capacity_drives_lp_projection(db) -> None:
+    """resolve_capacity_from_db=True queries CarrierCapacityCommitment
+    rows and feeds the LP. Same outcome as the dict path."""
+    plan_id = _seed_two_carriers_with_capacity_test_setup(db)
+    plan = db.query(TransportationPlan).filter_by(id=plan_id).one()
+    _seed_capacity_commitments(db, plan.plan_start_date, plan.plan_end_date)
+
+    ib = IntegratedBalancerService(db)
+    result = ib.balance_plan(
+        unconstrained_plan_id=plan_id,
+        resolve_capacity_from_db=True,
+    )
+
+    assert result.optimization_method == "LP_PROJECTION_PHASE_2B"
+    assert result.constraints_applied == 6  # 6 items reassigned to carrier 2
+    items = db.query(TransportationPlanItem).filter_by(
+        plan_id=result.constrained_plan_id,
+    ).all()
+    counts = {}
+    for it in items:
+        counts[it.carrier_id] = counts.get(it.carrier_id, 0) + 1
+    assert counts.get(1) == 4
+    assert counts.get(2) == 6
+
+
+def test_phase_3_42_dict_override_takes_precedence(db) -> None:
+    """When both `carrier_capacity` and `resolve_capacity_from_db=True`
+    are passed, the dict overrides per-carrier values from the DB."""
+    plan_id = _seed_two_carriers_with_capacity_test_setup(db)
+    plan = db.query(TransportationPlan).filter_by(id=plan_id).one()
+    _seed_capacity_commitments(db, plan.plan_start_date, plan.plan_end_date)
+
+    ib = IntegratedBalancerService(db)
+    result = ib.balance_plan(
+        unconstrained_plan_id=plan_id,
+        resolve_capacity_from_db=True,
+        carrier_capacity={1: 2},  # override carrier 1 to 2 (was 4 in DB)
+    )
+
+    items = db.query(TransportationPlanItem).filter_by(
+        plan_id=result.constrained_plan_id,
+    ).all()
+    counts = {}
+    for it in items:
+        counts[it.carrier_id] = counts.get(it.carrier_id, 0) + 1
+    assert counts.get(1) == 2  # capped by override
+    assert counts.get(2) == 8  # rest reassigned
+
+
+def test_phase_3_42_empty_db_resolution_falls_through_to_clone(db) -> None:
+    """No CarrierCapacityCommitment rows + flag set + no dict →
+    fall through to CLONE_PHASE_1."""
+    plan_id = _seed_two_carriers_with_capacity_test_setup(db)
+    # No _seed_capacity_commitments call
+
+    ib = IntegratedBalancerService(db)
+    result = ib.balance_plan(
+        unconstrained_plan_id=plan_id,
+        resolve_capacity_from_db=True,
+    )
+
+    assert result.optimization_method == "CLONE_PHASE_1"
+    assert result.constraints_applied == 0
+
+
+def test_phase_3_42_expired_commitments_not_used(db) -> None:
+    """A CarrierCapacityCommitment with effective_to in the past is
+    excluded from the resolved capacity."""
+    from datetime import datetime
+    from azirella_data_model.settlement import CarrierCapacityCommitment
+
+    plan_id = _seed_two_carriers_with_capacity_test_setup(db)
+    plan = db.query(TransportationPlan).filter_by(id=plan_id).one()
+
+    # Carrier 1: expired commitment (effective_to before now)
+    db.add(CarrierCapacityCommitment(
+        tenant_id=1, contract_id=1, lane_filter={}, equipment_type="DRY_VAN",
+        period_start=plan.plan_start_date, period_end=plan.plan_end_date,
+        period_granularity="WEEKLY",
+        commit_volume=4, currency="USD",
+        effective_from=datetime(2025, 1, 1),
+        effective_to=datetime(2025, 12, 31),  # expired
+    ))
+    # Carrier 2: active commitment
+    db.add(CarrierCapacityCommitment(
+        tenant_id=1, contract_id=2, lane_filter={}, equipment_type="DRY_VAN",
+        period_start=plan.plan_start_date, period_end=plan.plan_end_date,
+        period_granularity="WEEKLY",
+        commit_volume=100, currency="USD",
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.flush()
+
+    ib = IntegratedBalancerService(db)
+    result = ib.balance_plan(
+        unconstrained_plan_id=plan_id,
+        resolve_capacity_from_db=True,
+    )
+
+    items = db.query(TransportationPlanItem).filter_by(
+        plan_id=result.constrained_plan_id,
+    ).all()
+    counts = {}
+    for it in items:
+        counts[it.carrier_id] = counts.get(it.carrier_id, 0) + 1
+    # Carrier 1 has no active capacity → ALL 10 items go to carrier 2
+    assert counts.get(2) == 10
+    assert 1 not in counts
+
+
+# ===========================================================================
 # §3.38 Phase 2A.1 — ChargeCalculator integration (item 2)
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

Extends `IntegratedBalancerService.balance_plan()` with a new `resolve_capacity_from_db: bool = False` parameter. When True, queries the new `CarrierCapacityCommitment` Core table (Core PR #56 just merged) and builds the LP-projection capacity dict from canonical commercial-terms data.

Companion to [Autonomy-Core #56](https://github.com/azirella-ltd/Autonomy-Core/pull/56).

## What landed

- `balance_plan()` accepts `resolve_capacity_from_db=True` to query Core's `CarrierCapacityCommitment`.
- **Override merge**: `carrier_capacity={...}` + `resolve_capacity_from_db=True` merges with the dict winning per-carrier (what-if scenarios).
- **Empty-DB fallthrough**: no rows match → falls through to `CLONE_PHASE_1`.
- **Expired-commitment exclusion**: `effective_to < now` filtered out at query time.

## Test plan

- [x] 4 new pytest tests covering: DB-resolved drives LP, dict override merges, empty DB falls through, expired excluded.
- [x] End-to-end smoke verified: 10 items, DB-resolved {1: 4, 2: 100} → 4 + 6 split (matches dict path); override `{1: 2}` → 2 + 8 split.

## Phase 1 simplifications (deferred)

- No per-period-granularity prorating
- No `lane_filter` resolution at resolve time
- No `equipment_type` filter at resolve time
- No `min_volume` shortfall penalty (settlement-time concern)

## Cross-references

- Core PR (merged): https://github.com/azirella-ltd/Autonomy-Core/pull/56
- §3.42 register entry — full design + Phase 2 deferred work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)