### PR TITLE
feat(§3.42 P3 + §3.41 P3): geographic + per-equipment LP + prorating; real PyTorch GraphSAGE pipeline

### DIFF
--- a/backend/app/services/powell/graphsage_movement_planner.py
+++ b/backend/app/services/powell/graphsage_movement_planner.py
@@ -173,9 +173,415 @@ class NotYetImplementedModel(GraphSAGEMovementPlannerModel):
         return "graphsage_not_yet_implemented"
 
 
+# ===========================================================================
+# §3.41 Phase 3.2 — Real PyTorch GraphSAGE implementation
+# ===========================================================================
+
+
+class TorchGraphSAGEMovementPlanner(GraphSAGEMovementPlannerModel):
+    """Real PyTorch GraphSAGE model for the Movement Planner.
+
+    Architecture:
+
+    - 2 ``SAGEConv`` layers (``torch_geometric.nn.SAGEConv``) with mean
+      aggregator, ``relu`` between, hidden_dim=64.
+    - Per-(item, carrier) MLP scoring head: takes (item-node embedding
+      + carrier-node embedding + edge feature) → cost-prediction
+      scalar.
+    - Loss: MSE on (predicted_cost − observed_cost) when observed cost
+      available; falls back to MSE on (predicted − action_estimated)
+      for items without observed actuals (semi-supervised).
+
+    Graph construction (per inference call):
+
+    - Nodes: union of (lanes appearing in the forecast) + (carriers in
+      the candidate set).
+    - Edges: lane↔carrier when the carrier has at least one rate card
+      that matches the lane (an "this carrier could serve this lane"
+      relationship).
+    - Edge features: (rate_basis_one_hot, base_rate, distance_miles,
+      mode_compatibility_one_hot).
+
+    Phase 3.2 is the model **class** + training/inference plumbing.
+    Production training (multi-day GPU run, hyperparameter search,
+    held-out evaluation) is §3.41 Phase 3.5.
+
+    Dependencies:
+
+    - ``torch>=2.0`` — already in TMS requirements.
+    - ``torch_geometric>=2.5`` — already in TMS requirements (used
+      elsewhere; see e.g. SCP supply_planning_tgnn).
+
+    Imports are lazy so test fixtures without GPU + torch_geometric
+    can still load the rest of this module.
+    """
+
+    HIDDEN_DIM = 64
+    NUM_CONV_LAYERS = 2
+    DEFAULT_LR = 1e-3
+    DEFAULT_BATCH_SIZE = 64
+
+    def __init__(
+        self,
+        *,
+        hidden_dim: int = HIDDEN_DIM,
+        num_conv_layers: int = NUM_CONV_LAYERS,
+        learning_rate: float = DEFAULT_LR,
+        device: Optional[str] = None,
+    ) -> None:
+        self.hidden_dim = hidden_dim
+        self.num_conv_layers = num_conv_layers
+        self.learning_rate = learning_rate
+        self.device = device  # 'cuda' / 'cpu' / None (auto)
+        self._model = None  # Built lazily during fit()
+        self._version = "graphsage_untrained"
+        self._optimizer = None
+        self._loss_history: List[float] = []
+
+    # ------------------------------------------------------------------
+    # Build the underlying torch.nn.Module lazily
+    # ------------------------------------------------------------------
+
+    def _build_model(self, num_node_features: int, num_edge_features: int):
+        """Construct the GNN. Lazy import of torch / torch_geometric so
+        the module loads in environments that don't have them."""
+        import torch
+        import torch.nn as nn
+        from torch_geometric.nn import SAGEConv
+
+        class _GraphSAGEModel(nn.Module):
+            def __init__(self, in_dim: int, hidden_dim: int, edge_dim: int, n_layers: int):
+                super().__init__()
+                self.convs = nn.ModuleList()
+                self.convs.append(SAGEConv(in_dim, hidden_dim, aggr="mean"))
+                for _ in range(n_layers - 1):
+                    self.convs.append(
+                        SAGEConv(hidden_dim, hidden_dim, aggr="mean"),
+                    )
+                # Per-(item, carrier) MLP head
+                self.scorer = nn.Sequential(
+                    nn.Linear(hidden_dim * 2 + edge_dim, hidden_dim),
+                    nn.ReLU(),
+                    nn.Linear(hidden_dim, 1),
+                )
+
+            def forward(self, x, edge_index, edge_attr, item_idx, carrier_idx):
+                """``x``: node features ``[N, in_dim]``;
+                ``edge_index``: ``[2, E]``; ``edge_attr``: ``[E, edge_dim]``;
+                ``item_idx``: ``[B]`` indices of items in the batch;
+                ``carrier_idx``: ``[B]`` indices of carriers in the batch.
+
+                Returns predicted cost ``[B, 1]`` per (item, carrier)
+                pair.
+                """
+                h = x
+                for conv in self.convs:
+                    h = conv(h, edge_index)
+                    h = torch.relu(h)
+                # Per-pair edge feature is selected by aligning item_idx
+                # / carrier_idx with edge_index. Phase 3.2 simplification:
+                # callers pass edge_attr matching the item/carrier
+                # ordering; production training will use a proper
+                # bipartite-batch loader.
+                pair_features = torch.cat([
+                    h[item_idx],
+                    h[carrier_idx],
+                    edge_attr,
+                ], dim=-1)
+                return self.scorer(pair_features)
+
+        return _GraphSAGEModel(
+            in_dim=num_node_features,
+            hidden_dim=self.hidden_dim,
+            edge_dim=num_edge_features,
+            n_layers=self.num_conv_layers,
+        )
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def fit(self, training_data: List[Dict[str, Any]]) -> None:
+        """Train the model on a list of training examples.
+
+        Phase 3.2 expects ``training_data`` to be a list of dicts with
+        ``node_features``, ``edge_index``, ``edge_attr``,
+        ``item_carrier_pairs``, ``observed_costs``. Phase 3.3 wires the
+        :class:`MovementPlannerTrainingDataExtractor` output into this
+        shape via a ``MovementPlannerTrainer`` orchestrator.
+
+        For Phase 3.2 (this commit), training is single-batch full-graph
+        SGD. Production training uses minibatch sampling + held-out
+        validation; that's Phase 3.3 / 3.5.
+        """
+        if not training_data:
+            self._version = "graphsage_no_training_data"
+            return
+
+        import torch
+
+        # Pull dimensions from the first example so the model knows its
+        # input/edge feature widths.
+        first = training_data[0]
+        node_features = first["node_features"]
+        edge_attr = first["edge_attr"]
+        if hasattr(node_features, "shape"):
+            num_node_features = node_features.shape[-1]
+        else:
+            num_node_features = len(node_features[0])
+        if hasattr(edge_attr, "shape"):
+            num_edge_features = edge_attr.shape[-1]
+        else:
+            num_edge_features = len(edge_attr[0])
+
+        self._model = self._build_model(num_node_features, num_edge_features)
+        self._optimizer = torch.optim.Adam(
+            self._model.parameters(), lr=self.learning_rate,
+        )
+
+        device = self.device
+        if device is None:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        self._model.to(device)
+
+        self._model.train()
+        loss_history: List[float] = []
+
+        for example in training_data:
+            x = self._as_tensor(example["node_features"]).to(device)
+            edge_index = self._as_tensor(
+                example["edge_index"], dtype=torch.long,
+            ).to(device)
+            edge_attr_t = self._as_tensor(example["edge_attr"]).to(device)
+            pairs = example["item_carrier_pairs"]
+            item_idx = self._as_tensor(
+                [p[0] for p in pairs], dtype=torch.long,
+            ).to(device)
+            carrier_idx = self._as_tensor(
+                [p[1] for p in pairs], dtype=torch.long,
+            ).to(device)
+            observed = self._as_tensor(example["observed_costs"]).to(device)
+
+            self._optimizer.zero_grad()
+            pred = self._model(
+                x, edge_index, edge_attr_t, item_idx, carrier_idx,
+            ).squeeze(-1)
+            loss = torch.nn.functional.mse_loss(pred, observed)
+            loss.backward()
+            self._optimizer.step()
+            loss_history.append(float(loss.item()))
+
+        self._loss_history = loss_history
+        # Version-stamp by the final loss + step count (Phase 3.5 will
+        # use a proper checkpoint hash).
+        if loss_history:
+            final_loss = loss_history[-1]
+            self._version = (
+                f"graphsage_trained_steps={len(loss_history)}_"
+                f"final_loss={final_loss:.4f}"
+            )
+        else:
+            self._version = "graphsage_no_training_steps"
+
+    def predict(
+        self, inputs: GraphSAGEPredictionInput,
+    ) -> List[GraphSAGEPredictionOutput]:
+        """Score per-item assignment recommendations.
+
+        Phase 3.2 runs a single forward pass over the constructed
+        graph. ``inputs.lane_volume_forecasts`` + ``inputs.available_
+        carriers`` are converted into node + edge tensors via
+        :meth:`_inputs_to_graph_tensors`. The MLP scoring head emits
+        a predicted cost per (item, carrier) pair; we pick the
+        argmin-cost carrier per item.
+
+        For tests / production scenarios where training hasn't run,
+        the model returns the Phase 2A-heuristic carrier choice with
+        ``confidence=0.0`` so consumers can detect the untrained
+        state.
+        """
+        if self._model is None:
+            return [
+                GraphSAGEPredictionOutput(
+                    item_id=int(forecast.get("item_id", i)),
+                    carrier_id=None,
+                    rate_id=None,
+                    estimated_cost=None,
+                    confidence=0.0,
+                    rationale={
+                        "reason": "model_not_trained",
+                        "fallback": "use_phase_2a_heuristic",
+                    },
+                )
+                for i, forecast in enumerate(inputs.lane_volume_forecasts)
+            ]
+
+        import torch
+
+        graph = self._inputs_to_graph_tensors(inputs)
+        if graph is None:
+            return []
+
+        device = next(self._model.parameters()).device
+        x, edge_index, edge_attr, pair_idx_pairs, item_id_per_pair = graph
+        x = x.to(device)
+        edge_index = edge_index.to(device)
+        edge_attr = edge_attr.to(device)
+        item_idx = torch.tensor(
+            [p[0] for p in pair_idx_pairs], dtype=torch.long, device=device,
+        )
+        carrier_idx = torch.tensor(
+            [p[1] for p in pair_idx_pairs], dtype=torch.long, device=device,
+        )
+
+        self._model.eval()
+        with torch.no_grad():
+            pred = self._model(
+                x, edge_index, edge_attr, item_idx, carrier_idx,
+            ).squeeze(-1)
+        costs = pred.cpu().numpy()
+
+        # Group by item, pick min-cost carrier per item
+        from collections import defaultdict
+        per_item: Dict[int, List[tuple]] = defaultdict(list)
+        for k, (item_node, carrier_node) in enumerate(pair_idx_pairs):
+            per_item[item_id_per_pair[k]].append(
+                (float(costs[k]), inputs.available_carriers[carrier_node - len(inputs.lane_volume_forecasts)]),
+            )
+
+        outputs: List[GraphSAGEPredictionOutput] = []
+        for item_id, candidates in per_item.items():
+            if not candidates:
+                continue
+            candidates.sort(key=lambda pair: pair[0])
+            best_cost, best_carrier = candidates[0]
+            outputs.append(GraphSAGEPredictionOutput(
+                item_id=item_id,
+                carrier_id=int(best_carrier["carrier_id"]),
+                rate_id=best_carrier.get("rate_card_id"),
+                estimated_cost=best_cost,
+                confidence=self._confidence_score(candidates),
+                rationale={
+                    "model_version": self._version,
+                    "alternatives": [
+                        {"carrier_id": int(c["carrier_id"]), "predicted_cost": float(p)}
+                        for p, c in candidates[:3]
+                    ],
+                },
+            ))
+        return outputs
+
+    def model_version(self) -> str:
+        return self._version
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _inputs_to_graph_tensors(self, inputs: GraphSAGEPredictionInput):
+        """Convert the prediction-input dataclass to graph tensors.
+
+        Phase 3.2 graph: bipartite (items × carriers).
+        Items are nodes [0, n_items); carriers are nodes [n_items, n_items + n_carriers).
+        """
+        if not inputs.lane_volume_forecasts or not inputs.available_carriers:
+            return None
+        try:
+            import torch
+        except ImportError:
+            return None
+
+        n_items = len(inputs.lane_volume_forecasts)
+        n_carriers = len(inputs.available_carriers)
+        # Node features: simple 4-feature embedding
+        # (loads_p50, mode_idx, equipment_idx, is_item)
+        node_features = torch.zeros((n_items + n_carriers, 4))
+        for i, forecast in enumerate(inputs.lane_volume_forecasts):
+            node_features[i, 0] = float(forecast.get("forecast_loads_p50", 0))
+            node_features[i, 1] = self._mode_to_idx(forecast.get("mode"))
+            node_features[i, 2] = self._equipment_to_idx(
+                forecast.get("equipment_type"),
+            )
+            node_features[i, 3] = 1.0  # is_item flag
+        for j, carrier in enumerate(inputs.available_carriers):
+            node_features[n_items + j, 0] = float(carrier.get("capacity_remaining", 0))
+            node_features[n_items + j, 3] = 0.0  # is_carrier flag (not item)
+
+        # Edges: every item ↔ every carrier (Phase 3.2 fully-connected
+        # bipartite; Phase 3.5 prunes by rate-card existence).
+        edge_index = torch.zeros((2, n_items * n_carriers * 2), dtype=torch.long)
+        edge_attr = torch.zeros((n_items * n_carriers * 2, 3))
+        # Edge features: (base_rate, capacity_remaining, _padding)
+        pair_idx_pairs = []
+        item_id_per_pair = []
+        e = 0
+        for i, forecast in enumerate(inputs.lane_volume_forecasts):
+            for j, carrier in enumerate(inputs.available_carriers):
+                # Forward edge i → carrier_node
+                edge_index[0, e] = i
+                edge_index[1, e] = n_items + j
+                edge_attr[e, 0] = float(carrier.get("base_rate", 0))
+                edge_attr[e, 1] = float(carrier.get("capacity_remaining", 0))
+                e += 1
+                # Reverse edge for SAGEConv message-passing symmetry
+                edge_index[0, e] = n_items + j
+                edge_index[1, e] = i
+                edge_attr[e, 0] = float(carrier.get("base_rate", 0))
+                edge_attr[e, 1] = float(carrier.get("capacity_remaining", 0))
+                e += 1
+                # Track (item_node_idx, carrier_node_idx) for scoring
+                pair_idx_pairs.append((i, n_items + j))
+                item_id_per_pair.append(int(forecast.get("item_id", i)))
+
+        return node_features, edge_index, edge_attr, pair_idx_pairs, item_id_per_pair
+
+    @staticmethod
+    def _mode_to_idx(mode) -> float:
+        return {
+            "FTL": 0.0, "LTL": 1.0, "PARCEL": 2.0, "INTERMODAL": 3.0,
+            "OCEAN": 4.0, "RAIL": 5.0, "AIR": 6.0,
+        }.get(mode or "FTL", 0.0)
+
+    @staticmethod
+    def _equipment_to_idx(equipment_type) -> float:
+        return {
+            "DRY_VAN": 0.0, "REEFER": 1.0, "FLATBED": 2.0, "TANKER": 3.0,
+            "CONTAINER_20": 4.0, "CONTAINER_40": 5.0,
+        }.get(equipment_type, -1.0)
+
+    @staticmethod
+    def _as_tensor(x, dtype=None):
+        import torch
+        if hasattr(x, "shape"):  # already a tensor or numpy array
+            t = torch.as_tensor(x)
+        else:
+            t = torch.tensor(x)
+        if dtype is not None:
+            t = t.to(dtype=dtype)
+        else:
+            if t.dtype not in (torch.float32, torch.float64):
+                t = t.float()
+        return t
+
+    @staticmethod
+    def _confidence_score(candidates: List[tuple]) -> float:
+        """Confidence proxy: 1 − (best_cost / second_best_cost). When
+        cheapest candidate is much better than runner-up, confidence
+        is near 1.0; when they're tied, near 0.0.
+        """
+        if len(candidates) < 2:
+            return 0.5  # No alternative to compare against
+        best = candidates[0][0]
+        second = candidates[1][0]
+        if second <= 0:
+            return 0.5
+        return max(0.0, min(1.0, 1.0 - best / second))
+
+
 __all__ = [
     "GraphSAGEMovementPlannerModel",
     "GraphSAGEPredictionInput",
     "GraphSAGEPredictionOutput",
     "NotYetImplementedModel",
+    "TorchGraphSAGEMovementPlanner",
 ]

--- a/backend/app/services/powell/integrated_balancer_service.py
+++ b/backend/app/services/powell/integrated_balancer_service.py
@@ -60,10 +60,44 @@ These are GraphSAGE / LP-extension concerns deferred to Phase 3 per
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from sqlalchemy.orm import Session
+
+
+# Type alias for the capacity dict. Backward-compat: integer keys mean
+# "carrier-wide cap" (treated as (carrier_id, None)). Phase 3.2 (§3.42)
+# adds tuple keys (carrier_id, equipment_type) for per-equipment caps.
+_CapacityKey = Union[int, Tuple[int, Optional[str]]]
+_CapacityDict = Dict[_CapacityKey, float]
+
+
+def _normalize_capacity_dict(
+    capacity: Optional[_CapacityDict],
+) -> Dict[Tuple[int, Optional[str]], float]:
+    """Normalize ``Dict[int, float]`` (Phase 1 / 2B) and tuple-keyed
+    ``Dict[Tuple[int, Optional[str]], float]`` (Phase 3.2) shapes
+    into one canonical tuple-keyed dict.
+
+    Integer keys ``c`` are treated as ``(c, None)`` — meaning
+    "carrier-wide cap, any equipment." Tuple keys pass through.
+    """
+    if not capacity:
+        return {}
+    normalized: Dict[Tuple[int, Optional[str]], float] = {}
+    for key, value in capacity.items():
+        if isinstance(key, int):
+            normalized[(key, None)] = float(value)
+        elif isinstance(key, tuple) and len(key) == 2:
+            carrier_id, equipment_type = key
+            normalized[(int(carrier_id), equipment_type)] = float(value)
+        else:
+            raise ValueError(
+                f"Invalid capacity-dict key {key!r}; "
+                "expected int or (int, str|None) tuple."
+            )
+    return normalized
 
 from app.models.tms_planning import (
     PlanStatus,
@@ -81,34 +115,52 @@ Large enough that escalation is always worse than any feasible
 assignment. Configurable per-call for tenants with unusual cost scales."""
 
 
-def _commitment_matches_item(commitment, item) -> bool:
-    """Phase 2 (§3.42) — does this commitment plausibly serve this item?
+_GEO_KEYS = {
+    "origin_geo_id", "dest_geo_id",
+    "origin_state", "dest_state",
+    "origin_zip3", "dest_zip3",
+}
+
+
+def _commitment_matches_item(commitment, item, lane_geo_resolver=None) -> bool:
+    """Does this commitment plausibly serve this item?
 
     All three scopes (``lane_filter`` / ``equipment_type`` / ``mode``)
-    are AND-combined per item. ``None`` / empty ``lane_filter`` matches
-    anything. Geographic ``lane_filter`` shapes fail-closed in Phase 2.
+    are AND-combined per item.
+
+    Phase 2 (§3.42): supports `{}` catch-all + `{"lane_id": <id>}` only;
+    geographic shapes fail-closed.
+
+    Phase 3 (§3.42): geographic shapes (`origin_state`, `origin_zip3`,
+    `origin_geo_id`, `dest_*`) resolved via ``lane_geo_resolver``
+    (a :class:`LaneGeographyResolver`) when provided.
     """
-    # equipment_type: None on commitment = any
     if commitment.equipment_type is not None:
         if commitment.equipment_type != item.equipment_type:
             return False
-    # mode: None on commitment = any
     if commitment.mode is not None:
         if commitment.mode != item.mode:
             return False
-    # lane_filter: empty dict catch-all; {"lane_id": ...} explicit match;
-    # other shapes (geographic) fail-closed in Phase 2.
+
     lane_filter = commitment.lane_filter or {}
     if not lane_filter:
         return True
     if "lane_id" in lane_filter:
         if lane_filter["lane_id"] != item.lane_id:
             return False
-    # Geographic shapes — Phase 2 fail-closed.
-    geo_keys = {"origin_geo_id", "dest_geo_id", "origin_state", "dest_state",
-                "origin_zip3", "dest_zip3"}
-    if any(k in lane_filter for k in geo_keys):
-        return False
+
+    # Phase 3: geographic shapes via resolver.
+    geo_constraints = {k: v for k, v in lane_filter.items() if k in _GEO_KEYS}
+    if geo_constraints:
+        if lane_geo_resolver is None:
+            return False  # Phase 2 fail-closed when no resolver passed
+        meta = lane_geo_resolver.resolve(item.lane_id)
+        if meta is None:
+            return False
+        for key, expected in geo_constraints.items():
+            actual = meta.get(key)
+            if actual is None or actual != expected:
+                return False
     return True
 
 
@@ -170,7 +222,7 @@ class IntegratedBalancerService:
         self,
         *,
         unconstrained_plan_id: int,
-        carrier_capacity: Optional[Dict[int, float]] = None,
+        carrier_capacity: Optional[_CapacityDict] = None,
         resolve_capacity_from_db: bool = False,
         cascade_run_id: Optional[str] = None,
         escalation_penalty: float = _DEFAULT_ESCALATION_PENALTY,
@@ -220,12 +272,12 @@ class IntegratedBalancerService:
 
         # §3.42 — DB-resolved capacity. Runs first so an explicit
         # `carrier_capacity` dict can override specific carriers (test
-        # / what-if pattern). Resolved rows merge with the override:
-        # the override dict takes precedence per carrier_id.
+        # / what-if pattern).
         # Phase 2 (§3.42): pass source_items so commitment rows are
-        # filtered by lane + equipment + mode scope — irrelevant rows
-        # (e.g., REEFER commitments when the plan has no REEFER items)
-        # don't boost the carrier's pool.
+        # filtered by lane + equipment + mode scope.
+        # Phase 3.2 (§3.42): tuple keys (carrier_id, equipment_type)
+        # support per-equipment caps; integer keys still mean carrier-
+        # wide.
         if resolve_capacity_from_db:
             db_capacity = self._resolve_capacity_from_db(
                 tenant_id=source_plan.tenant_id,
@@ -235,14 +287,15 @@ class IntegratedBalancerService:
             )
             if db_capacity:
                 if carrier_capacity is not None:
-                    # Override merge: dict wins per carrier_id
-                    merged = dict(db_capacity)
-                    merged.update(carrier_capacity)
+                    # Override merge in normalised tuple-key space:
+                    # the dict wins per (carrier, equipment) tuple.
+                    merged = _normalize_capacity_dict(db_capacity)
+                    merged.update(_normalize_capacity_dict(carrier_capacity))
                     carrier_capacity = merged
                 else:
                     carrier_capacity = db_capacity
             # If db_capacity is empty AND no dict override → fall through
-            # to the Phase 1 clone path below (no capacity = no LP).
+            # to the Phase 1 clone path below.
 
         # Phase 1 fallback: no capacity → clone-only stub.
         if carrier_capacity is None:
@@ -502,43 +555,47 @@ class IntegratedBalancerService:
         self,
         *,
         items: Sequence[TransportationPlanItem],
-        carrier_capacity: Dict[int, float],
+        carrier_capacity: _CapacityDict,
         escalation_penalty: float,
     ) -> Tuple[Dict[int, int], set, Dict[int, float]]:
         """Solve the transportation LP via ``scipy.optimize.linprog``.
 
+        Phase 3.2 (§3.42): supports per-(carrier × equipment) capacity
+        constraints. Capacity dict keys are normalised to
+        ``(carrier_id, Optional[equipment_type])`` tuples — integer
+        keys (Phase 1 / 2B) become ``(carrier_id, None)`` meaning
+        "carrier-wide cap, any equipment". Per-tuple constraints are
+        added: ``sum_{i: matching equipment} x[i, carrier] ≤
+        capacity[(carrier, equipment)]``. Both per-carrier and per-
+        (carrier, equipment) constraints can coexist; the LP enforces
+        all of them.
+
         Returns ``(assignments, escalated, utilisation)`` where:
 
-        - ``assignments``: ``{item_id: carrier_id}`` for items the LP
-          assigned. Items not in the dict were escalated.
-        - ``escalated``: set of ``item_id`` the LP couldn't fit.
+        - ``assignments``: ``{item_id: carrier_id}``.
+        - ``escalated``: set of ``item_id``.
         - ``utilisation``: ``{carrier_id: utilization_fraction}``
-          post-solve (loads_assigned / capacity).
+          post-solve, computed against the carrier-wide cap or the sum
+          of per-equipment caps when no carrier-wide cap exists.
 
-        Raises ``RuntimeError`` if the LP solver fails (infeasible or
-        numerical issue).
+        Raises ``RuntimeError`` on solver failure.
         """
         from scipy.optimize import linprog
 
         if not items or not carrier_capacity:
             return {}, set(), {}
 
-        carriers = sorted(carrier_capacity.keys())
+        # Normalise to tuple-key shape.
+        normalised = _normalize_capacity_dict(carrier_capacity)
+
+        # Collect distinct carrier IDs from the capacity dict.
+        carriers = sorted({c for (c, _e) in normalised.keys()})
         n_items = len(items)
         n_carriers = len(carriers)
-
         if n_carriers == 0:
             return {}, {item.id for item in items}, {}
 
-        # Cost matrix:
-        #   - cost[i,c] = item.estimated_cost when c == item.carrier_id
-        #     (Phase 2A pick at the original rate).
-        #   - cost[i,c] = item.estimated_cost × 1.5 for fallback carriers
-        #     (Phase 2B simplification: 50% surcharge approximation; Phase
-        #     3 will re-resolve rate cards per fallback carrier).
-        #   - cost[i,c] = ESCALATION_PENALTY × 0.99 (high but below
-        #     escalation) when item has no estimated_cost (Phase 1
-        #     fallback path).
+        # Cost matrix (same Phase 2B logic).
         BIG = escalation_penalty * 0.99
         cost_matrix = np.zeros((n_items, n_carriers))
         for i, item in enumerate(items):
@@ -563,7 +620,7 @@ class IntegratedBalancerService:
         for i in range(n_items):
             c_obj[n_items * n_carriers + i] = escalation_penalty
 
-        # Equality: for each item i, sum_c x[i,c] + e[i] = 1
+        # Equality: per item, sum_c x[i,c] + e[i] = 1.
         A_eq = np.zeros((n_items, n_vars))
         b_eq = np.ones(n_items)
         for i in range(n_items):
@@ -571,13 +628,21 @@ class IntegratedBalancerService:
                 A_eq[i, i * n_carriers + j] = 1
             A_eq[i, n_items * n_carriers + i] = 1
 
-        # Inequality: for each carrier c, sum_i x[i,c] <= capacity[c]
-        A_ub = np.zeros((n_carriers, n_vars))
-        b_ub = np.zeros(n_carriers)
-        for j, carrier_id in enumerate(carriers):
-            for i in range(n_items):
-                A_ub[j, i * n_carriers + j] = 1
-            b_ub[j] = float(carrier_capacity[carrier_id])
+        # Phase 3.2 inequality: one row per (carrier, equipment) tuple.
+        # When equipment_type is None, the row sums all items on that
+        # carrier (carrier-wide cap). When equipment_type is set, the
+        # row sums only items matching that equipment.
+        capacity_keys = sorted(normalised.keys())  # deterministic order
+        n_capacity_constraints = len(capacity_keys)
+        A_ub = np.zeros((n_capacity_constraints, n_vars))
+        b_ub = np.zeros(n_capacity_constraints)
+        carrier_idx_by_id = {c: idx for idx, c in enumerate(carriers)}
+        for k, (carrier_id, equipment_type) in enumerate(capacity_keys):
+            j = carrier_idx_by_id[carrier_id]
+            for i, item in enumerate(items):
+                if equipment_type is None or item.equipment_type == equipment_type:
+                    A_ub[k, i * n_carriers + j] = 1
+            b_ub[k] = float(normalised[(carrier_id, equipment_type)])
 
         bounds = [(0, 1)] * n_vars
 
@@ -593,8 +658,6 @@ class IntegratedBalancerService:
 
         x = result.x
 
-        # Round fractional solutions: each item gets argmax carrier OR
-        # escalation if slack is largest.
         assignments: Dict[int, int] = {}
         escalated: set = set()
         for i, item in enumerate(items):
@@ -606,14 +669,28 @@ class IntegratedBalancerService:
             else:
                 assignments[item.id] = carriers[best_j]
 
+        # Utilisation: compute against carrier-wide cap when present,
+        # else sum per-equipment caps.
         loads_per_carrier: Dict[int, int] = {c: 0 for c in carriers}
         for _, carrier_id in assignments.items():
             loads_per_carrier[carrier_id] += 1
-        utilisation = {
-            c: round(loads_per_carrier[c] / carrier_capacity[c], 4)
-            if carrier_capacity[c] > 0 else 0.0
-            for c in carriers
-        }
+
+        utilisation: Dict[int, float] = {}
+        for carrier_id in carriers:
+            # Prefer the explicit carrier-wide cap if present.
+            cap = normalised.get((carrier_id, None))
+            if cap is None:
+                # Sum per-equipment caps as the carrier's effective cap.
+                cap = sum(
+                    v for (cid, _e), v in normalised.items()
+                    if cid == carrier_id
+                )
+            if cap and cap > 0:
+                utilisation[carrier_id] = round(
+                    loads_per_carrier[carrier_id] / cap, 4,
+                )
+            else:
+                utilisation[carrier_id] = 0.0
 
         return assignments, escalated, utilisation
 
@@ -628,7 +705,7 @@ class IntegratedBalancerService:
         period_start,
         period_end,
         items: Optional[Sequence] = None,
-    ) -> Dict[int, float]:
+    ) -> Dict[Tuple[int, Optional[str]], float]:
         """Build the ``{carrier_id: max_loads}`` dict by querying
         ``CarrierCapacityCommitment`` rows that overlap the plan's
         ``[period_start, period_end]`` window.
@@ -697,28 +774,44 @@ class IntegratedBalancerService:
             .all()
         )
 
-        capacity: Dict[int, float] = {}
+        # Phase 3.2 (§3.42): return per-(carrier_id, equipment_type) keys.
+        # Commitments with `equipment_type IS NULL` contribute to the
+        # carrier-wide cap key `(carrier_id, None)`; equipment-specific
+        # commitments contribute to `(carrier_id, "DRY_VAN")` etc.
+        # The LP enforces all per-tuple constraints.
+        capacity: Dict[Tuple[int, Optional[str]], float] = {}
         for commitment, carrier_id in rows:
             if commitment.effective_to is not None and commitment.effective_to < now:
                 continue
             if carrier_id is None:
                 continue
-            # Phase 2 (§3.42): require at least one plan item to match
-            # the commitment's scope. Without this filter (Phase 1), a
-            # commitment that no item could plausibly use still adds to
-            # the carrier's cap.
+            # Phase 2 (§3.42): scope filter.
             if items is not None and not self._capacity_filter_matches(
                 commitment, items,
             ):
                 continue
-            volume = float(commitment.commit_volume)
-            capacity[carrier_id] = capacity.get(carrier_id, 0.0) + volume
+            # Phase 3.3 (§3.42): prorate by period overlap. A WEEKLY
+            # commitment that spans Q2 (13 weeks) only contributes
+            # ~1/13 of its commit_volume to a single-week plan window.
+            volume = self._prorate_commitment_volume(
+                commitment, period_start, period_end,
+            )
+            key = (carrier_id, commitment.equipment_type)
+            capacity[key] = capacity.get(key, 0.0) + volume
 
+        # Phase 1 backward-compat: when the caller doesn't pass items,
+        # collapse equipment-specific keys to carrier-wide totals so
+        # legacy callers see the simple Dict[int, float] shape.
+        if items is None:
+            collapsed: Dict[Tuple[int, Optional[str]], float] = {}
+            for (carrier_id, _equipment), volume in capacity.items():
+                key = (carrier_id, None)
+                collapsed[key] = collapsed.get(key, 0.0) + volume
+            return collapsed
         return capacity
 
-    @staticmethod
-    def _capacity_filter_matches(commitment, items: Sequence) -> bool:
-        """Phase 2 (§3.42) capacity-filter matcher.
+    def _capacity_filter_matches(self, commitment, items: Sequence) -> bool:
+        """Phase 2+3 (§3.42) capacity-filter matcher.
 
         Returns ``True`` if at least one item in ``items`` matches the
         commitment's ``lane_filter`` + ``equipment_type`` + ``mode``
@@ -728,21 +821,66 @@ class IntegratedBalancerService:
         Rules (per item, AND-combined):
 
         - **lane_filter**: empty dict matches all; ``{"lane_id": <id>}``
-          matches when ``item.lane_id`` equals it. Geographic shapes
-          (``origin_state``, ``origin_zip3``, ``origin_geo_id``, etc.)
-          are not supported in Phase 2 — they fail-closed (don't match).
-          Phase 3 will resolve them via ``MovementPlannerService.
-          _resolve_lane_geography``.
-        - **equipment_type**: ``None`` matches any equipment; otherwise
-          must equal ``item.equipment_type``.
-        - **mode**: ``None`` matches any mode; otherwise must equal
+          matches when ``item.lane_id`` equals it. **Phase 3 (§3.42):**
+          geographic shapes (``origin_state``, ``origin_zip3``,
+          ``origin_geo_id``, ``dest_*``) resolved via the shared
+          :class:`LaneGeographyResolver`.
+        - **equipment_type**: ``None`` matches any; otherwise must
+          equal ``item.equipment_type``.
+        - **mode**: ``None`` matches any; otherwise must equal
           ``item.mode``.
         """
+        if not hasattr(self, "_lane_geo_resolver"):
+            from app.services.powell.lane_geography import LaneGeographyResolver
+            self._lane_geo_resolver = LaneGeographyResolver(self.db)
         for item in items:
-            if not _commitment_matches_item(commitment, item):
+            if not _commitment_matches_item(
+                commitment, item,
+                lane_geo_resolver=self._lane_geo_resolver,
+            ):
                 continue
             return True
         return False
+
+
+    @staticmethod
+    def _prorate_commitment_volume(commitment, plan_start, plan_end) -> float:
+        """Phase 3.3 (§3.42): prorate ``commit_volume`` by the fraction
+        of the commitment's period that overlaps the plan window.
+
+        Granularity-specific behaviour:
+
+        - **FLAT**: total ``commit_volume`` applies to the whole period
+          regardless of plan-window overlap. Returns full volume; no
+          proration.
+        - **WEEKLY / MONTHLY / QUARTERLY**: prorate by overlap-day-
+          fraction. A WEEKLY commitment over Q2 (91 days) overlapping
+          a 7-day plan contributes ``commit_volume × 7 / 91`` to the
+          resolved cap.
+
+        ``plan_start`` / ``plan_end`` are inclusive dates from
+        ``TransportationPlan``.
+        """
+        from datetime import date as _date, timedelta as _timedelta
+
+        full_volume = float(commitment.commit_volume)
+
+        granularity = (commitment.period_granularity or "WEEKLY").upper()
+        if granularity == "FLAT":
+            return full_volume
+
+        # Compute overlap in days (inclusive bounds).
+        overlap_start = max(commitment.period_start, plan_start)
+        overlap_end = min(commitment.period_end, plan_end)
+        if overlap_end < overlap_start:
+            return 0.0  # no overlap (defensive — caller already filtered)
+        overlap_days = (overlap_end - overlap_start).days + 1
+
+        commitment_days = (commitment.period_end - commitment.period_start).days + 1
+        if commitment_days <= 0:
+            return full_volume  # defensive: degenerate period
+        ratio = overlap_days / commitment_days
+        return round(full_volume * ratio, 4)
 
 
 __all__ = [

--- a/backend/app/services/powell/lane_geography.py
+++ b/backend/app/services/powell/lane_geography.py
@@ -1,0 +1,112 @@
+"""Shared lane-geography resolver — §3.42 Phase 3.
+
+Extracted from ``MovementPlannerService`` so that
+``IntegratedBalancerService._capacity_filter_matches`` (and any other
+service that needs to match `lane_filter` JSONB shapes) can reuse the
+same resolution logic.
+
+Walks ``TransportationLane → Site → Geography`` to extract per-lane
+metadata (``origin_geo_id``, ``origin_state``, ``origin_zip3``, dest
+counterparts, plus ``mode`` from TMS-side ``LaneProfile``). Each
+resolver instance caches per-lane (so N items on the same lane share
+one DB roundtrip).
+
+The cache is per-instance (not module-global) because tests + services
+need isolated caches across runs.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+
+class LaneGeographyResolver:
+    """Per-instance cached resolver of lane → geographic metadata.
+
+    Use one instance per service-call so the cache scopes to the call.
+    Pass to ``_capacity_filter_matches`` etc. as a callable that maps
+    ``lane_id → metadata dict | None``.
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+        self._cache: dict = {}
+
+    def resolve(self, lane_id: int) -> Optional[dict]:
+        """Resolve a lane's geography. Returns ``{origin_geo_id,
+        dest_geo_id, origin_state, dest_state, origin_zip3, dest_zip3,
+        mode}`` (any subset, depending on what's in the DB) or ``None``
+        when the lookup chain breaks.
+        """
+        cache_key = ("lane_geography", lane_id)
+        if cache_key in self._cache:
+            cached = self._cache[cache_key]
+            return cached if cached != "MISS" else None
+
+        try:
+            from azirella_data_model.master.config import TransportationLane
+        except ImportError:
+            self._cache[cache_key] = "MISS"
+            return None
+
+        lane = self.db.query(TransportationLane).filter_by(id=lane_id).first()
+        if lane is None:
+            self._cache[cache_key] = "MISS"
+            return None
+
+        meta: dict = {}
+
+        # Mode via TMS-side LaneProfile (more accurate than transportation_lane).
+        try:
+            from app.models.transportation_config import LaneProfile
+            profile = (
+                self.db.query(LaneProfile)
+                .filter_by(lane_id=lane_id).first()
+            )
+            if profile is not None and profile.primary_mode:
+                meta["mode"] = profile.primary_mode
+        except Exception:
+            pass
+
+        # Origin / destination via Site → Geography.
+        for endpoint, prefix in (
+            (getattr(lane, "from_site_id", None), "origin"),
+            (getattr(lane, "to_site_id", None), "dest"),
+        ):
+            if endpoint is None:
+                continue
+            try:
+                from azirella_data_model.master.entities import Geography
+                from azirella_data_model.master.config import Site
+
+                site = self.db.query(Site).filter_by(id=endpoint).first()
+                if site is None:
+                    continue
+                geo_id = getattr(site, "geography_id", None)
+                if geo_id is not None:
+                    meta[f"{prefix}_geo_id"] = geo_id
+                    geo = (
+                        self.db.query(Geography).filter_by(id=geo_id).first()
+                    )
+                    if geo is not None:
+                        for attr in ("state", "region", "country"):
+                            val = getattr(geo, attr, None)
+                            if val:
+                                meta[f"{prefix}_state"] = val
+                                break
+                        postal = (
+                            getattr(geo, "postal_code", None)
+                            or getattr(site, "postal_code", None)
+                        )
+                        if postal:
+                            meta[f"{prefix}_zip3"] = str(postal)[:3]
+            except Exception:
+                continue
+
+        result = meta if meta else "MISS"
+        self._cache[cache_key] = result
+        return meta if meta else None
+
+
+__all__ = ["LaneGeographyResolver"]

--- a/backend/app/services/powell/movement_planner_service.py
+++ b/backend/app/services/powell/movement_planner_service.py
@@ -595,8 +595,7 @@ class MovementPlannerService:
 
         meta = self._resolve_lane_geography(lane_id)
         if meta is None:
-            # Couldn't resolve — fail-closed (don't match).
-            return False
+            return False  # fail-closed
 
         for key, expected in lane_filter.items():
             if key == "lane_id":
@@ -607,83 +606,16 @@ class MovementPlannerService:
         return True
 
     def _resolve_lane_geography(self, lane_id: int) -> Optional[dict]:
-        """Resolve geographic metadata for a lane.
+        """Resolve geographic metadata for a lane via shared resolver.
 
-        Returns ``{origin_geo_id, dest_geo_id, origin_state, dest_state,
-        origin_zip3, dest_zip3, mode}`` or ``None`` when the lookup
-        chain breaks. Caches per-lane (per-service-instance) so that
-        N items on the same lane share one DB roundtrip.
+        Delegates to :class:`LaneGeographyResolver` (extracted to a
+        sibling module in §3.42 Phase 3 so `IntegratedBalancerService`
+        can reuse the same logic).
         """
-        cache_key = ("lane_geography", lane_id)
-        cached = getattr(self, "_lane_geo_cache", {}).get(cache_key)
-        if cached is not None:
-            return cached if cached != "MISS" else None
-
-        if not hasattr(self, "_lane_geo_cache"):
-            self._lane_geo_cache = {}
-
-        try:
-            from azirella_data_model.master.config import TransportationLane
-        except ImportError:
-            self._lane_geo_cache[cache_key] = "MISS"
-            return None
-
-        lane = self.db.query(TransportationLane).filter_by(id=lane_id).first()
-        if lane is None:
-            self._lane_geo_cache[cache_key] = "MISS"
-            return None
-
-        meta: dict = {}
-
-        # Mode lookup via TMS-side LaneProfile (more accurate than
-        # transportation_lane).
-        try:
-            from app.models.transportation_config import LaneProfile
-            profile = (
-                self.db.query(LaneProfile)
-                .filter_by(lane_id=lane_id).first()
-            )
-            if profile is not None and profile.primary_mode:
-                meta["mode"] = profile.primary_mode
-        except Exception:
-            pass
-
-        # Origin / destination geography via Site → Geography.
-        for endpoint, prefix in (
-            (getattr(lane, "from_site_id", None), "origin"),
-            (getattr(lane, "to_site_id", None), "dest"),
-        ):
-            if endpoint is None:
-                continue
-            try:
-                from azirella_data_model.master.entities import Geography
-                from azirella_data_model.master.config import Site
-
-                site = self.db.query(Site).filter_by(id=endpoint).first()
-                if site is None:
-                    continue
-                geo_id = getattr(site, "geography_id", None)
-                if geo_id is not None:
-                    meta[f"{prefix}_geo_id"] = geo_id
-                    geo = self.db.query(Geography).filter_by(id=geo_id).first()
-                    if geo is not None:
-                        # State / region / postal_code — names vary by
-                        # AWS SC DM; check available attributes.
-                        for attr in ("state", "region", "country"):
-                            val = getattr(geo, attr, None)
-                            if val:
-                                meta[f"{prefix}_state"] = val
-                                break
-                        postal = getattr(geo, "postal_code", None) or getattr(site, "postal_code", None)
-                        if postal:
-                            zip3 = str(postal)[:3]
-                            meta[f"{prefix}_zip3"] = zip3
-            except Exception:
-                continue
-
-        result = meta if meta else "MISS"
-        self._lane_geo_cache[cache_key] = result
-        return meta if meta else None
+        if not hasattr(self, "_lane_geo_resolver"):
+            from app.services.powell.lane_geography import LaneGeographyResolver
+            self._lane_geo_resolver = LaneGeographyResolver(self.db)
+        return self._lane_geo_resolver.resolve(lane_id)
 
     @staticmethod
     def _estimate_card_cost(

--- a/backend/app/services/powell/movement_planner_trainer.py
+++ b/backend/app/services/powell/movement_planner_trainer.py
@@ -1,0 +1,327 @@
+"""§3.41 Phase 3.3 — Training pipeline orchestrator for the GraphSAGE
+Movement Planner.
+
+Wires the Phase 3.1 :class:`MovementPlannerTrainingDataExtractor`
+output into the Phase 3.2 :class:`TorchGraphSAGEMovementPlanner.fit`
+training method.
+
+Responsibilities:
+
+1. **Extract**: pull historical training examples for a tenant and
+   period window via the ETL.
+2. **Transform**: group examples by plan, build per-plan node + edge
+   tensors, and pair them with observed-cost labels.
+3. **Train / validate**: split into train + held-out validation, run
+   ``fit()``, log loss curves.
+4. **Checkpoint**: stash the trained model + version under a
+   ``training_run_id`` so consumers can audit which model produced
+   which plan.
+
+Phase 3.3 ships the orchestrator's **shape**. Production training
+(Phase 3.5) will run on GPU with proper minibatching, hyperparameter
+search, and held-out test-set evaluation. Phase 3.3 does single-pass
+SGD on the full extracted dataset — useful for smoke tests and
+small-tenant prototyping but not production-grade.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.services.powell.graphsage_movement_planner import (
+    GraphSAGEPredictionInput,
+    TorchGraphSAGEMovementPlanner,
+)
+from app.services.powell.movement_planner_training_data import (
+    MovementPlannerTrainingDataExtractor,
+    MovementPlannerTrainingExample,
+)
+
+
+@dataclass(frozen=True)
+class TrainingRunResult:
+    """Per-run summary."""
+
+    training_run_id: str
+    """Unique identifier for this run (timestamp + tenant_id)."""
+
+    model_version: str
+    """The trained model's version stamp (Phase 3.2 emits a version
+    based on training-step count + final loss; Phase 3.5 will use a
+    proper checkpoint hash)."""
+
+    examples_extracted: int
+    """Total training examples pulled from the ETL."""
+
+    examples_used: int
+    """Examples that survived the training-eligibility filter (have
+    observed-cost OR planner-estimated-cost label)."""
+
+    train_loss_history: List[float] = field(default_factory=list)
+    val_loss: Optional[float] = None
+    """Held-out validation loss (Phase 3.3 computes a basic 80/20
+    split; Phase 3.5 will use proper time-based splits)."""
+
+    extraction_period_start: Optional[date] = None
+    extraction_period_end: Optional[date] = None
+
+
+class MovementPlannerTrainer:
+    """Orchestrates a training run for the GraphSAGE Movement Planner.
+
+    Usage::
+
+        trainer = MovementPlannerTrainer(db)
+        result = trainer.train(
+            tenant_id=42,
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 5, 1),
+        )
+        print(f"trained model version: {result.model_version}")
+        # Hand the trained model off to inference (Phase 3.4).
+
+    Phase 3.3 produces a single in-memory model. Phase 3.5 will
+    persist to a checkpoint store and attach the model to a
+    ``training_run`` row in Core's `powell_training_config` substrate.
+    """
+
+    DEFAULT_VAL_SPLIT = 0.2
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def train(
+        self,
+        *,
+        tenant_id: int,
+        period_start: Optional[date] = None,
+        period_end: Optional[date] = None,
+        only_completed: bool = False,
+        learning_rate: float = TorchGraphSAGEMovementPlanner.DEFAULT_LR,
+        val_split: float = DEFAULT_VAL_SPLIT,
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> TrainingRunResult:
+        """Run an end-to-end training pass.
+
+        - Extracts examples for the tenant + period window.
+        - Splits into train + validation (random 80/20 by default;
+          Phase 3.5 switches to time-based splits).
+        - Builds per-plan graph tensors via
+          :meth:`_examples_to_training_batches`.
+        - Runs ``model.fit(training_batches)``.
+        - Computes held-out validation MSE.
+        - Returns a :class:`TrainingRunResult` with the trained model
+          and run metadata.
+
+        Caller commits any DB state. Phase 3.3 does not write to DB —
+        production training (Phase 3.5) will persist a
+        ``training_run`` row.
+        """
+        extractor = MovementPlannerTrainingDataExtractor(self.db)
+        all_examples: List[MovementPlannerTrainingExample] = list(
+            extractor.extract(
+                tenant_id=tenant_id,
+                period_start_min=period_start,
+                period_start_max=period_end,
+                only_completed=only_completed,
+            )
+        )
+        examples_extracted = len(all_examples)
+
+        # Filter: need at least one cost label to train against.
+        eligible = [
+            ex for ex in all_examples
+            if ex.observed_total_cost is not None
+            or ex.action_estimated_cost is not None
+        ]
+        examples_used = len(eligible)
+
+        # Train / val split.
+        if val_split > 0 and examples_used >= 10:
+            split_idx = int(examples_used * (1 - val_split))
+            train_examples = eligible[:split_idx]
+            val_examples = eligible[split_idx:]
+        else:
+            train_examples = eligible
+            val_examples = []
+
+        # Build the model.
+        kwargs = dict(model_kwargs or {})
+        kwargs.setdefault("learning_rate", learning_rate)
+        model = TorchGraphSAGEMovementPlanner(**kwargs)
+
+        # Convert examples to per-plan training batches.
+        train_batches = self._examples_to_training_batches(train_examples)
+
+        if train_batches:
+            model.fit(train_batches)
+
+        # Held-out val loss (basic; Phase 3.5 adds proper metrics).
+        val_loss: Optional[float] = None
+        if val_examples and model._model is not None:
+            val_loss = self._compute_val_loss(model, val_examples)
+
+        run_id = (
+            f"trainer_{tenant_id}_"
+            f"{datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')}"
+        )
+
+        return TrainingRunResult(
+            training_run_id=run_id,
+            model_version=model.model_version(),
+            examples_extracted=examples_extracted,
+            examples_used=examples_used,
+            train_loss_history=model._loss_history,
+            val_loss=val_loss,
+            extraction_period_start=period_start,
+            extraction_period_end=period_end,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _examples_to_training_batches(
+        self, examples: List[MovementPlannerTrainingExample],
+    ) -> List[Dict[str, Any]]:
+        """Group examples by ``plan_id`` and build one training-batch
+        dict per plan.
+
+        Each dict has the shape ``TorchGraphSAGEMovementPlanner.fit()``
+        expects: ``node_features`` / ``edge_index`` / ``edge_attr`` /
+        ``item_carrier_pairs`` / ``observed_costs``.
+
+        Phase 3.3 simplification: each plan = one batch (single forward
+        pass per plan during fit). Production training (Phase 3.5) uses
+        proper minibatch sampling across plans.
+        """
+        from collections import defaultdict
+
+        try:
+            import torch
+        except ImportError:
+            return []
+
+        by_plan: Dict[int, List[MovementPlannerTrainingExample]] = defaultdict(list)
+        for ex in examples:
+            by_plan[ex.plan_id].append(ex)
+
+        batches: List[Dict[str, Any]] = []
+        for plan_id, plan_examples in by_plan.items():
+            # Distinct item-nodes + carrier-nodes for this plan.
+            item_ids = sorted({ex.item_id for ex in plan_examples})
+            carrier_ids = sorted({ex.action_carrier_id for ex in plan_examples})
+            n_items = len(item_ids)
+            n_carriers = len(carrier_ids)
+            if n_items == 0 or n_carriers == 0:
+                continue
+
+            item_idx_by_id = {iid: i for i, iid in enumerate(item_ids)}
+            carrier_idx_by_id = {
+                cid: n_items + j for j, cid in enumerate(carrier_ids)
+            }
+
+            # Node features (4-dim, matches inference shape):
+            # (loads_p50_proxy, mode_idx, equipment_idx, is_item).
+            node_features = torch.zeros((n_items + n_carriers, 4))
+            for ex in plan_examples:
+                idx = item_idx_by_id[ex.item_id]
+                node_features[idx, 0] = 1.0  # placeholder for per-item loads
+                node_features[idx, 1] = TorchGraphSAGEMovementPlanner._mode_to_idx(ex.mode)
+                node_features[idx, 2] = TorchGraphSAGEMovementPlanner._equipment_to_idx(
+                    ex.equipment_type,
+                )
+                node_features[idx, 3] = 1.0  # is_item
+
+            # Edges: (item, carrier) pair the example labels with.
+            # Plus reverse edges for SAGEConv symmetry.
+            n_pairs = len(plan_examples)
+            edge_index = torch.zeros((2, n_pairs * 2), dtype=torch.long)
+            edge_attr = torch.zeros((n_pairs * 2, 3))
+            item_carrier_pairs = []
+            observed_costs = []
+            for k, ex in enumerate(plan_examples):
+                i = item_idx_by_id[ex.item_id]
+                c = carrier_idx_by_id[ex.action_carrier_id]
+                edge_index[0, 2 * k] = i
+                edge_index[1, 2 * k] = c
+                edge_index[0, 2 * k + 1] = c
+                edge_index[1, 2 * k + 1] = i
+                # Edge feature: (base_rate, distance_miles, _pad)
+                rc_meta = ex.rate_card_metadata or {}
+                edge_attr[2 * k, 0] = float(rc_meta.get("base_rate") or 0)
+                edge_attr[2 * k, 1] = ex.distance_miles or 0.0
+                edge_attr[2 * k + 1, 0] = float(rc_meta.get("base_rate") or 0)
+                edge_attr[2 * k + 1, 1] = ex.distance_miles or 0.0
+                item_carrier_pairs.append((i, c))
+                # Use observed cost if present, else the planner's
+                # estimate as a fallback label.
+                cost_label = (
+                    ex.observed_total_cost
+                    if ex.observed_total_cost is not None
+                    else (ex.action_estimated_cost or 0.0)
+                )
+                observed_costs.append(float(cost_label))
+
+            batches.append({
+                "node_features": node_features,
+                "edge_index": edge_index,
+                "edge_attr": edge_attr,
+                "item_carrier_pairs": item_carrier_pairs,
+                "observed_costs": observed_costs,
+            })
+        return batches
+
+    def _compute_val_loss(
+        self,
+        model: TorchGraphSAGEMovementPlanner,
+        val_examples: List[MovementPlannerTrainingExample],
+    ) -> float:
+        """Held-out MSE. Phase 3.5 will replace this with proper
+        held-out metrics (MAPE, mode-split accuracy, plan-utilisation
+        regression)."""
+        try:
+            import torch
+        except ImportError:
+            return float("nan")
+
+        batches = self._examples_to_training_batches(val_examples)
+        if not batches:
+            return float("nan")
+
+        total_loss = 0.0
+        n_batches = 0
+        device = next(model._model.parameters()).device
+        model._model.eval()
+        with torch.no_grad():
+            for batch in batches:
+                x = batch["node_features"].to(device)
+                edge_index = batch["edge_index"].to(device)
+                edge_attr = batch["edge_attr"].to(device)
+                pairs = batch["item_carrier_pairs"]
+                item_idx = torch.tensor(
+                    [p[0] for p in pairs], dtype=torch.long, device=device,
+                )
+                carrier_idx = torch.tensor(
+                    [p[1] for p in pairs], dtype=torch.long, device=device,
+                )
+                observed = torch.tensor(
+                    batch["observed_costs"], dtype=torch.float32, device=device,
+                )
+                pred = model._model(
+                    x, edge_index, edge_attr, item_idx, carrier_idx,
+                ).squeeze(-1)
+                total_loss += float(
+                    torch.nn.functional.mse_loss(pred, observed).item()
+                )
+                n_batches += 1
+        return total_loss / n_batches if n_batches > 0 else float("nan")
+
+
+__all__ = [
+    "MovementPlannerTrainer",
+    "TrainingRunResult",
+]

--- a/backend/app/services/powell/movement_planner_training_data.py
+++ b/backend/app/services/powell/movement_planner_training_data.py
@@ -1,0 +1,285 @@
+"""§3.41 Phase 3.1 — Training data ETL for the GraphSAGE Movement Planner.
+
+Walks historical ``TransportationPlanItem`` rows joined with
+``FreightCharge`` actuals + ``RateCard`` snapshots and emits
+``MovementPlannerTrainingExample`` tuples suitable for supervised
+training of the Phase 3.2 GraphSAGE model.
+
+## Training-target shape
+
+Each example is a (state, action, observed_outcome) tuple:
+
+- **state**: lane + period + mode + equipment + forecast volume +
+  rate-card features (base_rate, rate_basis) + lane geography (origin/
+  dest geo, distance) + carrier metadata (status, contract type).
+- **action**: which carrier was assigned (one of N candidates).
+- **observed_outcome**: actual freight charge total + actual delivery
+  on-time? (when ``FreightCharge`` row exists; otherwise NULL).
+
+Phase 3.2 trains a GNN to predict the action (carrier choice) that
+minimises observed cost while respecting capacity constraints.
+
+## Training-set construction
+
+The extractor walks ``TransportationPlanItem`` rows where:
+
+1. ``status`` is ``CONFIRMED`` or ``COMPLETED`` (Phase 2A planner
+   ran + the load actually shipped).
+2. ``carrier_id IS NOT NULL`` (we have a labeled action).
+3. ``estimated_cost IS NOT NULL`` (we have at least the planner's
+   cost prediction; observed cost via ``FreightCharge`` join is
+   optional but preferred).
+4. The plan's ``period_start`` is in the requested window.
+
+Per-tenant scoping is mandatory. Cross-tenant model training is a
+separate workstream (per CLAUDE.md tenant-isolation requirements).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any, Dict, Iterator, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.tms_planning import (
+    PlanStatus,
+    PlanItemStatus,
+    TransportationPlan,
+    TransportationPlanItem,
+)
+
+
+@dataclass(frozen=True)
+class MovementPlannerTrainingExample:
+    """One (state, action, outcome) tuple for the GraphSAGE Movement
+    Planner. Phase 3.2 will batch these into mini-batches and feed
+    them into the GNN's training loop.
+    """
+
+    # State features (input to the GNN)
+    tenant_id: int
+    plan_id: int
+    item_id: int
+    lane_id: int
+    period_start: date
+    period_days: int
+    mode: str
+    equipment_type: Optional[str]
+    distance_miles: Optional[float]
+
+    # Action — the carrier the planner picked at runtime
+    action_carrier_id: int
+    action_rate_id: Optional[int]
+    action_estimated_cost: Optional[float]
+
+    # Observed outcome (labels for supervised training)
+    observed_total_cost: Optional[float]
+    """From ``FreightCharge.total_amount`` when the load is invoiced;
+    ``None`` for items still in transit or unbilled."""
+
+    observed_on_time: Optional[bool]
+    """``True`` when ``planned_delivery_date >= actual_delivery_date``
+    (when present); ``None`` when no actual recorded."""
+
+    # Carrier-level context (sparse; resolved at training time when
+    # the trainer needs it for graph node features)
+    carrier_metadata: Dict[str, Any] = field(default_factory=dict)
+    """Sparse dict of carrier facts at planning time: SCAC, type,
+    status. Resolved lazily so the extractor doesn't re-query the
+    same Carrier row for every item."""
+
+    rate_card_metadata: Dict[str, Any] = field(default_factory=dict)
+    """Rate-card snapshot: base_rate, rate_basis, lane_filter,
+    effective_window."""
+
+
+class MovementPlannerTrainingDataExtractor:
+    """ETL service that yields training examples from historical
+    ``TransportationPlanItem`` rows.
+
+    Design notes:
+
+    - **Streaming via generator**: ``extract()`` returns an iterator,
+      not a list, so callers can stream into a training loop without
+      loading the whole tenant history into memory.
+    - **Tenant-scoped**: cross-tenant training is a separate workstream
+      with its own privacy / compliance review. ``extract()`` requires
+      ``tenant_id``.
+    - **Per-call carrier / rate-card cache**: the extractor caches
+      ``Carrier`` + ``RateCard`` lookups across items to avoid N+1
+      queries when the same rate card appears across many items.
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+        self._carrier_cache: Dict[int, Dict[str, Any]] = {}
+        self._rate_card_cache: Dict[int, Dict[str, Any]] = {}
+
+    def extract(
+        self,
+        *,
+        tenant_id: int,
+        period_start_min: Optional[date] = None,
+        period_start_max: Optional[date] = None,
+        only_completed: bool = False,
+    ) -> Iterator[MovementPlannerTrainingExample]:
+        """Yield training examples for the given tenant.
+
+        Filters:
+
+        - ``period_start_min`` / ``period_start_max``: restrict to
+          plans whose ``plan_start_date`` falls in this window.
+        - ``only_completed``: when True, only items with status
+          ``COMPLETED`` (the load actually delivered) are included.
+          When False (default), ``CONFIRMED`` items are also yielded —
+          useful for in-flight monitoring or partial-history training.
+        """
+        query = (
+            self.db.query(TransportationPlanItem, TransportationPlan)
+            .join(
+                TransportationPlan,
+                TransportationPlan.id == TransportationPlanItem.plan_id,
+            )
+            .filter(
+                TransportationPlan.tenant_id == tenant_id,
+                TransportationPlanItem.carrier_id.isnot(None),
+                TransportationPlanItem.estimated_cost.isnot(None),
+            )
+        )
+
+        if only_completed:
+            query = query.filter(
+                TransportationPlanItem.status == PlanItemStatus.COMPLETED,
+            )
+        else:
+            query = query.filter(
+                TransportationPlanItem.status.in_([
+                    PlanItemStatus.CONFIRMED,
+                    PlanItemStatus.IN_EXECUTION,
+                    PlanItemStatus.COMPLETED,
+                ]),
+            )
+
+        if period_start_min is not None:
+            query = query.filter(
+                TransportationPlan.plan_start_date >= period_start_min,
+            )
+        if period_start_max is not None:
+            query = query.filter(
+                TransportationPlan.plan_start_date <= period_start_max,
+            )
+
+        for item, plan in query.yield_per(500):
+            yield self._build_example(item, plan)
+
+    def _build_example(
+        self, item: TransportationPlanItem, plan: TransportationPlan,
+    ) -> MovementPlannerTrainingExample:
+        carrier_metadata = (
+            self._carrier_facts(item.carrier_id) if item.carrier_id else {}
+        )
+        rate_card_metadata = (
+            self._rate_card_facts(item.rate_id) if item.rate_id else {}
+        )
+
+        observed_cost = self._observed_cost_for_item(item)
+        observed_on_time = self._observed_on_time_for_item(item)
+
+        return MovementPlannerTrainingExample(
+            tenant_id=item.tenant_id,
+            plan_id=item.plan_id,
+            item_id=item.id,
+            lane_id=item.lane_id or 0,
+            period_start=plan.plan_start_date,
+            period_days=plan.planning_horizon_days or 7,
+            mode=item.mode,
+            equipment_type=item.equipment_type,
+            distance_miles=(
+                float(item.distance_miles) if item.distance_miles else None
+            ),
+            action_carrier_id=int(item.carrier_id),
+            action_rate_id=item.rate_id,
+            action_estimated_cost=(
+                float(item.estimated_cost) if item.estimated_cost else None
+            ),
+            observed_total_cost=observed_cost,
+            observed_on_time=observed_on_time,
+            carrier_metadata=carrier_metadata,
+            rate_card_metadata=rate_card_metadata,
+        )
+
+    def _carrier_facts(self, carrier_id: int) -> Dict[str, Any]:
+        if carrier_id in self._carrier_cache:
+            return self._carrier_cache[carrier_id]
+        try:
+            from azirella_data_model.settlement import Carrier
+        except ImportError:
+            self._carrier_cache[carrier_id] = {}
+            return {}
+
+        carrier = self.db.query(Carrier).filter_by(id=carrier_id).first()
+        if carrier is None:
+            self._carrier_cache[carrier_id] = {}
+            return {}
+        facts = {
+            "scac": carrier.scac,
+            "carrier_type": carrier.carrier_type,
+            "status": carrier.status,
+        }
+        self._carrier_cache[carrier_id] = facts
+        return facts
+
+    def _rate_card_facts(self, rate_id: int) -> Dict[str, Any]:
+        if rate_id in self._rate_card_cache:
+            return self._rate_card_cache[rate_id]
+        try:
+            from azirella_data_model.settlement import RateCard
+        except ImportError:
+            self._rate_card_cache[rate_id] = {}
+            return {}
+
+        card = self.db.query(RateCard).filter_by(id=rate_id).first()
+        if card is None:
+            self._rate_card_cache[rate_id] = {}
+            return {}
+        facts = {
+            "rate_basis": card.rate_basis,
+            "base_rate": float(card.base_rate),
+            "lane_filter": card.lane_filter,
+            "currency": card.currency,
+            "effective_from": card.effective_from,
+            "effective_to": card.effective_to,
+        }
+        self._rate_card_cache[rate_id] = facts
+        return facts
+
+    def _observed_cost_for_item(
+        self, item: TransportationPlanItem,
+    ) -> Optional[float]:
+        """Look up the observed ``FreightCharge.total_amount`` for an
+        item, when present. Phase 3.1 simplification: the join key is
+        a TBD `plan_item_id` column on FreightCharge (not yet on the
+        schema). For now, return None — Phase 3 follow-on will wire
+        the join once the schema lands."""
+        # TODO Phase 3 follow-on: add plan_item_id FK on FreightCharge
+        # (or use a derived join via load_id when the load actually
+        # ships). For Phase 3.1 the action_estimated_cost is the only
+        # cost label available.
+        return None
+
+    def _observed_on_time_for_item(
+        self, item: TransportationPlanItem,
+    ) -> Optional[bool]:
+        """Look up actual delivery date vs planned. Phase 3.1
+        simplification: actual delivery is on the ``Load`` table when
+        the item ships; we'd join via ``item.load_id`` when present.
+        Without that wiring, return None."""
+        # TODO Phase 3 follow-on: join via load_id → actual_delivery_date.
+        return None
+
+
+__all__ = [
+    "MovementPlannerTrainingDataExtractor",
+    "MovementPlannerTrainingExample",
+]

--- a/backend/tests/powell/test_l3_planning_services.py
+++ b/backend/tests/powell/test_l3_planning_services.py
@@ -1145,6 +1145,202 @@ def test_phase_3_42_p2_mode_filter(db) -> None:
     assert result.optimization_method == "CLONE_PHASE_1"
 
 
+# ===========================================================================
+# §3.42 Phase 3 — per-(carrier × equipment) LP + prorating + geographic filters
+# ===========================================================================
+
+
+def test_phase_3_42_p3_per_equipment_lp_constraint(db) -> None:
+    """§3.42 Phase 3.2: per-(carrier × equipment) LP constraints.
+    Single carrier with DRY_VAN cap=4 + REEFER cap=10. Plan: 6 DRY_VAN
+    + 2 REEFER. Phase 3.2 fits 4 DRY_VAN + 2 REEFER, escalates 2
+    DRY_VAN. Phase 1 would have summed 14 and fitted all 8."""
+    from datetime import datetime
+    from azirella_data_model.settlement import (
+        Carrier, Contract, RateCard, CarrierCapacityCommitment,
+    )
+
+    db.add(Carrier(id=1, tenant_id=1, scac="C1", display_name="C1", carrier_type="TRUCKLOAD"))
+    db.flush()
+    db.add(Contract(id=1, tenant_id=1, carrier_id=1, contract_number="C1",
+        contract_type="PRIMARY", effective_from=datetime(2026, 1, 1), currency="USD"))
+    db.flush()
+    db.add(RateCard(id=1, tenant_id=1, contract_id=1, lane_filter={},
+        equipment_type="DRY_VAN", rate_basis="PER_MILE", base_rate=2.50,
+        effective_from=datetime(2026, 1, 1)))
+    db.add(RateCard(id=2, tenant_id=1, contract_id=1, lane_filter={},
+        equipment_type="REEFER", rate_basis="PER_MILE", base_rate=3.00,
+        effective_from=datetime(2026, 1, 1)))
+    db.flush()
+    db.add(CarrierCapacityCommitment(
+        tenant_id=1, contract_id=1, lane_filter={}, equipment_type="DRY_VAN",
+        period_start=date(2026, 5, 4), period_end=date(2026, 5, 10),
+        period_granularity="WEEKLY", commit_volume=4, currency="USD",
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.add(CarrierCapacityCommitment(
+        tenant_id=1, contract_id=1, lane_filter={}, equipment_type="REEFER",
+        period_start=date(2026, 5, 4), period_end=date(2026, 5, 10),
+        period_granularity="WEEKLY", commit_volume=10, currency="USD",
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.flush()
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=6)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="REEFER", forecast_loads_p50=2)
+
+    plan_id = MovementPlannerService(db).plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4)).plan_id
+    result = IntegratedBalancerService(db).balance_plan(
+        unconstrained_plan_id=plan_id, resolve_capacity_from_db=True)
+
+    items = db.query(TransportationPlanItem).filter_by(plan_id=result.constrained_plan_id).all()
+    cancelled = [i for i in items if i.status == PlanItemStatus.CANCELLED]
+    assert result.items_escalated == 2
+    # All escalated items should be DRY_VAN (DRY_VAN cap was tight)
+    cancelled_dv = sum(1 for i in cancelled if i.equipment_type == "DRY_VAN")
+    assert cancelled_dv == 2
+
+
+def test_phase_3_42_p3_prorating_weekly_over_quarter(db) -> None:
+    """§3.42 Phase 3.3: a WEEKLY commitment over Q2 (91 days) prorates
+    to ~7/91 of its volume for a 7-day plan. 100 commit_volume → ~7.69
+    effective cap → only 7 of 10 items fit."""
+    from datetime import datetime
+    from azirella_data_model.settlement import (
+        Carrier, Contract, RateCard, CarrierCapacityCommitment,
+    )
+
+    db.add(Carrier(id=1, tenant_id=1, scac="C1", display_name="C1", carrier_type="TRUCKLOAD"))
+    db.flush()
+    db.add(Contract(id=1, tenant_id=1, carrier_id=1, contract_number="C1",
+        contract_type="PRIMARY", effective_from=datetime(2026, 1, 1), currency="USD"))
+    db.flush()
+    db.add(RateCard(id=1, tenant_id=1, contract_id=1, lane_filter={},
+        equipment_type="DRY_VAN", rate_basis="PER_MILE", base_rate=2.50,
+        effective_from=datetime(2026, 1, 1)))
+    db.flush()
+    # Q2 commitment: Apr 1 — Jun 30 (91 days), commit_volume=100 WEEKLY
+    db.add(CarrierCapacityCommitment(
+        tenant_id=1, contract_id=1, lane_filter={}, equipment_type="DRY_VAN",
+        period_start=date(2026, 4, 1), period_end=date(2026, 6, 30),
+        period_granularity="WEEKLY", commit_volume=100, currency="USD",
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.flush()
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=10)
+
+    plan_id = MovementPlannerService(db).plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4)).plan_id
+    result = IntegratedBalancerService(db).balance_plan(
+        unconstrained_plan_id=plan_id, resolve_capacity_from_db=True)
+
+    items = db.query(TransportationPlanItem).filter_by(plan_id=result.constrained_plan_id).all()
+    on_carrier = sum(1 for i in items if i.carrier_id == 1)
+    # 100 × 7/91 = 7.69 → floor to 7 fittable items, 3 escalated.
+    assert on_carrier == 7
+    assert result.items_escalated == 3
+
+
+def test_phase_3_42_p3_prorating_flat_no_proration(db) -> None:
+    """§3.42 Phase 3.3: FLAT granularity commitment is NOT prorated —
+    full commit_volume applies regardless of period overlap."""
+    from datetime import datetime
+    from azirella_data_model.settlement import (
+        Carrier, Contract, RateCard, CarrierCapacityCommitment,
+    )
+
+    db.add(Carrier(id=1, tenant_id=1, scac="C1", display_name="C1", carrier_type="TRUCKLOAD"))
+    db.flush()
+    db.add(Contract(id=1, tenant_id=1, carrier_id=1, contract_number="C1",
+        contract_type="PRIMARY", effective_from=datetime(2026, 1, 1), currency="USD"))
+    db.flush()
+    db.add(RateCard(id=1, tenant_id=1, contract_id=1, lane_filter={},
+        equipment_type="DRY_VAN", rate_basis="PER_MILE", base_rate=2.50,
+        effective_from=datetime(2026, 1, 1)))
+    db.flush()
+    db.add(CarrierCapacityCommitment(
+        tenant_id=1, contract_id=1, lane_filter={}, equipment_type="DRY_VAN",
+        period_start=date(2026, 4, 1), period_end=date(2026, 6, 30),
+        period_granularity="FLAT", commit_volume=20, currency="USD",
+        effective_from=datetime(2026, 1, 1),
+    ))
+    db.flush()
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=10)
+
+    plan_id = MovementPlannerService(db).plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4)).plan_id
+    result = IntegratedBalancerService(db).balance_plan(
+        unconstrained_plan_id=plan_id, resolve_capacity_from_db=True)
+
+    # FLAT 20-load cap > 10 plan items → all fit
+    items = db.query(TransportationPlanItem).filter_by(plan_id=result.constrained_plan_id).all()
+    assert sum(1 for i in items if i.carrier_id == 1) == 10
+    assert result.items_escalated == 0
+
+
+# ===========================================================================
+# §3.41 Phase 3 — GraphSAGE training pipeline scaffold
+# ===========================================================================
+
+
+def test_phase_3_41_torch_graphsage_untrained_returns_low_confidence(db) -> None:
+    """§3.41 Phase 3.2: an untrained TorchGraphSAGEMovementPlanner
+    returns predictions with carrier_id=None and confidence=0.0 so
+    consumers can detect the untrained state and fall back to Phase 2A."""
+    from app.services.powell.graphsage_movement_planner import (
+        TorchGraphSAGEMovementPlanner,
+        GraphSAGEPredictionInput,
+    )
+
+    model = TorchGraphSAGEMovementPlanner()
+    inp = GraphSAGEPredictionInput(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4), period_days=7,
+        lane_volume_forecasts=[
+            {"item_id": 1, "lane_id": 10, "mode": "FTL", "equipment_type": "DRY_VAN",
+             "forecast_loads_p50": 5.0},
+        ],
+        available_carriers=[
+            {"carrier_id": 1, "rate_card_id": 1, "base_rate": 2.5, "capacity_remaining": 50},
+        ],
+    )
+    outputs = model.predict(inp)
+    assert len(outputs) == 1
+    assert outputs[0].carrier_id is None
+    assert outputs[0].confidence == 0.0
+    assert "model_not_trained" in outputs[0].rationale.get("reason", "")
+
+
+def test_phase_3_41_training_extractor_returns_iterator(db) -> None:
+    """§3.41 Phase 3.1: extractor returns an iterator of training
+    examples. Empty when no plan items exist."""
+    from app.services.powell.movement_planner_training_data import (
+        MovementPlannerTrainingDataExtractor,
+    )
+
+    extractor = MovementPlannerTrainingDataExtractor(db)
+    examples = list(extractor.extract(tenant_id=1))
+    assert examples == []  # No plans seeded
+
+
+def test_phase_3_41_trainer_returns_run_result_with_zero_examples(db) -> None:
+    """§3.41 Phase 3.3: trainer produces a TrainingRunResult even when
+    no examples are extracted. Model version reflects the no-data
+    state."""
+    from app.services.powell.movement_planner_trainer import (
+        MovementPlannerTrainer,
+    )
+
+    trainer = MovementPlannerTrainer(db)
+    result = trainer.train(tenant_id=1)
+    assert result.examples_extracted == 0
+    assert result.examples_used == 0
+    assert "no_training_data" in result.model_version
+    assert result.training_run_id.startswith("trainer_1_")
+
+
 def test_phase_3_42_expired_commitments_not_used(db) -> None:
     """A CarrierCapacityCommitment with effective_to in the past is
     excluded from the resolved capacity."""


### PR DESCRIPTION
## Summary

Two Phase 3 workstreams in one TMS PR:

### §3.42 Phase 3 — Closes the three Phase 2 deferred items

1. **Geographic filters** via shared `LaneGeographyResolver` (refactored from `MovementPlannerService`; both planner + balancer now reuse it).
2. **Per-(carrier × equipment) LP shape** — capacity dict accepts `Dict[Union[int, Tuple[int, Optional[str]]], float]`. Tuple keys add per-equipment LP constraints; integer keys remain "carrier-wide".
3. **Per-period-granularity prorating** — WEEKLY/MONTHLY/QUARTERLY commitments scale by day-fraction overlap with plan window; FLAT does not.

### §3.41 Phase 3.1-3.3 — Real PyTorch GraphSAGE pipeline

- **`MovementPlannerTrainingDataExtractor`** — streaming ETL.
- **`TorchGraphSAGEMovementPlanner`** — real PyTorch GNN (2 `SAGEConv` layers + MLP scoring head; fit + predict).
- **`MovementPlannerTrainer`** — orchestrator wiring ETL → batches → fit → val MSE.

## Concrete impact

**§3.42 P3.2**: carrier with DRY_VAN cap=4 + REEFER cap=10, plan 6 DRY_VAN + 2 REEFER. Phase 1 sums 14, fits all 8 (over-permissive). Phase 3.2 fits 4+2, escalates 2 DRY_VAN.

**§3.42 P3.3**: Q2 commit_volume=100 over 7-day plan → 7.69 effective cap (was 100).

## Test plan

- [x] 3 new §3.42 Phase 3 tests (per-equipment LP, WEEKLY-over-Q2 prorating, FLAT no-proration).
- [x] 3 new §3.41 Phase 3 tests (untrained sentinel, ETL iterator, trainer no-data).
- [x] 12 prior tests still pass (Phase 1+2 backward compat preserved).
- [x] PyTorch + torch_geometric already in TMS `requirements.txt`.

## Phase 3.4 + 3.5 deferred (separate workstreams)

- **§3.41 P3.4**: inference-service wiring into `MovementPlannerService` under feature flag.
- **§3.41 P3.5**: production GPU training, per-tenant calibration, monitoring.
- **§3.42 Phase 4**: `min_volume` shortfall penalty math (settlement-time concern).

## Schema gap flagged

`FreightCharge` lacks `plan_item_id` FK → ETL falls back to `action_estimated_cost` as semi-supervised label. Phase 3.5 wires the FK.

## Cross-references

- Core PR (merged): https://github.com/azirella-ltd/Autonomy-Core/pull/59
- §3.38 Phase 2B GraphSAGE scaffold: now replaced by real implementation.
- §3.42 Phase 1+2: built upon by Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)