### PR TITLE
feat(§3.46 Phases 1+2+4): L3 transport cascade runner + scheduler + CLI

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -424,9 +424,14 @@ from azirella_data_model.planes import PlaneRegistration, Plane, PlaneRegistry  
 from . import analytics  # noqa: F401
 
 # 37. TMS Planning — Forecast, Capacity Targets, Transportation Plan
+# `TransportationPlan` + `TransportationPlanItem` migrated to Core in
+# §3.39 (PR #14). PlanStatus + PlanItemStatus are re-exported from Core
+# via tms_planning.py's noqa import shim.
 from .tms_planning import (
     ForecastMethod, PlanStatus, PlanItemStatus,
     ShippingForecast, CapacityTarget,
+)
+from azirella_data_model.transport_plan import (  # noqa: E402
     TransportationPlan, TransportationPlanItem,
 )
 

--- a/backend/app/services/powell/integrated_balancer_service.py
+++ b/backend/app/services/powell/integrated_balancer_service.py
@@ -99,7 +99,7 @@ def _normalize_capacity_dict(
             )
     return normalized
 
-from app.models.tms_planning import (
+from azirella_data_model.transport_plan import (
     PlanStatus,
     PlanItemStatus,
     TransportationPlan,

--- a/backend/app/services/powell/l3_cascade_jobs.py
+++ b/backend/app/services/powell/l3_cascade_jobs.py
@@ -1,0 +1,220 @@
+"""§3.46 Phase 2 — APScheduler registration for the L3 transport cascade.
+
+Wires :class:`L3CascadeRunner` (Phase 1) to a daily 5:00 UTC cron via
+the existing ``SyncSchedulerService`` (which TMS already runs as a
+``BackgroundScheduler`` singleton; see ``app/services/sync_scheduler_service.py``
+and the prior callers in ``tms_extraction_jobs.py`` / ``conformal_orchestrator.py``).
+
+What runs at 5:00 UTC every day:
+
+1. Open a fresh sync DB session (the scheduler runs in a background
+   thread; we don't reuse FastAPI request sessions).
+2. Query every PRODUCTION-mode tenant with ``status='ACTIVE'``.
+3. For each tenant: find its active production-baseline
+   ``SupplyChainConfig``, run :class:`L3CascadeRunner` for
+   ``period_start = today UTC, period_days = 7``.
+4. Per-tenant try/except: one tenant's cascade failure is logged and
+   the loop continues. The Phase 1 runner already returns a
+   :class:`CascadeRunResult` with status="FAILED" for stage exceptions
+   (it doesn't raise) — this layer only needs to handle infrastructure
+   exceptions (DB connectivity, missing config, etc.).
+
+**Why 5:00 UTC and not the 5:15 / 5:30 split documented in CLAUDE.md.**
+The Phase 1 runner produces both ``unconstrained_reference`` and
+``constrained_live`` in one cascade_run with per-stage commits, so the
+"5am MPS refresh" and "5:30am constrained solve" become a single
+atomic two-stage event at 5:00. The 30-minute gap in CLAUDE.md was a
+budget for MPS to finish before the LP runs; per-stage commits make
+that gap implicit (Stage 1 commits before Stage 2 starts).
+
+**Idempotency.** The Phase 1 runner skips when a prior L3 plan exists
+for the period. So a misfire that re-fires the cron 10 minutes late
+is a safe no-op, not a duplicate plan. Set ``misfire_grace_time=3600``
+(1 hour) to give the cron room to recover from short host outages.
+
+**`period_start` policy.** Today (UTC). This refreshes a rolling
+7-day plan daily — what CLAUDE.md calls "Plan of Record refresh from
+conformal P50." Tenants on weekly cadence (rare for transport) should
+override at the per-tenant config level once §3.46 Phase 4 ships the
+manual-trigger CLI.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Optional
+
+from apscheduler.triggers.cron import CronTrigger
+
+if TYPE_CHECKING:
+    from app.services.sync_scheduler_service import SyncSchedulerService
+
+
+logger = logging.getLogger(__name__)
+
+
+_L3_CASCADE_JOB_ID = "l3_transport_cascade_daily"
+_L3_CASCADE_CRON_HOUR = 5
+_L3_CASCADE_CRON_MINUTE = 0
+_L3_CASCADE_PERIOD_DAYS = 7
+_MISFIRE_GRACE_SECONDS = 3600  # 1 hour
+
+
+def register_l3_cascade_jobs(
+    scheduler_service: "SyncSchedulerService",
+) -> None:
+    """Register the L3 transport cascade daily cron job.
+
+    Idempotent: ``replace_existing=True`` lets this be called on every
+    app start without piling up duplicate triggers.
+    """
+    scheduler = scheduler_service._scheduler
+    if scheduler is None:
+        logger.warning(
+            "Scheduler not available — L3 cascade job not registered",
+        )
+        return
+
+    scheduler.add_job(
+        func=_run_l3_cascade_for_all_tenants,
+        trigger=CronTrigger(
+            hour=_L3_CASCADE_CRON_HOUR,
+            minute=_L3_CASCADE_CRON_MINUTE,
+        ),
+        id=_L3_CASCADE_JOB_ID,
+        name=(
+            f"L3 transport cascade (daily "
+            f"{_L3_CASCADE_CRON_HOUR:02d}:{_L3_CASCADE_CRON_MINUTE:02d} UTC)"
+        ),
+        replace_existing=True,
+        misfire_grace_time=_MISFIRE_GRACE_SECONDS,
+    )
+    logger.info(
+        "Registered L3 transport cascade job (daily %02d:%02d UTC, id=%s)",
+        _L3_CASCADE_CRON_HOUR, _L3_CASCADE_CRON_MINUTE,
+        _L3_CASCADE_JOB_ID,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Job body
+# ---------------------------------------------------------------------------
+
+
+def _run_l3_cascade_for_all_tenants() -> None:
+    """Run the L3 cascade for every active production tenant.
+
+    Per-tenant failure is logged and skipped — one tenant's bad config
+    must not stop the cron from servicing the rest.
+    """
+    from app.db.session import sync_session_factory
+    from app.services.powell.l3_cascade_runner import L3CascadeRunner
+
+    period_start = _today_utc()
+    started_at = datetime.utcnow()
+    logger.info(
+        "L3 cascade — daily run starting (period_start=%s)", period_start,
+    )
+
+    n_ok = n_skipped = n_failed = 0
+    with sync_session_factory() as discovery_db:
+        tenant_configs = _discover_active_tenants(discovery_db)
+
+    for tenant_id, config_id in tenant_configs:
+        # Per-tenant DB session — failure on one doesn't poison the next.
+        try:
+            with sync_session_factory() as tenant_db:
+                runner = L3CascadeRunner(tenant_db)
+                result = runner.run(
+                    tenant_id=tenant_id,
+                    config_id=config_id,
+                    period_start=period_start,
+                    period_days=_L3_CASCADE_PERIOD_DAYS,
+                    resolve_capacity_from_db=True,
+                )
+            if result.status == "OK":
+                n_ok += 1
+                logger.info(
+                    "L3 cascade OK — tenant=%s cascade_run_id=%s "
+                    "constrained_plan_id=%s",
+                    tenant_id, result.cascade_run_id,
+                    result.stages[-1].plan_id if result.stages else None,
+                )
+            elif result.status == "SKIPPED":
+                n_skipped += 1
+                logger.info(
+                    "L3 cascade SKIPPED (idempotent) — tenant=%s period=%s",
+                    tenant_id, period_start,
+                )
+            else:  # FAILED
+                n_failed += 1
+                failed_stage = next(
+                    (s for s in result.stages if s.status == "FAILED"),
+                    None,
+                )
+                logger.error(
+                    "L3 cascade FAILED — tenant=%s cascade_run_id=%s "
+                    "stage=%s error=%s",
+                    tenant_id, result.cascade_run_id,
+                    failed_stage.stage if failed_stage else "?",
+                    failed_stage.error if failed_stage else "?",
+                )
+        except Exception:
+            n_failed += 1
+            logger.exception(
+                "L3 cascade — infra failure for tenant=%s "
+                "(continuing with next tenant)",
+                tenant_id,
+            )
+
+    duration = (datetime.utcnow() - started_at).total_seconds()
+    logger.info(
+        "L3 cascade — daily run complete (period_start=%s "
+        "tenants_ok=%d skipped=%d failed=%d duration_s=%.1f)",
+        period_start, n_ok, n_skipped, n_failed, duration,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _today_utc() -> date:
+    """Today, UTC. Factored out so tests can monkeypatch."""
+    return datetime.utcnow().date()
+
+
+def _discover_active_tenants(db) -> list:
+    """Return ``[(tenant_id, config_id)]`` for every PRODUCTION-mode
+    tenant with ``status='ACTIVE'`` that has at least one active
+    BASELINE supply-chain config.
+
+    Tenants without a usable config are silently skipped (logged
+    upstream when they hit the runner). LEARNING-mode tenants are
+    excluded — they run the cascade on-demand for scenario testing,
+    not on a daily cron.
+    """
+    from azirella_data_model.master.config import SupplyChainConfig
+    from azirella_data_model.tenant import Tenant, TenantMode
+
+    rows = (
+        db.query(Tenant.id, SupplyChainConfig.id)
+        .join(
+            SupplyChainConfig,
+            SupplyChainConfig.tenant_id == Tenant.id,
+        )
+        .filter(
+            Tenant.status == "ACTIVE",
+            Tenant.mode == TenantMode.PRODUCTION,
+            SupplyChainConfig.is_active.is_(True),
+            SupplyChainConfig.scenario_type == "BASELINE",
+        )
+        .all()
+    )
+    return [(tid, cid) for tid, cid in rows]
+
+
+__all__ = [
+    "register_l3_cascade_jobs",
+]

--- a/backend/app/services/powell/l3_cascade_runner.py
+++ b/backend/app/services/powell/l3_cascade_runner.py
@@ -1,0 +1,355 @@
+"""L3 transport cascade runner — §3.46 Phase 1.
+
+Orchestrates the L3 transport-side cascade for one (tenant, period):
+
+    LaneVolumePlan (already published — upstream)
+       ↓ MovementPlannerService.plan_movement
+    TransportationPlan(unconstrained_reference)
+       ↓ IntegratedBalancerService.balance_plan
+    TransportationPlan(constrained_live)
+
+This service ships the orchestration *primitive* — once it exists,
+anyone (a cron job, a CLI, an API endpoint, a test) can invoke the
+full cascade. APScheduler registration is §3.46 Phase 2.
+
+**Per-stage transactions.** Each stage commits its writes before the
+next runs, so a stage-2 exception leaves stage-1's
+``unconstrained_reference`` plan intact. The Movement plan is
+recoverable evidence even when the Balancer fails — operators can
+inspect what the heuristic produced, fix the capacity / commitment
+data, and re-run the Balancer alone.
+
+**Shared cascade_run_id.** Both writes are tagged with the same
+``cascade_run_id`` (shape: ``l3_<tenant>_<utc-iso>_<uuid8>``) so
+consumers can correlate the unconstrained → constrained pair.
+``TransportationPlan.cascade_run_id`` is a free-text column today;
+§3.46 Phase 3 promotes it to an FK on a Core ``CascadeRun``
+substrate.
+
+**Idempotency.** ``run()`` checks for an existing
+``TransportationPlan`` with ``plan_start_date == period_start`` AND
+``cascade_run_id LIKE 'l3_%'`` for the tenant; skips with
+``status="SKIPPED"`` unless ``force=True``. This makes the cron in
+§3.46 Phase 2 safe to fire-and-forget — re-running on the same period
+is a no-op.
+
+**Plane-module placement.** TMS-side decision orchestration. Per the
+plane-module invariant (CLAUDE.md): the cascade-runner pattern is
+plane-specific (TMS and SCP have different cascades — different
+upstream forecasts, different downstream gates); the *substrate* that
+lets cascades correlate (a Core ``CascadeRun`` table) is Phase 3
+follow-on.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from azirella_data_model.transport_plan import (
+    DEFAULT_PLAN_VERSION,
+    TransportationPlan,
+)
+
+from app.services.powell.integrated_balancer_service import (
+    IntegratedBalancerService,
+)
+from app.services.powell.movement_planner_service import (
+    MovementPlannerService,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+_RUN_ID_PREFIX = "l3"
+"""Prefix on every ``cascade_run_id`` produced by this runner. Lets
+consumers filter ``cascade_run_id LIKE 'l3_%'`` to find L3-cascade
+plans specifically, separate from any other cascade that might tag
+plans with a different prefix (e.g., a future ``s_`` for the S&OP
+weekly cascade)."""
+
+
+@dataclass(frozen=True)
+class StageResult:
+    """One stage's outcome."""
+
+    stage: str
+    """``"movement"`` / ``"balancer"``."""
+
+    status: str
+    """``"OK"`` / ``"FAILED"``."""
+
+    plan_id: Optional[int] = None
+    """Plan id produced by this stage. ``None`` on FAILED."""
+
+    error: Optional[str] = None
+    """Exception summary string when ``status == "FAILED"``."""
+
+    summary: dict = field(default_factory=dict)
+    """Stage-specific facts lifted from the underlying service result
+    (items_written, items_with_carrier, items_escalated,
+    optimization_method, …) for downstream observability without
+    forcing consumers to re-query the DB."""
+
+
+@dataclass(frozen=True)
+class CascadeRunResult:
+    """Per-call summary."""
+
+    cascade_run_id: str
+    tenant_id: int
+    config_id: int
+    period_start: date
+
+    status: str
+    """``"OK"`` (all stages succeeded) / ``"FAILED"`` (one stage
+    failed) / ``"SKIPPED"`` (idempotency check matched an existing
+    L3 plan for the period)."""
+
+    stages: List[StageResult] = field(default_factory=list)
+    """Ordered ``StageResult`` list, one per stage that actually ran.
+    Empty when ``status == "SKIPPED"``."""
+
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+
+
+class L3CascadeRunner:
+    """Orchestrate the L3 transport cascade for one (tenant, period).
+
+    Usage::
+
+        runner = L3CascadeRunner(db)
+        result = runner.run(
+            tenant_id=42, config_id=1,
+            period_start=date(2026, 5, 4), period_days=7,
+        )
+        if result.status == "OK":
+            constrained_plan_id = result.stages[-1].plan_id
+            ...
+
+    The runner manages its own transaction boundaries (per-stage
+    commit on success; rollback on per-stage failure). Caller does
+    NOT need to commit.
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def run(
+        self,
+        *,
+        tenant_id: int,
+        config_id: int,
+        period_start: date,
+        period_days: int = 7,
+        scenario_id: Optional[int] = None,
+        forecast_plan_version: str = DEFAULT_PLAN_VERSION,
+        force: bool = False,
+        resolve_capacity_from_db: bool = True,
+    ) -> CascadeRunResult:
+        """Run the cascade end-to-end for one (tenant, config, period).
+
+        Returns a :class:`CascadeRunResult` documenting per-stage
+        status. Always returns — does not raise on stage failure;
+        callers inspect ``result.status`` and per-stage errors. (The
+        scheduler in Phase 2 relies on this — one tenant's cascade
+        failure must not kill the cron job for the rest of the
+        tenants.)
+
+        - ``force=True`` bypasses the idempotency skip (re-runs even
+          when an L3 plan already exists for the period). Used by the
+          manual-trigger CLI in Phase 4 for replan-after-data-fix.
+        - ``resolve_capacity_from_db=True`` (default) makes the
+          Balancer query ``CarrierCapacityCommitment`` rows (§3.42).
+          Set False to keep the Phase 1 clone-only behaviour for
+          tenants without seeded commitments.
+        """
+        cascade_run_id = self._new_run_id(tenant_id)
+        started_at = datetime.utcnow()
+
+        # Idempotency check.
+        if not force:
+            existing = self._existing_l3_plan(tenant_id, period_start)
+            if existing is not None:
+                logger.info(
+                    "L3 cascade skipped (idempotent) — existing plan id=%s "
+                    "cascade_run_id=%s for tenant=%s period=%s",
+                    existing.id, existing.cascade_run_id,
+                    tenant_id, period_start,
+                )
+                return CascadeRunResult(
+                    cascade_run_id=cascade_run_id,
+                    tenant_id=tenant_id, config_id=config_id,
+                    period_start=period_start,
+                    status="SKIPPED",
+                    stages=[],
+                    started_at=started_at,
+                    completed_at=datetime.utcnow(),
+                )
+
+        stages: List[StageResult] = []
+
+        # Stage 1 — Movement Planner (unconstrained_reference).
+        movement = self._run_movement(
+            tenant_id=tenant_id, config_id=config_id,
+            period_start=period_start, period_days=period_days,
+            scenario_id=scenario_id,
+            forecast_plan_version=forecast_plan_version,
+            cascade_run_id=cascade_run_id,
+        )
+        stages.append(movement)
+        if movement.status != "OK" or movement.plan_id is None:
+            return CascadeRunResult(
+                cascade_run_id=cascade_run_id,
+                tenant_id=tenant_id, config_id=config_id,
+                period_start=period_start,
+                status="FAILED",
+                stages=stages,
+                started_at=started_at,
+                completed_at=datetime.utcnow(),
+            )
+
+        # Stage 2 — Integrated Balancer (constrained_live).
+        balancer = self._run_balancer(
+            unconstrained_plan_id=movement.plan_id,
+            cascade_run_id=cascade_run_id,
+            resolve_capacity_from_db=resolve_capacity_from_db,
+        )
+        stages.append(balancer)
+
+        return CascadeRunResult(
+            cascade_run_id=cascade_run_id,
+            tenant_id=tenant_id, config_id=config_id,
+            period_start=period_start,
+            status="OK" if balancer.status == "OK" else "FAILED",
+            stages=stages,
+            started_at=started_at,
+            completed_at=datetime.utcnow(),
+        )
+
+    # ------------------------------------------------------------------
+    # Stage runners (per-stage transaction boundary)
+    # ------------------------------------------------------------------
+
+    def _run_movement(
+        self, *,
+        tenant_id: int, config_id: int,
+        period_start: date, period_days: int,
+        scenario_id: Optional[int],
+        forecast_plan_version: str,
+        cascade_run_id: str,
+    ) -> StageResult:
+        try:
+            svc = MovementPlannerService(self.db)
+            result = svc.plan_movement(
+                tenant_id=tenant_id, config_id=config_id,
+                period_start=period_start, period_days=period_days,
+                scenario_id=scenario_id,
+                forecast_plan_version=forecast_plan_version,
+                cascade_run_id=cascade_run_id,
+            )
+            self.db.commit()
+            return StageResult(
+                stage="movement", status="OK",
+                plan_id=result.plan_id,
+                summary={
+                    "items_written": result.items_written,
+                    "items_with_carrier": result.items_with_carrier,
+                    "items_without_carrier": result.items_without_carrier,
+                    "skipped_zero_loads": result.skipped_zero_loads,
+                },
+            )
+        except Exception as exc:
+            self.db.rollback()
+            logger.exception(
+                "L3 cascade — Movement Planner failed "
+                "(cascade_run_id=%s tenant=%s period=%s)",
+                cascade_run_id, tenant_id, period_start,
+            )
+            return StageResult(
+                stage="movement", status="FAILED",
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+    def _run_balancer(
+        self, *,
+        unconstrained_plan_id: int,
+        cascade_run_id: str,
+        resolve_capacity_from_db: bool,
+    ) -> StageResult:
+        try:
+            svc = IntegratedBalancerService(self.db)
+            result = svc.balance_plan(
+                unconstrained_plan_id=unconstrained_plan_id,
+                cascade_run_id=cascade_run_id,
+                resolve_capacity_from_db=resolve_capacity_from_db,
+            )
+            self.db.commit()
+            return StageResult(
+                stage="balancer", status="OK",
+                plan_id=result.constrained_plan_id,
+                summary={
+                    "items_cloned": result.items_cloned,
+                    "items_escalated": result.items_escalated,
+                    "optimization_method": result.optimization_method,
+                },
+            )
+        except Exception as exc:
+            self.db.rollback()
+            logger.exception(
+                "L3 cascade — Integrated Balancer failed "
+                "(cascade_run_id=%s unconstrained_plan_id=%s)",
+                cascade_run_id, unconstrained_plan_id,
+            )
+            return StageResult(
+                stage="balancer", status="FAILED",
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _new_run_id(tenant_id: int) -> str:
+        """Build a human-readable + globally-unique cascade run id.
+
+        Shape: ``l3_{tenant_id}_{utc_iso}_{uuid8}``. The tenant id +
+        timestamp prefix lets log-grep match by tenant + day; the
+        UUID suffix guarantees uniqueness across same-second runs.
+        """
+        ts = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+        suffix = uuid.uuid4().hex[:8]
+        return f"{_RUN_ID_PREFIX}_{tenant_id}_{ts}_{suffix}"
+
+    def _existing_l3_plan(
+        self, tenant_id: int, period_start: date,
+    ) -> Optional[TransportationPlan]:
+        """Return any existing L3-cascade plan for the (tenant, period)
+        that idempotency should skip on. Matches by ``plan_start_date``
+        + the ``l3_`` prefix on ``cascade_run_id`` so plans produced
+        by a different cascade (or by manual operator action with no
+        cascade_run_id) don't trigger the skip.
+        """
+        return (
+            self.db.query(TransportationPlan)
+            .filter(
+                TransportationPlan.tenant_id == tenant_id,
+                TransportationPlan.plan_start_date == period_start,
+                TransportationPlan.cascade_run_id.like(f"{_RUN_ID_PREFIX}_%"),
+            )
+            .first()
+        )
+
+
+__all__ = [
+    "CascadeRunResult",
+    "L3CascadeRunner",
+    "StageResult",
+]

--- a/backend/app/services/powell/movement_planner_service.py
+++ b/backend/app/services/powell/movement_planner_service.py
@@ -1,4 +1,5 @@
-"""MovementPlannerService — §3.38 Phase 2A (carrier assignment via rate-card).
+"""MovementPlannerService — §3.38 Phase 2A (carrier assignment via rate-card)
++ §3.41 Phase 3.4 (GraphSAGE re-ranker under feature flag).
 
 The L3 Unconstrained Movement Plan service per
 ``docs/TMS_DECISION_HIERARCHY.md`` §4.2. Phase 2A adds **carrier
@@ -16,6 +17,24 @@ assignment + cost estimation** on top of Phase 1's load fan-out:
    `distance_miles` on the item.
 4. Falls back to NULL if no rate card matches (graceful degradation
    for tenants without seeded rate-cards).
+
+§3.41 Phase 3.4 — optional GraphSAGE re-ranker:
+
+5. After the heuristic produces per-item drafts, if a
+   :class:`GraphSAGEMovementPlannerModel` is passed via ``model=...``
+   the planner builds a single :class:`GraphSAGEPredictionInput` for
+   the full draft batch and asks the model to score (item, carrier)
+   pairs.
+6. For each item where the model emits ``confidence ≥
+   model_confidence_threshold`` and a non-null carrier, the heuristic's
+   carrier is **overridden** with the model's choice. Low-confidence
+   items keep the heuristic assignment (graceful fallback).
+7. Per-call A/B counters (``items_via_model``,
+   ``items_via_heuristic_fallback``, ``model_heuristic_agreements``,
+   ``model_heuristic_overrides``) land on :class:`PlanResult` and a
+   summary blob is stashed on the plan header's
+   ``optimization_metadata`` so consumers can audit which method
+   produced which plan.
 
 Phase 2A scope explicitly excludes:
 
@@ -39,11 +58,17 @@ If LaneProfile has no row for the lane, falls back to a tenant-config
 default (5 0 miles placeholder); Phase 2B will add haversine fallback
 from origin/destination site lat/lng.
 
-The `optimization_method` field signals Phase 2A vs Phase 1:
-- ``HEURISTIC_PHASE_1`` — fan-out only, no carrier (deprecated; only
-  used when ``carrier_assignment_enabled=False`` for testing)
+The `optimization_method` field signals which planner variant ran:
+- ``HEURISTIC_PHASE_1`` — fan-out only, no carrier (only used when
+  ``carrier_assignment_enabled=False`` for testing)
 - ``HEURISTIC_PHASE_2A`` — fan-out + cheapest-carrier from rate-card
-- ``GRAPHSAGE_UNCONSTRAINED`` — Phase 3 (deferred)
+  (default; also used when a model was passed but every item fell
+  back below the confidence threshold)
+- ``GRAPHSAGE_HEURISTIC_HYBRID`` — model overrode some items; the rest
+  used the heuristic
+- ``GRAPHSAGE_PHASE_3_4`` — model overrode every assignable item
+- ``GRAPHSAGE_UNCONSTRAINED`` — Phase 3.5 reserved (full GraphSAGE
+  re-plan with mode-substitution, not yet wired)
 
 Plane-module placement: this is TMS-plane decision policy (the *service*
 that decides how to plan + assign carriers). The substrate it reads
@@ -68,6 +93,11 @@ from azirella_data_model.transport_plan import (
     PlanStatus,
     TransportationPlan,
     TransportationPlanItem,
+)
+
+from app.services.powell.graphsage_movement_planner import (
+    GraphSAGEMovementPlannerModel,
+    GraphSAGEPredictionInput,
 )
 
 
@@ -175,6 +205,34 @@ class PlanResult:
     """Phase 2A: items where no rate card matched and ``carrier_id``
     stayed ``None``. Phase 1: equals ``items_written``."""
 
+    items_via_model: int = 0
+    """§3.41 Phase 3.4: items whose final carrier came from the
+    GraphSAGE model's high-confidence prediction (kept the heuristic
+    pick when ``model_carrier == heuristic_carrier``; overrode when
+    they differed). Always 0 when ``model=None``."""
+
+    items_via_heuristic_fallback: int = 0
+    """§3.41 Phase 3.4: items where the model abstained (low confidence
+    or null prediction) and the heuristic's choice was kept. When
+    ``model=None``, equals ``items_with_carrier`` (every item used
+    the heuristic). When the model is provided but untrained,
+    typically equals ``items_with_carrier`` (the untrained sentinel
+    emits ``confidence=0.0`` for every row)."""
+
+    model_heuristic_agreements: int = 0
+    """§3.41 Phase 3.4: items where the model and heuristic picked the
+    same carrier (subset of ``items_via_model``)."""
+
+    model_heuristic_overrides: int = 0
+    """§3.41 Phase 3.4: items where the model picked a different
+    carrier than the heuristic and we accepted the model's choice
+    (subset of ``items_via_model``)."""
+
+    model_version: Optional[str] = None
+    """§3.41 Phase 3.4: the trained model's version stamp (when a
+    model was passed). ``None`` when no model was used. Persisted on
+    the plan header's ``optimization_metadata`` for audit."""
+
 
 class MovementPlannerService:
     """L3 Unconstrained Movement Plan service — Phase 2A heuristic.
@@ -204,6 +262,8 @@ class MovementPlannerService:
         forecast_plan_version: str = DEFAULT_PLAN_VERSION,
         cascade_run_id: Optional[str] = None,
         carrier_assignment_enabled: bool = True,
+        model: Optional[GraphSAGEMovementPlannerModel] = None,
+        model_confidence_threshold: float = 0.5,
     ) -> PlanResult:
         """Read LaneVolumePlan rows for the given (tenant, config,
         period_start) and produce a TransportationPlan with items.
@@ -216,6 +276,16 @@ class MovementPlannerService:
         Phase 1 fallback (``carrier_assignment_enabled=False``): keeps
         Phase 1's NULL-carrier behaviour for tests / tenants without
         seeded rate cards.
+
+        §3.41 Phase 3.4 — when ``model`` is supplied, the heuristic
+        runs first as the baseline assignment; the model is then asked
+        to re-rank the full draft batch in a single ``predict()`` call,
+        and per-item picks override the heuristic when
+        ``confidence ≥ model_confidence_threshold``. Untrained models
+        return ``confidence=0.0`` for every row, so passing an
+        untrained ``TorchGraphSAGEMovementPlanner`` is equivalent to
+        Phase 2A — the heuristic is preserved and the model is
+        instrumented for monitoring only.
 
         Returns a :class:`PlanResult` with the plan id + item counts.
         Caller is responsible for `commit()`.
@@ -233,7 +303,8 @@ class MovementPlannerService:
             .all()
         )
 
-        # 2. Build the TransportationPlan header.
+        # 2. Build the TransportationPlan header (optimization_method
+        # is patched after pass 3 once we know how the model performed).
         plan = TransportationPlan(
             config_id=config_id,
             tenant_id=tenant_id,
@@ -254,14 +325,14 @@ class MovementPlannerService:
         self.db.add(plan)
         self.db.flush()  # populate plan.id
 
-        # 3. Fan out leaf rows into plan items + (Phase 2A) assign carriers.
+        # 3. Pass 1 — heuristic fan-out into pending-item drafts.
         items_per_lane: dict = {}
-        items_written = 0
         skipped_zero_loads = 0
-        items_with_carrier = 0
-        items_without_carrier = 0
-        total_estimated_cost = 0.0
-        total_distance = 0.0
+        pending: List[dict] = []
+        # Track candidate carriers seen across the plan; used as the
+        # available_carriers list for the GraphSAGE re-ranker. Keyed
+        # by (carrier_id, rate_id) to dedupe.
+        candidate_carriers: dict = {}
 
         for row in forecast_rows:
             if not _is_leaf_row(row, forecast_rows):
@@ -274,10 +345,11 @@ class MovementPlannerService:
 
             origin_id, destination_id = self._lane_endpoints(row.lane_id)
 
-            # Phase 2A: resolve carrier + rate + distance once per
-            # (lane, mode, equipment) — these are constant across the
-            # n_items per row, so do the lookup once and reuse.
-            distance_miles = self._lane_distance_miles(row.lane_id) if carrier_assignment_enabled else None
+            distance_miles = (
+                self._lane_distance_miles(row.lane_id)
+                if carrier_assignment_enabled
+                else None
+            )
             assignment = (
                 self._select_carrier_and_rate(
                     tenant_id=tenant_id,
@@ -291,6 +363,19 @@ class MovementPlannerService:
                 else _NULL_ASSIGNMENT
             )
 
+            if assignment.carrier_id is not None and assignment.rate_id is not None:
+                candidate_carriers.setdefault(
+                    (assignment.carrier_id, assignment.rate_id),
+                    {
+                        "carrier_id": assignment.carrier_id,
+                        "rate_card_id": assignment.rate_id,
+                        "base_rate": assignment.base_rate or 0.0,
+                        "equipment_type": row.equipment_type,
+                        "rate_basis": assignment.rate_basis,
+                        "capacity_remaining": 0,
+                    },
+                )
+
             for i in range(n_items):
                 pickup_dt = self._distribute_pickup(
                     period_start=period_start,
@@ -300,9 +385,6 @@ class MovementPlannerService:
                 )
                 delivery_dt = pickup_dt + timedelta(days=1)
 
-                # Per-item cost (some bases scale per-load, e.g., FLAT,
-                # and need re-application; PER_MILE is constant across
-                # items on the same lane).
                 per_item_weight = self._derive_weight(row, n_items)
                 per_item_volume = self._derive_volume(row, n_items)
                 per_item_cost = (
@@ -313,46 +395,117 @@ class MovementPlannerService:
                     if carrier_assignment_enabled and assignment.rate_id is not None
                     else None
                 )
-                cost_per_mile = (
-                    round(per_item_cost / distance_miles, 4)
-                    if per_item_cost is not None and distance_miles
-                    else None
-                )
 
-                item = TransportationPlanItem(
-                    plan_id=plan.id,
-                    tenant_id=tenant_id,
-                    origin_site_id=origin_id,
-                    destination_site_id=destination_id,
-                    lane_id=row.lane_id,
-                    mode=row.mode,
-                    equipment_type=row.equipment_type,
-                    carrier_id=assignment.carrier_id,
-                    rate_id=assignment.rate_id,
-                    status=PlanItemStatus.PLANNED,
-                    planned_pickup_date=pickup_dt,
-                    planned_delivery_date=delivery_dt,
-                    shipment_count=1,
-                    total_weight=per_item_weight,
-                    total_volume=per_item_volume,
-                    estimated_cost=per_item_cost,
-                    estimated_cost_per_mile=cost_per_mile,
-                    distance_miles=distance_miles if carrier_assignment_enabled else None,
-                    is_multi_stop=False,
-                )
-                self.db.add(item)
-                items_written += 1
-                items_per_lane[row.lane_id] = items_per_lane.get(row.lane_id, 0) + 1
-                if assignment.carrier_id is not None:
-                    items_with_carrier += 1
+                pending.append({
+                    "_row_lane_id": row.lane_id,
+                    "_heuristic_carrier_id": assignment.carrier_id,
+                    "_heuristic_rate_id": assignment.rate_id,
+                    "_heuristic_cost": per_item_cost,
+                    "_distance_miles": distance_miles,
+                    "_kwargs": {
+                        "plan_id": plan.id,
+                        "tenant_id": tenant_id,
+                        "origin_site_id": origin_id,
+                        "destination_site_id": destination_id,
+                        "lane_id": row.lane_id,
+                        "mode": row.mode,
+                        "equipment_type": row.equipment_type,
+                        "carrier_id": assignment.carrier_id,
+                        "rate_id": assignment.rate_id,
+                        "status": PlanItemStatus.PLANNED,
+                        "planned_pickup_date": pickup_dt,
+                        "planned_delivery_date": delivery_dt,
+                        "shipment_count": 1,
+                        "total_weight": per_item_weight,
+                        "total_volume": per_item_volume,
+                        "estimated_cost": per_item_cost,
+                        "estimated_cost_per_mile": (
+                            round(per_item_cost / distance_miles, 4)
+                            if per_item_cost is not None and distance_miles
+                            else None
+                        ),
+                        "distance_miles": (
+                            distance_miles
+                            if carrier_assignment_enabled
+                            else None
+                        ),
+                        "is_multi_stop": False,
+                    },
+                })
+
+        # 4. Pass 2 — optional GraphSAGE re-rank.
+        items_via_model = 0
+        items_via_heuristic_fallback = 0
+        agreements = 0
+        overrides = 0
+        model_version: Optional[str] = None
+
+        if model is not None and pending and carrier_assignment_enabled:
+            model_version = model.model_version()
+            predictions = self._predict_with_model(
+                model=model,
+                tenant_id=tenant_id,
+                config_id=config_id,
+                period_start=period_start,
+                period_days=period_days,
+                pending=pending,
+                candidate_carriers=candidate_carriers,
+            )
+            for idx, p in enumerate(pending):
+                pred = predictions.get(idx)
+                heuristic_carrier = p["_heuristic_carrier_id"]
+                if (
+                    pred is None
+                    or pred.confidence < model_confidence_threshold
+                    or pred.carrier_id is None
+                ):
+                    if heuristic_carrier is not None:
+                        items_via_heuristic_fallback += 1
+                    continue
+                items_via_model += 1
+                if pred.carrier_id == heuristic_carrier:
+                    agreements += 1
                 else:
-                    items_without_carrier += 1
-                if per_item_cost is not None:
-                    total_estimated_cost += per_item_cost
-                if distance_miles:
-                    total_distance += distance_miles
+                    overrides += 1
+                    p["_kwargs"]["carrier_id"] = pred.carrier_id
+                    if pred.rate_id is not None:
+                        p["_kwargs"]["rate_id"] = pred.rate_id
+                    if pred.estimated_cost is not None:
+                        new_cost = round(float(pred.estimated_cost), 2)
+                        p["_kwargs"]["estimated_cost"] = new_cost
+                        dist = p["_distance_miles"]
+                        p["_kwargs"]["estimated_cost_per_mile"] = (
+                            round(new_cost / dist, 4) if dist else None
+                        )
+        else:
+            for p in pending:
+                if p["_heuristic_carrier_id"] is not None:
+                    items_via_heuristic_fallback += 1
 
-        # 4. Update plan-header summary metrics.
+        # 5. Pass 3 — write items.
+        items_written = 0
+        items_with_carrier = 0
+        items_without_carrier = 0
+        total_estimated_cost = 0.0
+        total_distance = 0.0
+
+        for p in pending:
+            kwargs = p["_kwargs"]
+            self.db.add(TransportationPlanItem(**kwargs))
+            items_written += 1
+            items_per_lane[p["_row_lane_id"]] = (
+                items_per_lane.get(p["_row_lane_id"], 0) + 1
+            )
+            if kwargs["carrier_id"] is not None:
+                items_with_carrier += 1
+            else:
+                items_without_carrier += 1
+            if kwargs["estimated_cost"] is not None:
+                total_estimated_cost += kwargs["estimated_cost"]
+            if kwargs["distance_miles"]:
+                total_distance += kwargs["distance_miles"]
+
+        # 6. Update plan-header summary metrics + optimization_method.
         plan.total_planned_loads = items_written
         plan.total_planned_shipments = items_written
         if total_estimated_cost > 0:
@@ -364,7 +517,6 @@ class MovementPlannerService:
                     total_estimated_cost / total_distance, 4,
                 )
         if items_with_carrier > 0:
-            # Distinct carrier count for the plan summary
             assigned_carriers = (
                 self.db.query(TransportationPlanItem.carrier_id)
                 .filter(
@@ -376,6 +528,22 @@ class MovementPlannerService:
             )
             plan.carrier_count = assigned_carriers
 
+        plan.optimization_method = self._derive_optimization_method(
+            carrier_assignment_enabled=carrier_assignment_enabled,
+            model_provided=model is not None,
+            items_via_model=items_via_model,
+            items_assignable=items_with_carrier,
+        )
+        if model is not None:
+            plan.optimization_metadata = {
+                "graphsage_model_version": model_version,
+                "model_confidence_threshold": model_confidence_threshold,
+                "items_via_model": items_via_model,
+                "items_via_heuristic_fallback": items_via_heuristic_fallback,
+                "model_heuristic_agreements": agreements,
+                "model_heuristic_overrides": overrides,
+            }
+
         if items_written:
             self.db.flush()
 
@@ -386,6 +554,11 @@ class MovementPlannerService:
             skipped_zero_loads=skipped_zero_loads,
             items_with_carrier=items_with_carrier,
             items_without_carrier=items_without_carrier,
+            items_via_model=items_via_model,
+            items_via_heuristic_fallback=items_via_heuristic_fallback,
+            model_heuristic_agreements=agreements,
+            model_heuristic_overrides=overrides,
+            model_version=model_version,
         )
 
     # ------------------------------------------------------------------
@@ -758,6 +931,75 @@ class MovementPlannerService:
         if profile is None or profile.distance_miles is None:
             return _DEFAULT_DISTANCE_MILES_FALLBACK
         return float(profile.distance_miles)
+
+    # ------------------------------------------------------------------
+    # §3.41 Phase 3.4 — GraphSAGE re-rank helpers
+    # ------------------------------------------------------------------
+
+    def _predict_with_model(
+        self,
+        *,
+        model: GraphSAGEMovementPlannerModel,
+        tenant_id: int,
+        config_id: int,
+        period_start: date,
+        period_days: int,
+        pending: List[dict],
+        candidate_carriers: dict,
+    ) -> dict:
+        """Build a single :class:`GraphSAGEPredictionInput` from the
+        heuristic pending-item drafts and call ``model.predict``.
+
+        Returns ``{pending_index: GraphSAGEPredictionOutput}`` so the
+        caller can index by draft order. ``model.predict`` failures
+        downgrade to an empty dict (the heuristic stays in force).
+        """
+        lane_volume_forecasts = [
+            {
+                "item_id": idx,
+                "lane_id": p["_row_lane_id"],
+                "mode": p["_kwargs"]["mode"],
+                "equipment_type": p["_kwargs"]["equipment_type"],
+                "forecast_loads_p50": 1.0,
+            }
+            for idx, p in enumerate(pending)
+        ]
+        available_carriers = list(candidate_carriers.values())
+        if not available_carriers:
+            return {}
+
+        inputs = GraphSAGEPredictionInput(
+            tenant_id=tenant_id,
+            config_id=config_id,
+            period_start=period_start,
+            period_days=period_days,
+            lane_volume_forecasts=lane_volume_forecasts,
+            available_carriers=available_carriers,
+        )
+        try:
+            outputs = model.predict(inputs)
+        except Exception:
+            return {}
+        return {o.item_id: o for o in outputs}
+
+    @staticmethod
+    def _derive_optimization_method(
+        *,
+        carrier_assignment_enabled: bool,
+        model_provided: bool,
+        items_via_model: int,
+        items_assignable: int,
+    ) -> str:
+        """Pick the ``optimization_method`` label from the per-call
+        counters. Encodes the Phase 3.4 A/B vocabulary documented at
+        the top of this module."""
+        if not carrier_assignment_enabled:
+            return "HEURISTIC_PHASE_1"
+        if not model_provided or items_via_model == 0:
+            return "HEURISTIC_PHASE_2A"
+        if items_via_model >= items_assignable:
+            return "GRAPHSAGE_PHASE_3_4"
+        return "GRAPHSAGE_HEURISTIC_HYBRID"
 
 
 __all__ = [

--- a/backend/main.py
+++ b/backend/main.py
@@ -569,6 +569,10 @@ async def startup_event():
             from app.services.planning_cascade_jobs import register_planning_cascade_jobs
             register_planning_cascade_jobs(scheduler_service)
 
+            # Register L3 transport cascade (daily 5am — MovementPlanner → IntegratedBalancer)
+            from app.services.powell.l3_cascade_jobs import register_l3_cascade_jobs
+            register_l3_cascade_jobs(scheduler_service)
+
             # Register executive briefing scheduler (hourly check for scheduled generation)
             from app.services.executive_briefing_jobs import register_executive_briefing_jobs
             register_executive_briefing_jobs(scheduler_service)

--- a/backend/scripts/l3_cascade_cli.py
+++ b/backend/scripts/l3_cascade_cli.py
@@ -1,0 +1,350 @@
+"""§3.46 Phase 4 — manual-trigger CLI for the L3 transport cascade.
+
+Operator entry point for invoking :class:`L3CascadeRunner` outside the
+daily 5:00 UTC cron. Use cases:
+
+- **Replan after data fix.** Operator notices the cron's plan used
+  stale carrier-capacity data; fixes the commitments, re-runs the
+  cascade for one (tenant, period) with ``--force`` to bypass the
+  idempotency skip.
+- **Backfill.** Daily cron was down for 3 days; re-run the cascade
+  across the missed range with ``--from-date`` / ``--to-date``.
+- **Manual daily run.** Same as the cron does, but invoked from a
+  shell / smoke check (``--all-tenants`` with ``--period-start``
+  defaulting to today).
+
+Usage::
+
+    # Single tenant, single period.
+    python scripts/l3_cascade_cli.py --tenant-id 42 \\
+        --period-start 2026-05-04
+
+    # Single tenant, backfill range.
+    python scripts/l3_cascade_cli.py --tenant-id 42 \\
+        --from-date 2026-05-01 --to-date 2026-05-07 --force
+
+    # All active tenants, today.
+    python scripts/l3_cascade_cli.py --all-tenants
+
+    # Dry run — print what it WOULD do, don't touch the DB.
+    python scripts/l3_cascade_cli.py --all-tenants --dry-run
+
+Exit code 0 on success (every cascade returned OK or SKIPPED); 1
+when at least one cascade failed; 2 on argparse / config error.
+
+Output: one log line per cascade run with status + cascade_run_id +
+constrained_plan_id. Log level INFO by default, --verbose enables
+DEBUG.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date, datetime, timedelta
+from typing import List, Optional, Tuple
+
+
+logger = logging.getLogger("l3_cascade_cli")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """CLI entry point. Returns the process exit code."""
+    args = _parse_args(argv)
+    _configure_logging(args.verbose)
+
+    try:
+        targets = _resolve_targets(args)
+    except _ConfigError as exc:
+        logger.error("config error: %s", exc)
+        return 2
+
+    if not targets:
+        logger.warning("no (tenant, period) targets matched the args; nothing to do")
+        return 0
+
+    logger.info(
+        "L3 cascade CLI — running %d cascade target(s) (force=%s, dry_run=%s)",
+        len(targets), args.force, args.dry_run,
+    )
+
+    if args.dry_run:
+        for tenant_id, config_id, period_start in targets:
+            logger.info(
+                "DRY RUN — would run L3 cascade for tenant=%s config=%s period=%s",
+                tenant_id, config_id, period_start,
+            )
+        return 0
+
+    n_ok = n_skipped = n_failed = 0
+    for tenant_id, config_id, period_start in targets:
+        status = _run_one(
+            tenant_id=tenant_id, config_id=config_id,
+            period_start=period_start, period_days=args.period_days,
+            force=args.force, resolve_capacity_from_db=args.use_capacity_db,
+        )
+        if status == "OK":
+            n_ok += 1
+        elif status == "SKIPPED":
+            n_skipped += 1
+        else:
+            n_failed += 1
+
+    logger.info(
+        "L3 cascade CLI — done (ok=%d skipped=%d failed=%d)",
+        n_ok, n_skipped, n_failed,
+    )
+    return 1 if n_failed > 0 else 0
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+class _ConfigError(Exception):
+    """Raised when args + DB state can't resolve a usable target."""
+
+
+def _parse_args(argv: Optional[List[str]]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Manually invoke the L3 transport cascade.",
+    )
+
+    # Tenant scope (mutually exclusive).
+    tenant_group = parser.add_mutually_exclusive_group(required=True)
+    tenant_group.add_argument(
+        "--tenant-id", type=int,
+        help="Run for one specific tenant.",
+    )
+    tenant_group.add_argument(
+        "--all-tenants", action="store_true",
+        help=(
+            "Run for every active PRODUCTION tenant — same iteration "
+            "as the daily 5:00 UTC cron."
+        ),
+    )
+
+    # Period scope (mutually exclusive).
+    period_group = parser.add_mutually_exclusive_group()
+    period_group.add_argument(
+        "--period-start", type=_parse_date,
+        help=(
+            "Single planning-period start date (YYYY-MM-DD). "
+            "Defaults to today (UTC) if neither --period-start nor "
+            "--from-date is given."
+        ),
+    )
+    period_group.add_argument(
+        "--from-date", type=_parse_date,
+        help=(
+            "Backfill range start (inclusive). Requires --to-date. "
+            "Iterates one cascade per date in the range."
+        ),
+    )
+
+    parser.add_argument(
+        "--to-date", type=_parse_date,
+        help="Backfill range end (inclusive). Requires --from-date.",
+    )
+    parser.add_argument(
+        "--config-id", type=int, default=None,
+        help=(
+            "SupplyChainConfig id. If omitted with --tenant-id, "
+            "auto-discovers the tenant's active BASELINE config."
+        ),
+    )
+    parser.add_argument(
+        "--period-days", type=int, default=7,
+        help="Planning horizon (default 7).",
+    )
+    parser.add_argument(
+        "--force", action="store_true",
+        help=(
+            "Bypass the idempotency skip — re-run even if a prior L3 "
+            "plan exists for the period (replan-after-data-fix path)."
+        ),
+    )
+    parser.add_argument(
+        "--no-capacity-db", action="store_true",
+        help=(
+            "Skip CarrierCapacityCommitment lookup (clone-only "
+            "Phase 1 fallback). Useful for smoke tests on tenants "
+            "without seeded commitments."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the targets that would run; don't touch the DB.",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true",
+        help="Enable DEBUG logging.",
+    )
+
+    args = parser.parse_args(argv)
+    args.use_capacity_db = not args.no_capacity_db
+
+    # Range-mode arg validation.
+    if args.from_date and not args.to_date:
+        parser.error("--from-date requires --to-date")
+    if args.to_date and not args.from_date:
+        parser.error("--to-date requires --from-date")
+    if args.from_date and args.to_date and args.from_date > args.to_date:
+        parser.error("--from-date must be ≤ --to-date")
+
+    return args
+
+
+def _parse_date(s: str) -> date:
+    try:
+        return datetime.strptime(s, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"expected YYYY-MM-DD, got {s!r}: {exc}",
+        ) from None
+
+
+def _configure_logging(verbose: bool) -> None:
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%SZ",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Target resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_targets(args: argparse.Namespace) -> List[Tuple[int, int, date]]:
+    """Expand args into a list of ``(tenant_id, config_id, period_start)``
+    triples. Multi-tenant + multi-period combinations expand the
+    cross-product; single-tenant + single-period yields one row."""
+    from app.db.session import sync_session_factory
+    from app.services.powell.l3_cascade_jobs import _discover_active_tenants
+
+    # Resolve the tenant set.
+    tenant_pairs: List[Tuple[int, int]]  # (tenant_id, config_id)
+    if args.all_tenants:
+        with sync_session_factory() as db:
+            tenant_pairs = _discover_active_tenants(db)
+        if not tenant_pairs:
+            raise _ConfigError(
+                "no active PRODUCTION tenants with a BASELINE config found"
+            )
+    else:
+        if args.config_id is not None:
+            tenant_pairs = [(args.tenant_id, args.config_id)]
+        else:
+            with sync_session_factory() as db:
+                cid = _discover_config_for_tenant(db, args.tenant_id)
+            if cid is None:
+                raise _ConfigError(
+                    f"tenant {args.tenant_id} has no active BASELINE config "
+                    "(pass --config-id explicitly to override)"
+                )
+            tenant_pairs = [(args.tenant_id, cid)]
+
+    # Resolve the period set.
+    if args.from_date and args.to_date:
+        periods = _date_range(args.from_date, args.to_date)
+    elif args.period_start:
+        periods = [args.period_start]
+    else:
+        periods = [datetime.utcnow().date()]
+
+    return [
+        (tid, cid, period)
+        for (tid, cid) in tenant_pairs
+        for period in periods
+    ]
+
+
+def _discover_config_for_tenant(db, tenant_id: int) -> Optional[int]:
+    """Look up the tenant's active BASELINE config; None if not found."""
+    from azirella_data_model.master.config import SupplyChainConfig
+
+    row = (
+        db.query(SupplyChainConfig.id)
+        .filter(
+            SupplyChainConfig.tenant_id == tenant_id,
+            SupplyChainConfig.is_active.is_(True),
+            SupplyChainConfig.scenario_type == "BASELINE",
+        )
+        .first()
+    )
+    return row[0] if row else None
+
+
+def _date_range(start: date, end: date) -> List[date]:
+    """Inclusive list of dates from start to end."""
+    n = (end - start).days
+    return [start + timedelta(days=i) for i in range(n + 1)]
+
+
+# ---------------------------------------------------------------------------
+# Per-target runner
+# ---------------------------------------------------------------------------
+
+
+def _run_one(
+    *,
+    tenant_id: int,
+    config_id: int,
+    period_start: date,
+    period_days: int,
+    force: bool,
+    resolve_capacity_from_db: bool,
+) -> str:
+    """Run the cascade for one target. Returns the run status string."""
+    from app.db.session import sync_session_factory
+    from app.services.powell.l3_cascade_runner import L3CascadeRunner
+
+    try:
+        with sync_session_factory() as db:
+            runner = L3CascadeRunner(db)
+            result = runner.run(
+                tenant_id=tenant_id, config_id=config_id,
+                period_start=period_start, period_days=period_days,
+                force=force,
+                resolve_capacity_from_db=resolve_capacity_from_db,
+            )
+        constrained_id = (
+            result.stages[-1].plan_id
+            if result.stages and result.stages[-1].stage == "balancer"
+            else None
+        )
+        if result.status == "OK":
+            logger.info(
+                "OK tenant=%s period=%s cascade_run_id=%s constrained_plan_id=%s",
+                tenant_id, period_start,
+                result.cascade_run_id, constrained_id,
+            )
+        elif result.status == "SKIPPED":
+            logger.info(
+                "SKIPPED tenant=%s period=%s (idempotent — pass --force to replan)",
+                tenant_id, period_start,
+            )
+        else:  # FAILED
+            failed_stage = next(
+                (s for s in result.stages if s.status == "FAILED"), None,
+            )
+            logger.error(
+                "FAILED tenant=%s period=%s cascade_run_id=%s stage=%s error=%s",
+                tenant_id, period_start, result.cascade_run_id,
+                failed_stage.stage if failed_stage else "?",
+                failed_stage.error if failed_stage else "?",
+            )
+        return result.status
+    except Exception as exc:
+        logger.exception(
+            "FAILED tenant=%s period=%s — infra error: %s",
+            tenant_id, period_start, exc,
+        )
+        return "FAILED"
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/powell/test_l3_cascade_jobs.py
+++ b/backend/tests/powell/test_l3_cascade_jobs.py
@@ -1,0 +1,202 @@
+"""§3.46 Phase 2 — L3 cascade scheduler-registration tests.
+
+The Phase 1 runner is end-to-end-tested in ``test_l3_cascade_runner.py``.
+Phase 2 only adds the APScheduler wiring — these tests cover:
+
+- ``register_l3_cascade_jobs`` calls ``add_job`` with the right id +
+  trigger when given a SyncSchedulerService stub;
+- ``register_l3_cascade_jobs`` is a no-op when the scheduler is None
+  (the SyncSchedulerService starts disabled in some envs);
+- ``_discover_active_tenants`` returns only PRODUCTION + ACTIVE tenants
+  with an active BASELINE config, and pairs each tenant with its
+  config_id.
+
+We don't test the full ``_run_l3_cascade_for_all_tenants`` body — it
+opens a real DB session via ``sync_session_factory()`` which isn't
+available in the test fixture. The runner-level behaviour (per-stage
+commits, idempotency, A/B counters) is already covered by the Phase 1
+tests; this layer is just discovery + iteration glue.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import Column, Integer, create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from azirella_data_model.base import Base
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db() -> Session:
+    """In-memory SQLite session with the tenant + config tables."""
+    # Stub FK targets the discovery query doesn't need but the ORMs reference.
+    for tbl, cls_name in (
+        ("customers", "_Cu"),
+        ("users", "_Us"),
+    ):
+        if tbl not in Base.metadata.tables:
+            type(cls_name, (Base,), {
+                "__tablename__": tbl,
+                "id": Column(Integer, primary_key=True),
+            })
+
+    from azirella_data_model.master.config import SupplyChainConfig
+    from azirella_data_model.tenant import Tenant
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(
+        bind=engine,
+        tables=[
+            Base.metadata.tables["customers"],
+            Base.metadata.tables["users"],
+            Tenant.__table__,
+            SupplyChainConfig.__table__,
+        ],
+    )
+    Sess = sessionmaker(bind=engine)
+    s = Sess()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+# ---------------------------------------------------------------------------
+# register_l3_cascade_jobs
+# ---------------------------------------------------------------------------
+
+
+def test_register_calls_add_job_with_daily_cron() -> None:
+    """register_l3_cascade_jobs adds one job at the daily 5:00 UTC cron
+    with the canonical id, replace_existing=True, and a 1-hour misfire
+    grace (so a delayed cron doesn't no-op the day's run)."""
+    from app.services.powell.l3_cascade_jobs import (
+        _L3_CASCADE_JOB_ID,
+        register_l3_cascade_jobs,
+    )
+
+    fake_scheduler = MagicMock()
+    fake_service = MagicMock(_scheduler=fake_scheduler)
+
+    register_l3_cascade_jobs(fake_service)
+
+    assert fake_scheduler.add_job.call_count == 1
+    kwargs = fake_scheduler.add_job.call_args.kwargs
+    assert kwargs["id"] == _L3_CASCADE_JOB_ID
+    assert kwargs["replace_existing"] is True
+    assert kwargs["misfire_grace_time"] == 3600
+    # Trigger has hour=5, minute=0 — APScheduler stores them as fields.
+    trigger = kwargs["trigger"]
+    field_map = {f.name: str(f) for f in trigger.fields}
+    assert field_map["hour"] == "5"
+    assert field_map["minute"] == "0"
+
+
+def test_register_no_op_when_scheduler_none() -> None:
+    """If the SyncSchedulerService doesn't have an active scheduler
+    (some envs / tests start it disabled), register is a logged no-op
+    rather than an exception."""
+    from app.services.powell.l3_cascade_jobs import register_l3_cascade_jobs
+
+    fake_service = MagicMock(_scheduler=None)
+    register_l3_cascade_jobs(fake_service)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _discover_active_tenants
+# ---------------------------------------------------------------------------
+
+
+def _seed_tenant(
+    db: Session, *, tid: int, mode: str, status: str,
+) -> None:
+    from azirella_data_model.tenant import Tenant
+    db.add(Tenant(
+        id=tid, customer_id=1, name=f"T{tid}", mode=mode, status=status,
+    ))
+
+
+def _seed_config(
+    db: Session, *, cid: int, tid: int,
+    is_active: bool = True, scenario_type: str = "BASELINE",
+) -> None:
+    from azirella_data_model.master.config import SupplyChainConfig
+    db.add(SupplyChainConfig(
+        id=cid, tenant_id=tid, name=f"Cfg{cid}",
+        is_active=is_active, scenario_type=scenario_type,
+    ))
+
+
+def test_discover_includes_production_active_with_baseline_config(db) -> None:
+    """Happy path: a PRODUCTION + ACTIVE tenant with an active BASELINE
+    config is returned with its (tenant_id, config_id) pair."""
+    from app.services.powell.l3_cascade_jobs import _discover_active_tenants
+
+    _seed_tenant(db, tid=1, mode="PRODUCTION", status="ACTIVE")
+    _seed_config(db, cid=10, tid=1)
+    db.flush()
+
+    rows = _discover_active_tenants(db)
+    assert rows == [(1, 10)]
+
+
+def test_discover_excludes_learning_mode(db) -> None:
+    """LEARNING-mode tenants run the cascade on-demand, not on the
+    daily cron."""
+    from app.services.powell.l3_cascade_jobs import _discover_active_tenants
+
+    _seed_tenant(db, tid=1, mode="LEARNING", status="ACTIVE")
+    _seed_config(db, cid=10, tid=1)
+    db.flush()
+
+    assert _discover_active_tenants(db) == []
+
+
+def test_discover_excludes_inactive_status(db) -> None:
+    """Tenants with status != 'ACTIVE' (e.g., SUSPENDED, ARCHIVED)
+    are excluded."""
+    from app.services.powell.l3_cascade_jobs import _discover_active_tenants
+
+    _seed_tenant(db, tid=1, mode="PRODUCTION", status="SUSPENDED")
+    _seed_config(db, cid=10, tid=1)
+    db.flush()
+
+    assert _discover_active_tenants(db) == []
+
+
+def test_discover_excludes_non_baseline_or_inactive_config(db) -> None:
+    """SCENARIO configs and is_active=False configs are excluded — the
+    daily cron runs the production-baseline cascade only. Scenarios
+    are run on-demand via the manual trigger."""
+    from app.services.powell.l3_cascade_jobs import _discover_active_tenants
+
+    _seed_tenant(db, tid=1, mode="PRODUCTION", status="ACTIVE")
+    _seed_config(db, cid=10, tid=1, scenario_type="SCENARIO")  # excluded
+    _seed_config(db, cid=11, tid=1, is_active=False)            # excluded
+    db.flush()
+
+    assert _discover_active_tenants(db) == []
+
+
+def test_discover_returns_one_pair_per_tenant_config_match(db) -> None:
+    """Multiple eligible tenants → multiple rows."""
+    from app.services.powell.l3_cascade_jobs import _discover_active_tenants
+
+    _seed_tenant(db, tid=1, mode="PRODUCTION", status="ACTIVE")
+    _seed_tenant(db, tid=2, mode="PRODUCTION", status="ACTIVE")
+    _seed_tenant(db, tid=3, mode="LEARNING", status="ACTIVE")  # excluded
+    _seed_config(db, cid=10, tid=1)
+    _seed_config(db, cid=20, tid=2)
+    _seed_config(db, cid=30, tid=3)
+    db.flush()
+
+    rows = sorted(_discover_active_tenants(db))
+    assert rows == [(1, 10), (2, 20)]

--- a/backend/tests/powell/test_l3_cascade_runner.py
+++ b/backend/tests/powell/test_l3_cascade_runner.py
@@ -1,0 +1,269 @@
+"""§3.46 Phase 1 — L3CascadeRunner tests.
+
+Verifies orchestration of MovementPlannerService → IntegratedBalancerService:
+- happy-path end-to-end (both stages OK, shared cascade_run_id);
+- idempotency skip (second run on same period is a no-op);
+- force=True bypasses the idempotency skip;
+- stage-2 failure preserves stage-1 (per-stage transaction boundary);
+- stage-1 failure short-circuits stage-2;
+- cascade_run_id format and prefix.
+
+The fixture mirrors ``test_l3_planning_services.py`` (in-memory SQLite,
+stubs for FK targets that are out-of-scope for the orchestration layer).
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional
+
+import pytest
+from sqlalchemy import Column, Integer, create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from azirella_data_model.base import Base
+from azirella_data_model.transport_plan import (
+    LaneVolumePlan,
+    TransportationPlan,
+    TransportationPlanItem,
+)
+
+from app.services.powell.l3_cascade_runner import (
+    CascadeRunResult,
+    L3CascadeRunner,
+    StageResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# Local fixture (in-memory SQLite) — same pattern as test_l3_planning_services
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db() -> Session:
+    """In-memory SQLite session with FK-target stubs."""
+    for tbl, cls_name in (
+        ("supply_chain_configs", "_Cfg"),
+        ("scenarios", "_Sc"),
+        ("transportation_lane", "_Ln"),
+        ("site", "_Si"),
+        ("tenants", "_Tn"),
+        ("users", "_Us"),
+        ("carrier", "_Ca"),
+        ("freight_rate", "_Fr"),
+        ("load", "_Ld"),
+    ):
+        if tbl not in Base.metadata.tables:
+            type(cls_name, (Base,), {
+                "__tablename__": tbl,
+                "id": Column(Integer, primary_key=True),
+            })
+
+    engine = create_engine("sqlite:///:memory:")
+    tables = [
+        Base.metadata.tables[t] for t in [
+            "supply_chain_configs", "scenarios", "transportation_lane",
+            "site", "tenants", "users", "carrier", "freight_rate", "load",
+        ]
+    ] + [
+        LaneVolumePlan.__table__,
+        TransportationPlan.__table__,
+        TransportationPlanItem.__table__,
+    ]
+    Base.metadata.create_all(bind=engine, tables=tables)
+    Sess = sessionmaker(bind=engine)
+    s = Sess()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+def _seed_lane_volume_plan(
+    db: Session,
+    *,
+    lane_id: int = 10,
+    period_start: date = date(2026, 5, 4),
+    forecast_loads_p50: float = 3.0,
+    config_id: int = 1,
+    tenant_id: int = 1,
+) -> LaneVolumePlan:
+    row = LaneVolumePlan(
+        tenant_id=tenant_id, config_id=config_id,
+        scenario_id=None, lane_id=lane_id,
+        period_start=period_start, period_days=7,
+        mode="FTL", equipment_type="DRY_VAN",
+        forecast_loads_p10=forecast_loads_p50 - 1,
+        forecast_loads_p50=forecast_loads_p50,
+        forecast_loads_p90=forecast_loads_p50 + 1,
+        plan_version="unconstrained_reference",
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_runs_both_stages(db) -> None:
+    """End-to-end: forecast row → unconstrained plan → constrained plan.
+    Both stages succeed; shared cascade_run_id; OK status."""
+    _seed_lane_volume_plan(db, forecast_loads_p50=3)
+
+    runner = L3CascadeRunner(db)
+    result = runner.run(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        # No rate cards seeded → MovementPlanner falls back to NULL
+        # carriers; that's fine for the orchestration test.
+        resolve_capacity_from_db=False,  # Phase 1 clone-only
+    )
+
+    assert result.status == "OK", result
+    assert result.cascade_run_id.startswith("l3_1_")
+    assert len(result.stages) == 2
+    assert result.stages[0].stage == "movement"
+    assert result.stages[0].status == "OK"
+    assert result.stages[0].plan_id is not None
+    assert result.stages[1].stage == "balancer"
+    assert result.stages[1].status == "OK"
+    assert result.stages[1].plan_id is not None
+    assert result.stages[1].plan_id != result.stages[0].plan_id
+
+    # Both plans tagged with the same cascade_run_id.
+    plans = db.query(TransportationPlan).order_by(TransportationPlan.id).all()
+    assert len(plans) == 2
+    assert plans[0].cascade_run_id == result.cascade_run_id
+    assert plans[1].cascade_run_id == result.cascade_run_id
+    assert plans[0].plan_version == "unconstrained_reference"
+    assert plans[1].plan_version == "constrained_live"
+
+
+def test_idempotency_second_run_skips(db) -> None:
+    """A second run for the same (tenant, period) returns SKIPPED
+    without running either stage. Subsequent reruns are safe (the
+    cron in Phase 2 fires daily; we don't want duplicate plans)."""
+    _seed_lane_volume_plan(db, forecast_loads_p50=2)
+    runner = L3CascadeRunner(db)
+    first = runner.run(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        resolve_capacity_from_db=False,
+    )
+    assert first.status == "OK"
+
+    second = runner.run(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        resolve_capacity_from_db=False,
+    )
+    assert second.status == "SKIPPED"
+    assert second.stages == []
+    assert second.cascade_run_id != first.cascade_run_id  # New id even on skip
+    # No additional plans written.
+    assert db.query(TransportationPlan).count() == 2
+
+
+def test_force_bypasses_idempotency(db) -> None:
+    """force=True re-runs the cascade even when a prior plan exists
+    (replan-after-data-fix path)."""
+    _seed_lane_volume_plan(db, forecast_loads_p50=2)
+    runner = L3CascadeRunner(db)
+    first = runner.run(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        resolve_capacity_from_db=False,
+    )
+    assert first.status == "OK"
+
+    second = runner.run(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        resolve_capacity_from_db=False, force=True,
+    )
+    assert second.status == "OK"
+    assert second.cascade_run_id != first.cascade_run_id
+    # 2 cascades × 2 plans each = 4 plans total.
+    assert db.query(TransportationPlan).count() == 4
+
+
+def test_stage_2_failure_preserves_stage_1(db, monkeypatch) -> None:
+    """Per-stage transactions: if Balancer raises, the unconstrained
+    plan stays in the DB (operators can fix capacity data + re-run
+    just the Balancer)."""
+    _seed_lane_volume_plan(db, forecast_loads_p50=2)
+
+    from app.services.powell import integrated_balancer_service as ibs
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("simulated balancer failure")
+
+    monkeypatch.setattr(
+        ibs.IntegratedBalancerService, "balance_plan", _raise,
+    )
+
+    runner = L3CascadeRunner(db)
+    result = runner.run(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        resolve_capacity_from_db=False,
+    )
+
+    assert result.status == "FAILED"
+    assert len(result.stages) == 2
+    assert result.stages[0].status == "OK"
+    assert result.stages[1].status == "FAILED"
+    assert "simulated balancer failure" in result.stages[1].error
+
+    # Unconstrained plan still in DB.
+    plans = db.query(TransportationPlan).all()
+    assert len(plans) == 1
+    assert plans[0].plan_version == "unconstrained_reference"
+    assert plans[0].cascade_run_id == result.cascade_run_id
+
+
+def test_stage_1_failure_short_circuits(db, monkeypatch) -> None:
+    """If Movement Planner raises, the cascade stops there — Balancer
+    is not called."""
+    _seed_lane_volume_plan(db, forecast_loads_p50=2)
+
+    from app.services.powell import movement_planner_service as mps
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("simulated movement failure")
+
+    monkeypatch.setattr(
+        mps.MovementPlannerService, "plan_movement", _raise,
+    )
+
+    runner = L3CascadeRunner(db)
+    result = runner.run(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        resolve_capacity_from_db=False,
+    )
+
+    assert result.status == "FAILED"
+    assert len(result.stages) == 1
+    assert result.stages[0].stage == "movement"
+    assert result.stages[0].status == "FAILED"
+    assert "simulated movement failure" in result.stages[0].error
+    assert db.query(TransportationPlan).count() == 0
+
+
+def test_cascade_run_id_format(db) -> None:
+    """``l3_{tenant_id}_{utc_iso}_{uuid8}`` — verifies prefix, tenant
+    id slot, and uniqueness across same-period calls."""
+    _seed_lane_volume_plan(db, forecast_loads_p50=1)
+    runner = L3CascadeRunner(db)
+    a = runner.run(
+        tenant_id=42, config_id=1, period_start=date(2026, 5, 4),
+        resolve_capacity_from_db=False,
+    )
+    b = runner.run(
+        tenant_id=42, config_id=1, period_start=date(2026, 5, 4),
+        resolve_capacity_from_db=False, force=True,
+    )
+
+    parts = a.cascade_run_id.split("_")
+    assert parts[0] == "l3"
+    assert parts[1] == "42"
+    assert len(parts[2]) == 16  # YYYYMMDDTHHMMSSZ
+    assert len(parts[3]) == 8   # uuid hex slice
+    assert a.cascade_run_id != b.cascade_run_id

--- a/backend/tests/powell/test_l3_planning_services.py
+++ b/backend/tests/powell/test_l3_planning_services.py
@@ -1341,6 +1341,251 @@ def test_phase_3_41_trainer_returns_run_result_with_zero_examples(db) -> None:
     assert result.training_run_id.startswith("trainer_1_")
 
 
+# ===========================================================================
+# §3.41 Phase 3.4 — GraphSAGE inference-service wiring + A/B counters
+# ===========================================================================
+
+
+def _stub_model(*, carrier_id_per_item, rate_id_per_item=None, confidence=1.0,
+                model_version="stub_v1"):
+    """Return a stand-in :class:`GraphSAGEMovementPlannerModel` whose
+    ``predict`` emits the given carrier per draft item-id with the
+    given confidence. ``carrier_id_per_item`` is a dict ``{item_id:
+    carrier_id_or_None}``; missing keys → no prediction (heuristic
+    fallback). ``confidence`` may be a scalar (applied to every
+    prediction) or a dict ``{item_id: float}`` for mixed-confidence
+    tests."""
+    from app.services.powell.graphsage_movement_planner import (
+        GraphSAGEMovementPlannerModel,
+        GraphSAGEPredictionOutput,
+    )
+
+    class _Stub(GraphSAGEMovementPlannerModel):
+        def fit(self, training_data):
+            pass
+
+        def predict(self, inputs):
+            outputs = []
+            for fc in inputs.lane_volume_forecasts:
+                item_id = fc["item_id"]
+                if item_id not in carrier_id_per_item:
+                    continue
+                carrier = carrier_id_per_item[item_id]
+                conf = (
+                    confidence[item_id] if isinstance(confidence, dict)
+                    else confidence
+                )
+                outputs.append(GraphSAGEPredictionOutput(
+                    item_id=item_id,
+                    carrier_id=carrier,
+                    rate_id=(rate_id_per_item or {}).get(item_id),
+                    estimated_cost=None,
+                    confidence=conf,
+                    rationale={"source": "stub"},
+                ))
+            return outputs
+
+        def model_version(self):
+            return model_version
+
+    return _Stub()
+
+
+def test_phase_3_4_no_model_keeps_phase_2a(db) -> None:
+    """§3.41 Phase 3.4 baseline: when no model is passed, the planner
+    behaves exactly like Phase 2A — optimization_method stays
+    HEURISTIC_PHASE_2A and the new model counters are all 0."""
+    _seed_carrier_and_rate_cards(db)
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=3)
+
+    svc = MovementPlannerService(db)
+    result = svc.plan_movement(tenant_id=1, config_id=1, period_start=date(2026, 5, 4))
+
+    assert result.items_with_carrier == 3
+    assert result.items_via_model == 0
+    assert result.model_heuristic_agreements == 0
+    assert result.model_heuristic_overrides == 0
+    assert result.items_via_heuristic_fallback == 3
+    assert result.model_version is None
+
+    plan = db.query(TransportationPlan).one()
+    assert plan.optimization_method == "HEURISTIC_PHASE_2A"
+    assert plan.optimization_metadata is None
+
+
+def test_phase_3_4_untrained_model_abstains_falls_back_to_heuristic(db) -> None:
+    """§3.41 Phase 3.4: an untrained TorchGraphSAGEMovementPlanner
+    emits confidence=0.0, so every item falls back to the heuristic.
+    optimization_method stays HEURISTIC_PHASE_2A; model_version is
+    captured for audit."""
+    from app.services.powell.graphsage_movement_planner import (
+        TorchGraphSAGEMovementPlanner,
+    )
+
+    _seed_carrier_and_rate_cards(db)
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=3)
+
+    svc = MovementPlannerService(db)
+    model = TorchGraphSAGEMovementPlanner()
+    result = svc.plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        model=model,
+    )
+
+    assert result.items_with_carrier == 3
+    assert result.items_via_model == 0
+    assert result.items_via_heuristic_fallback == 3
+    assert result.model_version == "graphsage_untrained"
+
+    plan = db.query(TransportationPlan).one()
+    assert plan.optimization_method == "HEURISTIC_PHASE_2A"
+    assert plan.optimization_metadata is not None
+    assert plan.optimization_metadata["graphsage_model_version"] == "graphsage_untrained"
+    assert plan.optimization_metadata["items_via_model"] == 0
+
+
+def test_phase_3_4_high_confidence_model_overrides_heuristic(db) -> None:
+    """§3.41 Phase 3.4: when the model returns a different carrier with
+    confidence ≥ threshold, the heuristic's choice is overridden;
+    optimization_method becomes GRAPHSAGE_PHASE_3_4 (every assignable
+    item went through the model)."""
+    _seed_carrier_and_rate_cards(db)
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=3)
+
+    # Heuristic picks carrier 1 (cheaper); stub overrides to carrier 2.
+    model = _stub_model(
+        carrier_id_per_item={0: 2, 1: 2, 2: 2},
+        rate_id_per_item={0: 2, 1: 2, 2: 2},
+        confidence=0.9,
+        model_version="stub_override_v1",
+    )
+
+    svc = MovementPlannerService(db)
+    result = svc.plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        model=model, model_confidence_threshold=0.5,
+    )
+
+    assert result.items_with_carrier == 3
+    assert result.items_via_model == 3
+    assert result.model_heuristic_overrides == 3
+    assert result.model_heuristic_agreements == 0
+    assert result.items_via_heuristic_fallback == 0
+    assert result.model_version == "stub_override_v1"
+
+    plan = db.query(TransportationPlan).one()
+    assert plan.optimization_method == "GRAPHSAGE_PHASE_3_4"
+    items = db.query(TransportationPlanItem).all()
+    assert all(item.carrier_id == 2 for item in items)
+    assert all(item.rate_id == 2 for item in items)
+
+
+def test_phase_3_4_high_confidence_agreement_does_not_count_as_override(db) -> None:
+    """§3.41 Phase 3.4: when the model picks the same carrier as the
+    heuristic with confidence ≥ threshold, the assignment is counted as
+    an *agreement*, not an override; the heuristic's already-correct
+    rate id and cost are preserved."""
+    _seed_carrier_and_rate_cards(db)
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=2)
+
+    # Heuristic picks carrier 1; stub agrees on carrier 1.
+    model = _stub_model(
+        carrier_id_per_item={0: 1, 1: 1},
+        confidence=0.95,
+    )
+
+    svc = MovementPlannerService(db)
+    result = svc.plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        model=model,
+    )
+
+    assert result.items_via_model == 2
+    assert result.model_heuristic_agreements == 2
+    assert result.model_heuristic_overrides == 0
+
+    plan = db.query(TransportationPlan).one()
+    assert plan.optimization_method == "GRAPHSAGE_PHASE_3_4"
+    items = db.query(TransportationPlanItem).all()
+    assert all(item.carrier_id == 1 for item in items)
+    assert all(item.estimated_cost == 1875.0 for item in items)  # heuristic cost preserved
+
+
+def test_phase_3_4_partial_confidence_produces_hybrid(db) -> None:
+    """§3.41 Phase 3.4: when the model is high-confidence on some items
+    and low-confidence on others, the result is GRAPHSAGE_HEURISTIC_HYBRID
+    and per-item splits land in items_via_model / items_via_heuristic_fallback."""
+    _seed_carrier_and_rate_cards(db)
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=4)
+
+    # Items 0, 1: high-confidence override to carrier 2.
+    # Items 2, 3: low-confidence — heuristic stays.
+    model = _stub_model(
+        carrier_id_per_item={0: 2, 1: 2, 2: 2, 3: 2},
+        rate_id_per_item={0: 2, 1: 2, 2: 2, 3: 2},
+        confidence={0: 0.9, 1: 0.9, 2: 0.1, 3: 0.1},
+    )
+
+    svc = MovementPlannerService(db)
+    result = svc.plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        model=model, model_confidence_threshold=0.5,
+    )
+
+    assert result.items_with_carrier == 4
+    assert result.items_via_model == 2
+    assert result.model_heuristic_overrides == 2
+    assert result.items_via_heuristic_fallback == 2
+
+    plan = db.query(TransportationPlan).one()
+    assert plan.optimization_method == "GRAPHSAGE_HEURISTIC_HYBRID"
+    # First two items overridden to carrier 2; last two stayed at carrier 1.
+    items = sorted(
+        db.query(TransportationPlanItem).all(),
+        key=lambda i: i.planned_pickup_date,
+    )
+    assert items[0].carrier_id == 2 and items[1].carrier_id == 2
+    assert items[2].carrier_id == 1 and items[3].carrier_id == 1
+
+
+def test_phase_3_4_model_predict_exception_falls_back_safely(db) -> None:
+    """§3.41 Phase 3.4: if ``model.predict`` throws, the planner returns
+    the heuristic result with optimization_method=HEURISTIC_PHASE_2A
+    (no items_via_model). This is Phase 3.5's robustness contract:
+    inference failures must never break planning."""
+    from app.services.powell.graphsage_movement_planner import (
+        GraphSAGEMovementPlannerModel,
+    )
+
+    class _ThrowingModel(GraphSAGEMovementPlannerModel):
+        def fit(self, training_data): pass
+        def predict(self, inputs):
+            raise RuntimeError("simulated inference failure")
+        def model_version(self):
+            return "throw_v1"
+
+    _seed_carrier_and_rate_cards(db)
+    _seed_lane_profile(db)
+    _seed_lane_volume_plan(db, lane_id=10, mode="FTL", equipment_type="DRY_VAN", forecast_loads_p50=2)
+
+    svc = MovementPlannerService(db)
+    result = svc.plan_movement(
+        tenant_id=1, config_id=1, period_start=date(2026, 5, 4),
+        model=_ThrowingModel(),
+    )
+
+    assert result.items_with_carrier == 2
+    assert result.items_via_model == 0
+    assert result.items_via_heuristic_fallback == 2
+    plan = db.query(TransportationPlan).one()
+    assert plan.optimization_method == "HEURISTIC_PHASE_2A"
+
+
 def test_phase_3_42_expired_commitments_not_used(db) -> None:
     """A CarrierCapacityCommitment with effective_to in the past is
     excluded from the resolved capacity."""

--- a/backend/tests/scripts/test_l3_cascade_cli.py
+++ b/backend/tests/scripts/test_l3_cascade_cli.py
@@ -1,0 +1,145 @@
+"""§3.46 Phase 4 — l3_cascade_cli arg-parsing + helper tests.
+
+The full ``main()`` round-trip needs a real DB session via
+``sync_session_factory()`` which isn't available in the test fixture
+(same constraint as the Phase 2 jobs file). These tests cover the
+deterministic helpers — argument parsing, range expansion — without
+hitting the DB.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from scripts.l3_cascade_cli import (
+    _date_range,
+    _parse_args,
+)
+
+
+# ---------------------------------------------------------------------------
+# _date_range
+# ---------------------------------------------------------------------------
+
+
+def test_date_range_inclusive() -> None:
+    assert _date_range(date(2026, 5, 1), date(2026, 5, 3)) == [
+        date(2026, 5, 1),
+        date(2026, 5, 2),
+        date(2026, 5, 3),
+    ]
+
+
+def test_date_range_single_day() -> None:
+    assert _date_range(date(2026, 5, 1), date(2026, 5, 1)) == [
+        date(2026, 5, 1),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _parse_args — happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_parse_single_tenant_default_period() -> None:
+    args = _parse_args(["--tenant-id", "42"])
+    assert args.tenant_id == 42
+    assert args.all_tenants is False
+    assert args.period_start is None
+    assert args.from_date is None
+    assert args.period_days == 7
+    assert args.force is False
+    assert args.use_capacity_db is True
+    assert args.dry_run is False
+
+
+def test_parse_single_tenant_with_period() -> None:
+    args = _parse_args([
+        "--tenant-id", "42",
+        "--period-start", "2026-05-04",
+        "--config-id", "1",
+        "--period-days", "14",
+        "--force",
+    ])
+    assert args.tenant_id == 42
+    assert args.config_id == 1
+    assert args.period_start == date(2026, 5, 4)
+    assert args.period_days == 14
+    assert args.force is True
+
+
+def test_parse_backfill_range() -> None:
+    args = _parse_args([
+        "--tenant-id", "42",
+        "--from-date", "2026-05-01",
+        "--to-date", "2026-05-07",
+        "--force",
+    ])
+    assert args.from_date == date(2026, 5, 1)
+    assert args.to_date == date(2026, 5, 7)
+
+
+def test_parse_all_tenants() -> None:
+    args = _parse_args(["--all-tenants"])
+    assert args.all_tenants is True
+    assert args.tenant_id is None
+
+
+def test_parse_no_capacity_db_flag() -> None:
+    args = _parse_args(["--tenant-id", "42", "--no-capacity-db"])
+    assert args.use_capacity_db is False
+
+
+def test_parse_dry_run() -> None:
+    args = _parse_args(["--tenant-id", "42", "--dry-run"])
+    assert args.dry_run is True
+
+
+# ---------------------------------------------------------------------------
+# _parse_args — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_parse_requires_tenant_or_all() -> None:
+    with pytest.raises(SystemExit):
+        _parse_args([])
+
+
+def test_parse_rejects_tenant_id_with_all_tenants() -> None:
+    with pytest.raises(SystemExit):
+        _parse_args(["--tenant-id", "42", "--all-tenants"])
+
+
+def test_parse_rejects_period_start_with_from_date() -> None:
+    with pytest.raises(SystemExit):
+        _parse_args([
+            "--tenant-id", "42",
+            "--period-start", "2026-05-04",
+            "--from-date", "2026-05-01",
+            "--to-date", "2026-05-07",
+        ])
+
+
+def test_parse_rejects_from_date_without_to_date() -> None:
+    with pytest.raises(SystemExit):
+        _parse_args(["--tenant-id", "42", "--from-date", "2026-05-01"])
+
+
+def test_parse_rejects_to_date_without_from_date() -> None:
+    with pytest.raises(SystemExit):
+        _parse_args(["--tenant-id", "42", "--to-date", "2026-05-07"])
+
+
+def test_parse_rejects_inverted_range() -> None:
+    with pytest.raises(SystemExit):
+        _parse_args([
+            "--tenant-id", "42",
+            "--from-date", "2026-05-07",
+            "--to-date", "2026-05-01",
+        ])
+
+
+def test_parse_rejects_bad_date_format() -> None:
+    with pytest.raises(SystemExit):
+        _parse_args(["--tenant-id", "42", "--period-start", "5/4/2026"])


### PR DESCRIPTION
## Summary

Three TMS-side phases of §3.46 land together; Phase 3 (Core `CascadeRun` substrate) ships as the companion `azirella-ltd/Autonomy-Core#61`.

- **Phase 1 — `L3CascadeRunner` (`app/services/powell/l3_cascade_runner.py`).** Orchestration primitive that runs `MovementPlannerService → IntegratedBalancerService` for one (tenant, period) with a shared `cascade_run_id` (shape `l3_<tenant>_<utc>_<uuid8>`), per-stage commits (stage-2 failure preserves stage-1), and idempotency skip when a prior L3 plan exists for the period (`force=True` bypasses).
- **Phase 2 — APScheduler registration (`app/services/powell/l3_cascade_jobs.py`).** Daily 5:00 UTC cron iterates active PRODUCTION + BASELINE-config tenants, runs `L3CascadeRunner` per-tenant with try/except isolation, wired into `main.py` startup alongside `register_planning_cascade_jobs`.
- **Phase 4 — manual-trigger CLI (`scripts/l3_cascade_cli.py`).** Operator entry point for replan-after-data-fix (`--tenant-id 42 --period-start 2026-05-04 --force`), backfill (`--from-date / --to-date`), and manual daily run (`--all-tenants`). Includes `--dry-run` and `--no-capacity-db` flags.

## Stacking

This branch is stacked on top of `feat/3.41-phase-3.4-graphsage-inference-wiring` (PR #20), because Phase 1's `L3CascadeRunner` imports `IntegratedBalancerService`, which had a broken `app.models.tms_planning.TransportationPlan` re-export until PR #20 landed the retarget. Merge order: **PR #20 first, then this PR**. After PR #20 merges, this PR's diff against `main` will narrow to just the §3.46 changes (the rebase already de-duped any commits also on main).

## Test plan

- [x] **Phase 1**: 6 tests + 6-scenario programmatic smoke (no_model / untrained_abstains is N/A here — those are Phase 3.4; here the 6 are happy_path / idempotency_skip / force_bypass / stage-2_fail_preserves_stage-1 / stage-1_fail_short_circuits / run_id_format).
- [x] **Phase 2**: 7 tests (5 `_discover_active_tenants` filter cases + 2 `register_l3_cascade_jobs` cases) + register-side smoke verified.
- [x] **Phase 4**: 13 tests (argparse happy paths + error paths + `_date_range`) + 11-case CLI smoke verified.
- [ ] After PR #20 + this PR + Core #61 land: deploy to staging, verify the daily 5:00 UTC cron fires + writes a `TransportationPlan(plan_version='constrained_live')` per active tenant.
- [ ] Phase 3-followon (separate PR): emit `CascadeRun` rows from `L3CascadeRunner` once Core #61 lands; retarget `transportation_plan.cascade_run_id` String → FK on `cascade_run.id`.

Refs: `docs/MIGRATION_REGISTER.md` §3.46 + `CONSUMER_ADOPTION_LOG.md` 2026-05-03 in Autonomy-Core (Core #61).

🤖 Generated with [Claude Code](https://claude.com/claude-code)