### PR TITLE
feat(§3.42 Phase 2): filter capacity commitments at resolve time

### DIFF
--- a/backend/app/services/powell/integrated_balancer_service.py
+++ b/backend/app/services/powell/integrated_balancer_service.py
@@ -81,6 +81,37 @@ Large enough that escalation is always worse than any feasible
 assignment. Configurable per-call for tenants with unusual cost scales."""
 
 
+def _commitment_matches_item(commitment, item) -> bool:
+    """Phase 2 (§3.42) — does this commitment plausibly serve this item?
+
+    All three scopes (``lane_filter`` / ``equipment_type`` / ``mode``)
+    are AND-combined per item. ``None`` / empty ``lane_filter`` matches
+    anything. Geographic ``lane_filter`` shapes fail-closed in Phase 2.
+    """
+    # equipment_type: None on commitment = any
+    if commitment.equipment_type is not None:
+        if commitment.equipment_type != item.equipment_type:
+            return False
+    # mode: None on commitment = any
+    if commitment.mode is not None:
+        if commitment.mode != item.mode:
+            return False
+    # lane_filter: empty dict catch-all; {"lane_id": ...} explicit match;
+    # other shapes (geographic) fail-closed in Phase 2.
+    lane_filter = commitment.lane_filter or {}
+    if not lane_filter:
+        return True
+    if "lane_id" in lane_filter:
+        if lane_filter["lane_id"] != item.lane_id:
+            return False
+    # Geographic shapes — Phase 2 fail-closed.
+    geo_keys = {"origin_geo_id", "dest_geo_id", "origin_state", "dest_state",
+                "origin_zip3", "dest_zip3"}
+    if any(k in lane_filter for k in geo_keys):
+        return False
+    return True
+
+
 @dataclass(frozen=True)
 class BalanceResult:
     """Per-call summary."""
@@ -191,11 +222,16 @@ class IntegratedBalancerService:
         # `carrier_capacity` dict can override specific carriers (test
         # / what-if pattern). Resolved rows merge with the override:
         # the override dict takes precedence per carrier_id.
+        # Phase 2 (§3.42): pass source_items so commitment rows are
+        # filtered by lane + equipment + mode scope — irrelevant rows
+        # (e.g., REEFER commitments when the plan has no REEFER items)
+        # don't boost the carrier's pool.
         if resolve_capacity_from_db:
             db_capacity = self._resolve_capacity_from_db(
                 tenant_id=source_plan.tenant_id,
                 period_start=source_plan.plan_start_date,
                 period_end=source_plan.plan_end_date,
+                items=source_items,
             )
             if db_capacity:
                 if carrier_capacity is not None:
@@ -591,33 +627,49 @@ class IntegratedBalancerService:
         tenant_id: int,
         period_start,
         period_end,
+        items: Optional[Sequence] = None,
     ) -> Dict[int, float]:
         """Build the ``{carrier_id: max_loads}`` dict by querying
         ``CarrierCapacityCommitment`` rows that overlap the plan's
         ``[period_start, period_end]`` window.
 
-        Resolution rules (Phase 1 of §3.42):
+        Resolution rules:
 
         - Match rows where ``commitment.period_start <= plan.period_end``
           AND ``commitment.period_end >= plan.period_start`` (overlap).
         - Match rows where ``effective_from <= today`` AND
           ``effective_to IS NULL OR effective_to >= today``.
+        - **Phase 2 (§3.42):** when ``items`` is provided, also filter by
+          :meth:`_capacity_filter_matches` — the commitment's
+          ``lane_filter`` + ``equipment_type`` + ``mode`` must match at
+          least one plan item. Without this filter (Phase 1), a contract's
+          REEFER-on-FL-NY commitment would boost the carrier's pool even
+          when the plan has no REEFER FL-NY items. Phase 2 closes that
+          over-permissiveness gap.
         - Per ``contract.id``, sum ``commit_volume`` across all matching
           rows. The carrier id resolves through ``Contract.carrier_id``.
         - Multiple commitments for the same carrier across different
-          contracts roll up additively (carrier may serve multiple
-          contracts; each contract's commitment is independent).
+          contracts roll up additively.
 
-        Returns empty dict when no commitments match. Caller treats
-        that as "no capacity data → fall through to clone-only path".
+        Returns empty dict when no commitments match. Caller treats that
+        as "no capacity data → fall through to clone-only path".
 
-        Phase 2 of §3.42 will add:
-        - Per-period-granularity prorating (``WEEKLY`` commitments
-          should slice their contribution to the plan's actual week
-          coverage; today we sum the full ``commit_volume``).
-        - Lane-filter resolution (Phase 1 ignores ``lane_filter``;
-          all rows for the contract roll up into the carrier total).
-        - Equipment-filter resolution (Phase 1 ignores ``equipment_type``).
+        ``items`` is optional for backward compatibility. When omitted,
+        Phase 1 behaviour (no per-item filter) applies.
+
+        Still NOT in Phase 2 (deferred to Phase 3 of §3.42):
+        - Per-period-granularity prorating (``WEEKLY`` rows still
+          contribute their full ``commit_volume`` regardless of how the
+          plan period slices the commitment's coverage).
+        - Per-(carrier × equipment) capacity dict — the LP shape is
+          still ``{carrier_id: total_loads}``, so a single carrier's
+          DRY_VAN + REEFER commitments still aggregate. Per-equipment
+          LP constraints would require changing the LP shape.
+        - Geographic ``lane_filter`` shapes (``origin_state``,
+          ``origin_zip3``, ``origin_geo_id``, etc.) — Phase 2 supports
+          catch-all ``{}`` and ``{"lane_id": <id>}`` only; geographic
+          shapes need the same ``_resolve_lane_geography`` walk that
+          ``MovementPlannerService`` does.
         """
         try:
             from azirella_data_model.settlement import (
@@ -651,10 +703,46 @@ class IntegratedBalancerService:
                 continue
             if carrier_id is None:
                 continue
+            # Phase 2 (§3.42): require at least one plan item to match
+            # the commitment's scope. Without this filter (Phase 1), a
+            # commitment that no item could plausibly use still adds to
+            # the carrier's cap.
+            if items is not None and not self._capacity_filter_matches(
+                commitment, items,
+            ):
+                continue
             volume = float(commitment.commit_volume)
             capacity[carrier_id] = capacity.get(carrier_id, 0.0) + volume
 
         return capacity
+
+    @staticmethod
+    def _capacity_filter_matches(commitment, items: Sequence) -> bool:
+        """Phase 2 (§3.42) capacity-filter matcher.
+
+        Returns ``True`` if at least one item in ``items`` matches the
+        commitment's ``lane_filter`` + ``equipment_type`` + ``mode``
+        scope. The match is OR across items — a commitment counts if
+        any plan item could plausibly use it.
+
+        Rules (per item, AND-combined):
+
+        - **lane_filter**: empty dict matches all; ``{"lane_id": <id>}``
+          matches when ``item.lane_id`` equals it. Geographic shapes
+          (``origin_state``, ``origin_zip3``, ``origin_geo_id``, etc.)
+          are not supported in Phase 2 — they fail-closed (don't match).
+          Phase 3 will resolve them via ``MovementPlannerService.
+          _resolve_lane_geography``.
+        - **equipment_type**: ``None`` matches any equipment; otherwise
+          must equal ``item.equipment_type``.
+        - **mode**: ``None`` matches any mode; otherwise must equal
+          ``item.mode``.
+        """
+        for item in items:
+            if not _commitment_matches_item(commitment, item):
+                continue
+            return True
+        return False
 
 
 __all__ = [

--- a/backend/tests/powell/test_l3_planning_services.py
+++ b/backend/tests/powell/test_l3_planning_services.py
@@ -973,6 +973,178 @@ def test_phase_3_42_empty_db_resolution_falls_through_to_clone(db) -> None:
     assert result.constraints_applied == 0
 
 
+def test_phase_3_42_p2_irrelevant_equipment_commitments_filtered_out(db) -> None:
+    """§3.42 Phase 2: a REEFER commitment under the same carrier does
+    not boost the carrier's pool when plan items are all DRY_VAN."""
+    from datetime import datetime
+    from azirella_data_model.settlement import (
+        Carrier, Contract, RateCard, CarrierCapacityCommitment,
+    )
+
+    # 1 carrier with 2 contracts: one DRY_VAN with low cap, one REEFER with high cap
+    db.add(Carrier(id=1, tenant_id=1, scac="C1", display_name="C1", carrier_type="TRUCKLOAD"))
+    db.flush()
+    db.add(Contract(id=1, tenant_id=1, carrier_id=1, contract_number="C1-A",
+        contract_type="PRIMARY", effective_from=datetime(2026, 1, 1), currency="USD"))
+    db.add(Contract(id=2, tenant_id=1, carrier_id=1, contract_number="C1-B",
+        contract_type="PRIMARY", effective_from=datetime(2026, 1, 1), currency="USD"))
+    db.flush()
+    db.add(RateCard(id=1, tenant_id=1, contract_id=1, lane_filter={},
+        equipment_type="DRY_VAN", rate_basis="PER_MILE", base_rate=2.50,
+        effective_from=datetime(2026, 1, 1)))
+    db.flush()
+    # Relevant DRY_VAN commitment (low cap)
+    db.add(CarrierCapacityCommitment(
+        tenant_id=1, contract_id=1, lane_filter={}, equipment_type="DRY_VAN",
+        period_start=date(2026, 5, 4), period_end=date(2026, 5, 10),
+        period_granularity="WEEKLY", commit_volume=4, currency="USD",
+        effective_from=datetime(2026, 1, 1),
+    ))
+    # Irrelevant REEFER commitment (high cap; should NOT count)
+    db.add(CarrierCapacityCommitment(
+        tenant_id=1, contract_id=2, lane_filter={}, equipment_type="REEFER",
+        period_start=date(2026, 5, 4), period_end=date(2026, 5, 10),
+        period_granularity="WEEKLY", commit_volume=100, currency="USD",
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.flush()
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=10)
+
+    mp = MovementPlannerService(db)
+    plan_id = mp.plan_movement(tenant_id=1, config_id=1, period_start=date(2026, 5, 4)).plan_id
+
+    ib = IntegratedBalancerService(db)
+    result = ib.balance_plan(unconstrained_plan_id=plan_id, resolve_capacity_from_db=True)
+
+    # Only DRY_VAN cap of 4 counts; 6 of 10 items escalated.
+    # Phase 1 (no filter) would have summed 4 + 100 = 104, escalating 0.
+    assert result.items_escalated == 6
+    items = db.query(TransportationPlanItem).filter_by(
+        plan_id=result.constrained_plan_id,
+    ).all()
+    on_c1 = sum(1 for it in items if it.carrier_id == 1)
+    cancelled = sum(1 for it in items if it.status == PlanItemStatus.CANCELLED)
+    assert on_c1 == 4
+    assert cancelled == 6
+
+
+def test_phase_3_42_p2_lane_filter_mismatch_filtered_out(db) -> None:
+    """§3.42 Phase 2: a commitment scoped to lane_id 99 doesn't count
+    when plan items are all on lane 10."""
+    from datetime import datetime
+    from azirella_data_model.settlement import (
+        Carrier, Contract, RateCard, CarrierCapacityCommitment,
+    )
+
+    db.add(Carrier(id=1, tenant_id=1, scac="C1", display_name="C1", carrier_type="TRUCKLOAD"))
+    db.flush()
+    db.add(Contract(id=1, tenant_id=1, carrier_id=1, contract_number="C1",
+        contract_type="PRIMARY", effective_from=datetime(2026, 1, 1), currency="USD"))
+    db.flush()
+    db.add(RateCard(id=1, tenant_id=1, contract_id=1, lane_filter={},
+        equipment_type="DRY_VAN", rate_basis="PER_MILE", base_rate=2.50,
+        effective_from=datetime(2026, 1, 1)))
+    # Commitment scoped to lane 99 only — items are on lane 10
+    db.add(CarrierCapacityCommitment(
+        tenant_id=1, contract_id=1, lane_filter={"lane_id": 99},
+        equipment_type="DRY_VAN",
+        period_start=date(2026, 5, 4), period_end=date(2026, 5, 10),
+        period_granularity="WEEKLY", commit_volume=100, currency="USD",
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.flush()
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=3)
+
+    plan_id = MovementPlannerService(db).plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4)).plan_id
+
+    ib = IntegratedBalancerService(db)
+    result = ib.balance_plan(unconstrained_plan_id=plan_id, resolve_capacity_from_db=True)
+
+    # Lane 99 commitment doesn't match lane 10 items → no capacity →
+    # falls through to CLONE_PHASE_1.
+    assert result.optimization_method == "CLONE_PHASE_1"
+
+
+def test_phase_3_42_p2_geographic_filter_fails_closed(db) -> None:
+    """§3.42 Phase 2: geographic lane_filter shapes (origin_state etc.)
+    are not yet supported — the matcher fails closed (commitment
+    excluded). Phase 3 will resolve them via _resolve_lane_geography."""
+    from datetime import datetime
+    from azirella_data_model.settlement import (
+        Carrier, Contract, RateCard, CarrierCapacityCommitment,
+    )
+
+    db.add(Carrier(id=1, tenant_id=1, scac="C1", display_name="C1", carrier_type="TRUCKLOAD"))
+    db.flush()
+    db.add(Contract(id=1, tenant_id=1, carrier_id=1, contract_number="C1",
+        contract_type="PRIMARY", effective_from=datetime(2026, 1, 1), currency="USD"))
+    db.flush()
+    db.add(RateCard(id=1, tenant_id=1, contract_id=1, lane_filter={},
+        equipment_type="DRY_VAN", rate_basis="PER_MILE", base_rate=2.50,
+        effective_from=datetime(2026, 1, 1)))
+    db.add(CarrierCapacityCommitment(
+        tenant_id=1, contract_id=1, lane_filter={"origin_state": "TX"},
+        equipment_type="DRY_VAN",
+        period_start=date(2026, 5, 4), period_end=date(2026, 5, 10),
+        period_granularity="WEEKLY", commit_volume=100, currency="USD",
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.flush()
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=3)
+
+    plan_id = MovementPlannerService(db).plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4)).plan_id
+
+    ib = IntegratedBalancerService(db)
+    result = ib.balance_plan(unconstrained_plan_id=plan_id, resolve_capacity_from_db=True)
+
+    # Geographic filter not supported in Phase 2 → commitment excluded
+    # → no capacity → CLONE_PHASE_1.
+    assert result.optimization_method == "CLONE_PHASE_1"
+
+
+def test_phase_3_42_p2_mode_filter(db) -> None:
+    """§3.42 Phase 2: a commitment with explicit mode='LTL' doesn't
+    count for FTL plan items."""
+    from datetime import datetime
+    from azirella_data_model.settlement import (
+        Carrier, Contract, RateCard, CarrierCapacityCommitment,
+    )
+
+    db.add(Carrier(id=1, tenant_id=1, scac="C1", display_name="C1", carrier_type="TRUCKLOAD"))
+    db.flush()
+    db.add(Contract(id=1, tenant_id=1, carrier_id=1, contract_number="C1",
+        contract_type="PRIMARY", effective_from=datetime(2026, 1, 1), currency="USD"))
+    db.flush()
+    db.add(RateCard(id=1, tenant_id=1, contract_id=1, lane_filter={},
+        equipment_type="DRY_VAN", rate_basis="PER_MILE", base_rate=2.50,
+        effective_from=datetime(2026, 1, 1)))
+    # Commitment scoped to LTL — items are FTL
+    db.add(CarrierCapacityCommitment(
+        tenant_id=1, contract_id=1, lane_filter={}, mode="LTL",
+        equipment_type="DRY_VAN",
+        period_start=date(2026, 5, 4), period_end=date(2026, 5, 10),
+        period_granularity="WEEKLY", commit_volume=100, currency="USD",
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.flush()
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=3)
+
+    plan_id = MovementPlannerService(db).plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4)).plan_id
+
+    ib = IntegratedBalancerService(db)
+    result = ib.balance_plan(unconstrained_plan_id=plan_id, resolve_capacity_from_db=True)
+
+    # LTL commitment doesn't match FTL items → CLONE_PHASE_1.
+    assert result.optimization_method == "CLONE_PHASE_1"
+
+
 def test_phase_3_42_expired_commitments_not_used(db) -> None:
     """A CarrierCapacityCommitment with effective_to in the past is
     excluded from the resolved capacity."""


### PR DESCRIPTION
## Summary

§3.42 Phase 2 closes the Phase 1 over-permissiveness gap.

`_resolve_capacity_from_db()` accepts an optional `items` parameter; each `CarrierCapacityCommitment` row is run through `_capacity_filter_matches(commitment, items)` before summing into the per-carrier cap.

## Filter rules

- `equipment_type`: NULL = any; otherwise must equal at least one item's equipment.
- `mode`: NULL = any; otherwise must equal at least one item's mode.
- `lane_filter`: catch-all `{}` matches; `{"lane_id": <id>}` matches when at least one item's `lane_id` equals it.
- Geographic shapes fail-closed in Phase 2 (commitment excluded). Phase 3 will resolve via `_resolve_lane_geography`.

OR across items. Backward compat: `items` optional.

## Concrete impact

Carrier with DRY_VAN cap=4 + REEFER cap=100 under separate contracts; plan items all DRY_VAN.
- **Phase 1**: rolls up 104, 0 escalations (bogus)
- **Phase 2**: rolls up 4, 6 of 10 items escalated (correct)

## Test plan

- [x] 4 new pytest tests covering all four filter dimensions.
- [x] End-to-end smoke verified.
- [x] Existing Phase 1 tests still pass (the seed function uses commitments that match the items, so filtering doesn't change the outcome).

## Cross-references

- Companion Core PR (merged): https://github.com/azirella-ltd/Autonomy-Core/pull/58
- Plus Alembic head merge already shipped: https://github.com/azirella-ltd/Autonomy-Core/pull/57

🤖 Generated with [Claude Code](https://claude.com/claude-code)