### PR TITLE
feat(§3.41 Phase 3.4): GraphSAGE inference wiring under feature flag

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -424,9 +424,14 @@ from azirella_data_model.planes import PlaneRegistration, Plane, PlaneRegistry  
 from . import analytics  # noqa: F401
 
 # 37. TMS Planning — Forecast, Capacity Targets, Transportation Plan
+# `TransportationPlan` + `TransportationPlanItem` migrated to Core in
+# §3.39 (PR #14). PlanStatus + PlanItemStatus are re-exported from Core
+# via tms_planning.py's noqa import shim.
 from .tms_planning import (
     ForecastMethod, PlanStatus, PlanItemStatus,
     ShippingForecast, CapacityTarget,
+)
+from azirella_data_model.transport_plan import (  # noqa: E402
     TransportationPlan, TransportationPlanItem,
 )
 

--- a/backend/app/services/powell/integrated_balancer_service.py
+++ b/backend/app/services/powell/integrated_balancer_service.py
@@ -99,7 +99,7 @@ def _normalize_capacity_dict(
             )
     return normalized
 
-from app.models.tms_planning import (
+from azirella_data_model.transport_plan import (
     PlanStatus,
     PlanItemStatus,
     TransportationPlan,

--- a/backend/app/services/powell/movement_planner_service.py
+++ b/backend/app/services/powell/movement_planner_service.py
@@ -1,4 +1,5 @@
-"""MovementPlannerService — §3.38 Phase 2A (carrier assignment via rate-card).
+"""MovementPlannerService — §3.38 Phase 2A (carrier assignment via rate-card)
++ §3.41 Phase 3.4 (GraphSAGE re-ranker under feature flag).
 
 The L3 Unconstrained Movement Plan service per
 ``docs/TMS_DECISION_HIERARCHY.md`` §4.2. Phase 2A adds **carrier
@@ -16,6 +17,24 @@ assignment + cost estimation** on top of Phase 1's load fan-out:
    `distance_miles` on the item.
 4. Falls back to NULL if no rate card matches (graceful degradation
    for tenants without seeded rate-cards).
+
+§3.41 Phase 3.4 — optional GraphSAGE re-ranker:
+
+5. After the heuristic produces per-item drafts, if a
+   :class:`GraphSAGEMovementPlannerModel` is passed via ``model=...``
+   the planner builds a single :class:`GraphSAGEPredictionInput` for
+   the full draft batch and asks the model to score (item, carrier)
+   pairs.
+6. For each item where the model emits ``confidence ≥
+   model_confidence_threshold`` and a non-null carrier, the heuristic's
+   carrier is **overridden** with the model's choice. Low-confidence
+   items keep the heuristic assignment (graceful fallback).
+7. Per-call A/B counters (``items_via_model``,
+   ``items_via_heuristic_fallback``, ``model_heuristic_agreements``,
+   ``model_heuristic_overrides``) land on :class:`PlanResult` and a
+   summary blob is stashed on the plan header's
+   ``optimization_metadata`` so consumers can audit which method
+   produced which plan.
 
 Phase 2A scope explicitly excludes:
 
@@ -39,11 +58,17 @@ If LaneProfile has no row for the lane, falls back to a tenant-config
 default (5 0 miles placeholder); Phase 2B will add haversine fallback
 from origin/destination site lat/lng.
 
-The `optimization_method` field signals Phase 2A vs Phase 1:
-- ``HEURISTIC_PHASE_1`` — fan-out only, no carrier (deprecated; only
-  used when ``carrier_assignment_enabled=False`` for testing)
+The `optimization_method` field signals which planner variant ran:
+- ``HEURISTIC_PHASE_1`` — fan-out only, no carrier (only used when
+  ``carrier_assignment_enabled=False`` for testing)
 - ``HEURISTIC_PHASE_2A`` — fan-out + cheapest-carrier from rate-card
-- ``GRAPHSAGE_UNCONSTRAINED`` — Phase 3 (deferred)
+  (default; also used when a model was passed but every item fell
+  back below the confidence threshold)
+- ``GRAPHSAGE_HEURISTIC_HYBRID`` — model overrode some items; the rest
+  used the heuristic
+- ``GRAPHSAGE_PHASE_3_4`` — model overrode every assignable item
+- ``GRAPHSAGE_UNCONSTRAINED`` — Phase 3.5 reserved (full GraphSAGE
+  re-plan with mode-substitution, not yet wired)
 
 Plane-module placement: this is TMS-plane decision policy (the *service*
 that decides how to plan + assign carriers). The substrate it reads
@@ -68,6 +93,11 @@ from azirella_data_model.transport_plan import (
     PlanStatus,
     TransportationPlan,
     TransportationPlanItem,
+)
+
+from app.services.powell.graphsage_movement_planner import (
+    GraphSAGEMovementPlannerModel,
+    GraphSAGEPredictionInput,
 )
 
 
@@ -175,6 +205,34 @@ class PlanResult:
     """Phase 2A: items where no rate card matched and ``carrier_id``
     stayed ``None``. Phase 1: equals ``items_written``."""
 
+    items_via_model: int = 0
+    """§3.41 Phase 3.4: items whose final carrier came from the
+    GraphSAGE model's high-confidence prediction (kept the heuristic
+    pick when ``model_carrier == heuristic_carrier``; overrode when
+    they differed). Always 0 when ``model=None``."""
+
+    items_via_heuristic_fallback: int = 0
+    """§3.41 Phase 3.4: items where the model abstained (low confidence
+    or null prediction) and the heuristic's choice was kept. When
+    ``model=None``, equals ``items_with_carrier`` (every item used
+    the heuristic). When the model is provided but untrained,
+    typically equals ``items_with_carrier`` (the untrained sentinel
+    emits ``confidence=0.0`` for every row)."""
+
+    model_heuristic_agreements: int = 0
+    """§3.41 Phase 3.4: items where the model and heuristic picked the
+    same carrier (subset of ``items_via_model``)."""
+
+    model_heuristic_overrides: int = 0
+    """§3.41 Phase 3.4: items where the model picked a different
+    carrier than the heuristic and we accepted the model's choice
+    (subset of ``items_via_model``)."""
+
+    model_version: Optional[str] = None
+    """§3.41 Phase 3.4: the trained model's version stamp (when a
+    model was passed). ``None`` when no model was used. Persisted on
+    the plan header's ``optimization_metadata`` for audit."""
+
 
 class MovementPlannerService:
     """L3 Unconstrained Movement Plan service — Phase 2A heuristic.
@@ -204,6 +262,8 @@ class MovementPlannerService:
         forecast_plan_version: str = DEFAULT_PLAN_VERSION,
         cascade_run_id: Optional[str] = None,
         carrier_assignment_enabled: bool = True,
+        model: Optional[GraphSAGEMovementPlannerModel] = None,
+        model_confidence_threshold: float = 0.5,
     ) -> PlanResult:
         """Read LaneVolumePlan rows for the given (tenant, config,
         period_start) and produce a TransportationPlan with items.
@@ -216,6 +276,16 @@ class MovementPlannerService:
         Phase 1 fallback (``carrier_assignment_enabled=False``): keeps
         Phase 1's NULL-carrier behaviour for tests / tenants without
         seeded rate cards.
+
+        §3.41 Phase 3.4 — when ``model`` is supplied, the heuristic
+        runs first as the baseline assignment; the model is then asked
+        to re-rank the full draft batch in a single ``predict()`` call,
+        and per-item picks override the heuristic when
+        ``confidence ≥ model_confidence_threshold``. Untrained models
+        return ``confidence=0.0`` for every row, so passing an
+        untrained ``TorchGraphSAGEMovementPlanner`` is equivalent to
+        Phase 2A — the heuristic is preserved and the model is
+        instrumented for monitoring only.
 
         Returns a :class:`PlanResult` with the plan id + item counts.
         Caller is responsible for `commit()`.
@@ -233,7 +303,8 @@ class MovementPlannerService:
             .all()
         )
 
-        # 2. Build the TransportationPlan header.
+        # 2. Build the TransportationPlan header (optimization_method
+        # is patched after pass 3 once we know how the model performed).
         plan = TransportationPlan(
             config_id=config_id,
             tenant_id=tenant_id,
@@ -254,14 +325,14 @@ class MovementPlannerService:
         self.db.add(plan)
         self.db.flush()  # populate plan.id
 
-        # 3. Fan out leaf rows into plan items + (Phase 2A) assign carriers.
+        # 3. Pass 1 — heuristic fan-out into pending-item drafts.
         items_per_lane: dict = {}
-        items_written = 0
         skipped_zero_loads = 0
-        items_with_carrier = 0
-        items_without_carrier = 0
-        total_estimated_cost = 0.0
-        total_distance = 0.0
+        pending: List[dict] = []
+        # Track candidate carriers seen across the plan; used as the
+        # available_carriers list for the GraphSAGE re-ranker. Keyed
+        # by (carrier_id, rate_id) to dedupe.
+        candidate_carriers: dict = {}
 
         for row in forecast_rows:
             if not _is_leaf_row(row, forecast_rows):
@@ -274,10 +345,11 @@ class MovementPlannerService:
 
             origin_id, destination_id = self._lane_endpoints(row.lane_id)
 
-            # Phase 2A: resolve carrier + rate + distance once per
-            # (lane, mode, equipment) — these are constant across the
-            # n_items per row, so do the lookup once and reuse.
-            distance_miles = self._lane_distance_miles(row.lane_id) if carrier_assignment_enabled else None
+            distance_miles = (
+                self._lane_distance_miles(row.lane_id)
+                if carrier_assignment_enabled
+                else None
+            )
             assignment = (
                 self._select_carrier_and_rate(
                     tenant_id=tenant_id,
@@ -291,6 +363,19 @@ class MovementPlannerService:
                 else _NULL_ASSIGNMENT
             )
 
+            if assignment.carrier_id is not None and assignment.rate_id is not None:
+                candidate_carriers.setdefault(
+                    (assignment.carrier_id, assignment.rate_id),
+                    {
+                        "carrier_id": assignment.carrier_id,
+                        "rate_card_id": assignment.rate_id,
+                        "base_rate": assignment.base_rate or 0.0,
+                        "equipment_type": row.equipment_type,
+                        "rate_basis": assignment.rate_basis,
+                        "capacity_remaining": 0,
+                    },
+                )
+
             for i in range(n_items):
                 pickup_dt = self._distribute_pickup(
                     period_start=period_start,
@@ -300,9 +385,6 @@ class MovementPlannerService:
                 )
                 delivery_dt = pickup_dt + timedelta(days=1)
 
-                # Per-item cost (some bases scale per-load, e.g., FLAT,
-                # and need re-application; PER_MILE is constant across
-                # items on the same lane).
                 per_item_weight = self._derive_weight(row, n_items)
                 per_item_volume = self._derive_volume(row, n_items)
                 per_item_cost = (
@@ -313,46 +395,117 @@ class MovementPlannerService:
                     if carrier_assignment_enabled and assignment.rate_id is not None
                     else None
                 )
-                cost_per_mile = (
-                    round(per_item_cost / distance_miles, 4)
-                    if per_item_cost is not None and distance_miles
-                    else None
-                )
 
-                item = TransportationPlanItem(
-                    plan_id=plan.id,
-                    tenant_id=tenant_id,
-                    origin_site_id=origin_id,
-                    destination_site_id=destination_id,
-                    lane_id=row.lane_id,
-                    mode=row.mode,
-                    equipment_type=row.equipment_type,
-                    carrier_id=assignment.carrier_id,
-                    rate_id=assignment.rate_id,
-                    status=PlanItemStatus.PLANNED,
-                    planned_pickup_date=pickup_dt,
-                    planned_delivery_date=delivery_dt,
-                    shipment_count=1,
-                    total_weight=per_item_weight,
-                    total_volume=per_item_volume,
-                    estimated_cost=per_item_cost,
-                    estimated_cost_per_mile=cost_per_mile,
-                    distance_miles=distance_miles if carrier_assignment_enabled else None,
-                    is_multi_stop=False,
-                )
-                self.db.add(item)
-                items_written += 1
-                items_per_lane[row.lane_id] = items_per_lane.get(row.lane_id, 0) + 1
-                if assignment.carrier_id is not None:
-                    items_with_carrier += 1
+                pending.append({
+                    "_row_lane_id": row.lane_id,
+                    "_heuristic_carrier_id": assignment.carrier_id,
+                    "_heuristic_rate_id": assignment.rate_id,
+                    "_heuristic_cost": per_item_cost,
+                    "_distance_miles": distance_miles,
+                    "_kwargs": {
+                        "plan_id": plan.id,
+                        "tenant_id": tenant_id,
+                        "origin_site_id": origin_id,
+                        "destination_site_id": destination_id,
+                        "lane_id": row.lane_id,
+                        "mode": row.mode,
+                        "equipment_type": row.equipment_type,
+                        "carrier_id": assignment.carrier_id,
+                        "rate_id": assignment.rate_id,
+                        "status": PlanItemStatus.PLANNED,
+                        "planned_pickup_date": pickup_dt,
+                        "planned_delivery_date": delivery_dt,
+                        "shipment_count": 1,
+                        "total_weight": per_item_weight,
+                        "total_volume": per_item_volume,
+                        "estimated_cost": per_item_cost,
+                        "estimated_cost_per_mile": (
+                            round(per_item_cost / distance_miles, 4)
+                            if per_item_cost is not None and distance_miles
+                            else None
+                        ),
+                        "distance_miles": (
+                            distance_miles
+                            if carrier_assignment_enabled
+                            else None
+                        ),
+                        "is_multi_stop": False,
+                    },
+                })
+
+        # 4. Pass 2 — optional GraphSAGE re-rank.
+        items_via_model = 0
+        items_via_heuristic_fallback = 0
+        agreements = 0
+        overrides = 0
+        model_version: Optional[str] = None
+
+        if model is not None and pending and carrier_assignment_enabled:
+            model_version = model.model_version()
+            predictions = self._predict_with_model(
+                model=model,
+                tenant_id=tenant_id,
+                config_id=config_id,
+                period_start=period_start,
+                period_days=period_days,
+                pending=pending,
+                candidate_carriers=candidate_carriers,
+            )
+            for idx, p in enumerate(pending):
+                pred = predictions.get(idx)
+                heuristic_carrier = p["_heuristic_carrier_id"]
+                if (
+                    pred is None
+                    or pred.confidence < model_confidence_threshold
+                    or pred.carrier_id is None
+                ):
+                    if heuristic_carrier is not None:
+                        items_via_heuristic_fallback += 1
+                    continue
+                items_via_model += 1
+                if pred.carrier_id == heuristic_carrier:
+                    agreements += 1
                 else:
-                    items_without_carrier += 1
-                if per_item_cost is not None:
-                    total_estimated_cost += per_item_cost
-                if distance_miles:
-                    total_distance += distance_miles
+                    overrides += 1
+                    p["_kwargs"]["carrier_id"] = pred.carrier_id
+                    if pred.rate_id is not None:
+                        p["_kwargs"]["rate_id"] = pred.rate_id
+                    if pred.estimated_cost is not None:
+                        new_cost = round(float(pred.estimated_cost), 2)
+                        p["_kwargs"]["estimated_cost"] = new_cost
+                        dist = p["_distance_miles"]
+                        p["_kwargs"]["estimated_cost_per_mile"] = (
+                            round(new_cost / dist, 4) if dist else None
+                        )
+        else:
+            for p in pending:
+                if p["_heuristic_carrier_id"] is not None:
+                    items_via_heuristic_fallback += 1
 
-        # 4. Update plan-header summary metrics.
+        # 5. Pass 3 — write items.
+        items_written = 0
+        items_with_carrier = 0
+        items_without_carrier = 0
+        total_estimated_cost = 0.0
+        total_distance = 0.0
+
+        for p in pending:
+            kwargs = p["_kwargs"]
+            self.db.add(TransportationPlanItem(**kwargs))
+            items_written += 1
+            items_per_lane[p["_row_lane_id"]] = (
+                items_per_lane.get(p["_row_lane_id"], 0) + 1
+            )
+            if kwargs["carrier_id"] is not None:
+                items_with_carrier += 1
+            else:
+                items_without_carrier += 1
+            if kwargs["estimated_cost"] is not None:
+                total_estimated_cost += kwargs["estimated_cost"]
+            if kwargs["distance_miles"]:
+                total_distance += kwargs["distance_miles"]
+
+        # 6. Update plan-header summary metrics + optimization_method.
         plan.total_planned_loads = items_written
         plan.total_planned_shipments = items_written
         if total_estimated_cost > 0:
@@ -364,7 +517,6 @@ class MovementPlannerService:
                     total_estimated_cost / total_distance, 4,
                 )
         if items_with_carrier > 0:
-            # Distinct carrier count for the plan summary
             assigned_carriers = (
                 self.db.query(TransportationPlanItem.carrier_id)
                 .filter(
@@ -376,6 +528,22 @@ class MovementPlannerService:
             )
             plan.carrier_count = assigned_carriers
 
+        plan.optimization_method = self._derive_optimization_method(
+            carrier_assignment_enabled=carrier_assignment_enabled,
+            model_provided=model is not None,
+            items_via_model=items_via_model,
+            items_assignable=items_with_carrier,
+        )
+        if model is not None:
+            plan.optimization_metadata = {
+                "graphsage_model_version": model_version,
+                "model_confidence_threshold": model_confidence_threshold,
+                "items_via_model": items_via_model,
+                "items_via_heuristic_fallback": items_via_heuristic_fallback,
+                "model_heuristic_agreements": agreements,
+                "model_heuristic_overrides": overrides,
+            }
+
         if items_written:
             self.db.flush()
 
@@ -386,6 +554,11 @@ class MovementPlannerService:
             skipped_zero_loads=skipped_zero_loads,
             items_with_carrier=items_with_carrier,
             items_without_carrier=items_without_carrier,
+            items_via_model=items_via_model,
+            items_via_heuristic_fallback=items_via_heuristic_fallback,
+            model_heuristic_agreements=agreements,
+            model_heuristic_overrides=overrides,
+            model_version=model_version,
         )
 
     # ------------------------------------------------------------------
@@ -758,6 +931,75 @@ class MovementPlannerService:
         if profile is None or profile.distance_miles is None:
             return _DEFAULT_DISTANCE_MILES_FALLBACK
         return float(profile.distance_miles)
+
+    # ------------------------------------------------------------------
+    # §3.41 Phase 3.4 — GraphSAGE re-rank helpers
+    # ------------------------------------------------------------------
+
+    def _predict_with_model(
+        self,
+        *,
+        model: GraphSAGEMovementPlannerModel,
+        tenant_id: int,
+        config_id: int,
+        period_start: date,
+        period_days: int,
+        pending: List[dict],
+        candidate_carriers: dict,
+    ) -> dict:
+        """Build a single :class:`GraphSAGEPredictionInput` from the
+        heuristic pending-item drafts and call ``model.predict``.
+
+        Returns ``{pending_index: GraphSAGEPredictionOutput}`` so the
+        caller can index by draft order. ``model.predict`` failures
+        downgrade to an empty dict (the heuristic stays in force).
+        """
+        lane_volume_forecasts = [
+            {
+                "item_id": idx,
+                "lane_id": p["_row_lane_id"],
+                "mode": p["_kwargs"]["mode"],
+                "equipment_type": p["_kwargs"]["equipment_type"],
+                "forecast_loads_p50": 1.0,
+            }
+            for idx, p in enumerate(pending)
+        ]
+        available_carriers = list(candidate_carriers.values())
+        if not available_carriers:
+            return {}
+
+        inputs = GraphSAGEPredictionInput(
+            tenant_id=tenant_id,
+            config_id=config_id,
+            period_start=period_start,
+            period_days=period_days,
+            lane_volume_forecasts=lane_volume_forecasts,
+            available_carriers=available_carriers,
+        )
+        try:
+            outputs = model.predict(inputs)
+        except Exception:
+            return {}
+        return {o.item_id: o for o in outputs}
+
+    @staticmethod
+    def _derive_optimization_method(
+        *,
+        carrier_assignment_enabled: bool,
+        model_provided: bool,
+        items_via_model: int,
+        items_assignable: int,
+    ) -> str:
+        """Pick the ``optimization_method`` label from the per-call
+        counters. Encodes the Phase 3.4 A/B vocabulary documented at
+        the top of this module."""
+        if not carrier_assignment_enabled:
+            return "HEURISTIC_PHASE_1"
+        if not model_provided or items_via_model == 0:
+            return "HEURISTIC_PHASE_2A"
+        if items_via_model >= items_assignable:
+            return "GRAPHSAGE_PHASE_3_4"
+        return "GRAPHSAGE_HEURISTIC_HYBRID"
 
 
 __all__ = [

--- a/backend/tests/powell/test_l3_planning_services.py
+++ b/backend/tests/powell/test_l3_planning_services.py
@@ -1341,6 +1341,251 @@ def test_phase_3_41_trainer_returns_run_result_with_zero_examples(db) -> None:
     assert result.training_run_id.startswith("trainer_1_")
 
 
+# ===========================================================================
+# §3.41 Phase 3.4 — GraphSAGE inference-service wiring + A/B counters
+# ===========================================================================
+
+
+def _stub_model(*, carrier_id_per_item, rate_id_per_item=None, confidence=1.0,
+                model_version="stub_v1"):
+    """Return a stand-in :class:`GraphSAGEMovementPlannerModel` whose
+    ``predict`` emits the given carrier per draft item-id with the
+    given confidence. ``carrier_id_per_item`` is a dict ``{item_id:
+    carrier_id_or_None}``; missing keys → no prediction (heuristic
+    fallback). ``confidence`` may be a scalar (applied to every
+    prediction) or a dict ``{item_id: float}`` for mixed-confidence
+    tests."""
+    from app.services.powell.graphsage_movement_planner import (
+        GraphSAGEMovementPlannerModel,
+        GraphSAGEPredictionOutput,
+    )
+
+    class _Stub(GraphSAGEMovementPlannerModel):
+        def fit(self, training_data):
+            pass
+
+        def predict(self, inputs):
+            outputs = []
+            for fc in inputs.lane_volume_forecasts:
+                item_id = fc["item_id"]
+                if item_id not in carrier_id_per_item:
+                    continue
+                carrier = carrier_id_per_item[item_id]
+                conf = (
+                    confidence[item_id] if isinstance(confidence, dict)
+                    else confidence
+                )
+                outputs.append(GraphSAGEPredictionOutput(
+                    item_id=item_id,
+                    carrier_id=carrier,
+                    rate_id=(rate_id_per_item or {}).get(item_id),
+                    estimated_cost=None,
+                    confidence=conf,
+                    rationale={"source": "stub"},
+                ))
+            return outputs
+
+        def model_version(self):
+            return model_version
+
+    return _Stub()
+
+
+def test_phase_3_4_no_model_keeps_phase_2a(db) -> None:
+    """§3.41 Phase 3.4 baseline: when no model is passed, the planner
+    behaves exactly like Phase 2A — optimization_method stays
+    HEURISTIC_PHASE_2A and the new model counters are all 0."""
+    _seed_carrier_and_rate_cards(db)
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=3)
+
+    svc = MovementPlannerService(db)
+    result = svc.plan_movement(tenant_id=1, config_id=1, period_start=date(2026, 5, 4))
+
+    assert result.items_with_carrier == 3
+    assert result.items_via_model == 0
+    assert result.model_heuristic_agreements == 0
+    assert result.model_heuristic_overrides == 0
+    assert result.items_via_heuristic_fallback == 3
+    assert result.model_version is None
+
+    plan = db.query(TransportationPlan).one()
+    assert plan.optimization_method == "HEURISTIC_PHASE_2A"
+    assert plan.optimization_metadata is None
+
+
+def test_phase_3_4_untrained_model_abstains_falls_back_to_heuristic(db) -> None:
+    """§3.41 Phase 3.4: an untrained TorchGraphSAGEMovementPlanner
+    emits confidence=0.0, so every item falls back to the heuristic.
+    optimization_method stays HEURISTIC_PHASE_2A; model_version is
+    captured for audit."""
+    from app.services.powell.graphsage_movement_planner import (
+        TorchGraphSAGEMovementPlanner,
+    )
+
+    _seed_carrier_and_rate_cards(db)
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=3)
+
+    svc = MovementPlannerService(db)
+    model = TorchGraphSAGEMovementPlanner()
+    result = svc.plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        model=model,
+    )
+
+    assert result.items_with_carrier == 3
+    assert result.items_via_model == 0
+    assert result.items_via_heuristic_fallback == 3
+    assert result.model_version == "graphsage_untrained"
+
+    plan = db.query(TransportationPlan).one()
+    assert plan.optimization_method == "HEURISTIC_PHASE_2A"
+    assert plan.optimization_metadata is not None
+    assert plan.optimization_metadata["graphsage_model_version"] == "graphsage_untrained"
+    assert plan.optimization_metadata["items_via_model"] == 0
+
+
+def test_phase_3_4_high_confidence_model_overrides_heuristic(db) -> None:
+    """§3.41 Phase 3.4: when the model returns a different carrier with
+    confidence ≥ threshold, the heuristic's choice is overridden;
+    optimization_method becomes GRAPHSAGE_PHASE_3_4 (every assignable
+    item went through the model)."""
+    _seed_carrier_and_rate_cards(db)
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=3)
+
+    # Heuristic picks carrier 1 (cheaper); stub overrides to carrier 2.
+    model = _stub_model(
+        carrier_id_per_item={0: 2, 1: 2, 2: 2},
+        rate_id_per_item={0: 2, 1: 2, 2: 2},
+        confidence=0.9,
+        model_version="stub_override_v1",
+    )
+
+    svc = MovementPlannerService(db)
+    result = svc.plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        model=model, model_confidence_threshold=0.5,
+    )
+
+    assert result.items_with_carrier == 3
+    assert result.items_via_model == 3
+    assert result.model_heuristic_overrides == 3
+    assert result.model_heuristic_agreements == 0
+    assert result.items_via_heuristic_fallback == 0
+    assert result.model_version == "stub_override_v1"
+
+    plan = db.query(TransportationPlan).one()
+    assert plan.optimization_method == "GRAPHSAGE_PHASE_3_4"
+    items = db.query(TransportationPlanItem).all()
+    assert all(item.carrier_id == 2 for item in items)
+    assert all(item.rate_id == 2 for item in items)
+
+
+def test_phase_3_4_high_confidence_agreement_does_not_count_as_override(db) -> None:
+    """§3.41 Phase 3.4: when the model picks the same carrier as the
+    heuristic with confidence ≥ threshold, the assignment is counted as
+    an *agreement*, not an override; the heuristic's already-correct
+    rate id and cost are preserved."""
+    _seed_carrier_and_rate_cards(db)
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=2)
+
+    # Heuristic picks carrier 1; stub agrees on carrier 1.
+    model = _stub_model(
+        carrier_id_per_item={0: 1, 1: 1},
+        confidence=0.95,
+    )
+
+    svc = MovementPlannerService(db)
+    result = svc.plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        model=model,
+    )
+
+    assert result.items_via_model == 2
+    assert result.model_heuristic_agreements == 2
+    assert result.model_heuristic_overrides == 0
+
+    plan = db.query(TransportationPlan).one()
+    assert plan.optimization_method == "GRAPHSAGE_PHASE_3_4"
+    items = db.query(TransportationPlanItem).all()
+    assert all(item.carrier_id == 1 for item in items)
+    assert all(item.estimated_cost == 1875.0 for item in items)  # heuristic cost preserved
+
+
+def test_phase_3_4_partial_confidence_produces_hybrid(db) -> None:
+    """§3.41 Phase 3.4: when the model is high-confidence on some items
+    and low-confidence on others, the result is GRAPHSAGE_HEURISTIC_HYBRID
+    and per-item splits land in items_via_model / items_via_heuristic_fallback."""
+    _seed_carrier_and_rate_cards(db)
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=4)
+
+    # Items 0, 1: high-confidence override to carrier 2.
+    # Items 2, 3: low-confidence — heuristic stays.
+    model = _stub_model(
+        carrier_id_per_item={0: 2, 1: 2, 2: 2, 3: 2},
+        rate_id_per_item={0: 2, 1: 2, 2: 2, 3: 2},
+        confidence={0: 0.9, 1: 0.9, 2: 0.1, 3: 0.1},
+    )
+
+    svc = MovementPlannerService(db)
+    result = svc.plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        model=model, model_confidence_threshold=0.5,
+    )
+
+    assert result.items_with_carrier == 4
+    assert result.items_via_model == 2
+    assert result.model_heuristic_overrides == 2
+    assert result.items_via_heuristic_fallback == 2
+
+    plan = db.query(TransportationPlan).one()
+    assert plan.optimization_method == "GRAPHSAGE_HEURISTIC_HYBRID"
+    # First two items overridden to carrier 2; last two stayed at carrier 1.
+    items = sorted(
+        db.query(TransportationPlanItem).all(),
+        key=lambda i: i.planned_pickup_date,
+    )
+    assert items[0].carrier_id == 2 and items[1].carrier_id == 2
+    assert items[2].carrier_id == 1 and items[3].carrier_id == 1
+
+
+def test_phase_3_4_model_predict_exception_falls_back_safely(db) -> None:
+    """§3.41 Phase 3.4: if ``model.predict`` throws, the planner returns
+    the heuristic result with optimization_method=HEURISTIC_PHASE_2A
+    (no items_via_model). This is Phase 3.5's robustness contract:
+    inference failures must never break planning."""
+    from app.services.powell.graphsage_movement_planner import (
+        GraphSAGEMovementPlannerModel,
+    )
+
+    class _ThrowingModel(GraphSAGEMovementPlannerModel):
+        def fit(self, training_data): pass
+        def predict(self, inputs):
+            raise RuntimeError("simulated inference failure")
+        def model_version(self):
+            return "throw_v1"
+
+    _seed_carrier_and_rate_cards(db)
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=2)
+
+    svc = MovementPlannerService(db)
+    result = svc.plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        model=_ThrowingModel(),
+    )
+
+    assert result.items_with_carrier == 2
+    assert result.items_via_model == 0
+    assert result.items_via_heuristic_fallback == 2
+    plan = db.query(TransportationPlan).one()
+    assert plan.optimization_method == "HEURISTIC_PHASE_2A"
+
+
 def test_phase_3_42_expired_commitments_not_used(db) -> None:
     """A CarrierCapacityCommitment with effective_to in the past is
     excluded from the resolved capacity."""


### PR DESCRIPTION
## Summary

- Wires the §3.41 Phase 3.2 `TorchGraphSAGEMovementPlanner` into `MovementPlannerService.plan_movement()` with A/B comparison against the Phase 2A heuristic, gated by an optional `model=` kwarg.
- Three-pass design: heuristic drafts → optional `model.predict()` re-rank (per-item override on `confidence ≥ threshold`) → write items. Per-call A/B counters land on `PlanResult` and `TransportationPlan.optimization_metadata`.
- New `optimization_method` vocabulary: `GRAPHSAGE_PHASE_3_4` / `GRAPHSAGE_HEURISTIC_HYBRID`. Untrained `TorchGraphSAGEMovementPlanner` returns `confidence=0.0` so handing one in is a no-op vs. heuristic — safe rollout path.
- Robustness contract enforced from 3.4: `model.predict()` exceptions are caught; planner returns the heuristic plan with `HEURISTIC_PHASE_2A`.
- Pre-existing import-path housekeeping (broken since §3.39 / PR #14): `app/models/__init__.py:427` and `integrated_balancer_service.py:102` retargeted from the deleted `app.models.tms_planning.TransportationPlan` re-export to `azirella_data_model.transport_plan` directly.

## Test plan

- [x] 6 new tests in `tests/powell/test_l3_planning_services.py` — no_model / untrained_abstains / high_conf_override / agreement_no_override / partial_conf_hybrid / predict_throws_safe_fallback.
- [x] 6-scenario programmatic smoke verified end-to-end against in-memory SQLite (counters, optimization_method, override / agreement, override-cost, hybrid split, exception fallback).
- [ ] CI runs the full `test_l3_planning_services.py` suite (note: pre-existing duplicate-`Carrier` ORM debt — `app.models.tms_entities.Carrier` vs. `azirella_data_model.settlement.entities.Carrier` — blocks running the file outside CI; this PR doesn't touch that and isn't blocked by it).

Refs: `docs/MIGRATION_REGISTER.md` §3.41 + `CONSUMER_ADOPTION_LOG.md` 2026-05-03 in Autonomy-Core (companion docs PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)