### PR TITLE
feat(§3.47): carrier-identity cutover — Core owns Carrier, TMS owns CarrierTMSProfile

### DIFF
--- a/backend/app/api/endpoints/freight_procurement.py
+++ b/backend/app/api/endpoints/freight_procurement.py
@@ -180,7 +180,7 @@ async def get_carrier_waterfall(
 
             entries.append(WaterfallEntry(
                 carrier_id=carrier.id,
-                carrier_name=carrier.name,
+                carrier_name=carrier.display_name,
                 carrier_code=profile.code if profile else None,
                 rate=float(rate) if rate else 0,
                 priority=cl.priority,

--- a/backend/app/api/endpoints/freight_procurement.py
+++ b/backend/app/api/endpoints/freight_procurement.py
@@ -20,8 +20,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_db, get_current_user
 from app.models.tms_entities import (
-    Load, LoadStatus, Carrier, CarrierLane, FreightRate, FreightTender,
-    TenderStatus,
+    Load, LoadStatus, Carrier, CarrierTMSProfile, CarrierLane, FreightRate,
+    FreightTender, TenderStatus,
 )
 from app.models.user import User
 
@@ -141,9 +141,16 @@ async def get_carrier_waterfall(
         if not load:
             raise HTTPException(404, f"Load {load_id} not found")
 
+        # §3.47 Phase 2 — outer-join CarrierTMSProfile so dispatch
+        # fields (`code` etc.) come from the new substrate. Outer-join
+        # keeps the row when no profile exists yet (defensive).
         lane_q = (
-            select(CarrierLane, Carrier)
+            select(CarrierLane, Carrier, CarrierTMSProfile)
             .join(Carrier, CarrierLane.carrier_id == Carrier.id)
+            .outerjoin(
+                CarrierTMSProfile,
+                CarrierTMSProfile.carrier_id == Carrier.id,
+            )
             .where(CarrierLane.is_active.is_(True))
             .order_by(CarrierLane.priority)
         )
@@ -160,7 +167,7 @@ async def get_carrier_waterfall(
 
         entries = []
         tenant_for_rates = user.tenant_id if user.tenant_id is not None else load.tenant_id
-        for cl, carrier in cls[:20]:
+        for cl, carrier, profile in cls[:20]:
             rate = sync_db.execute(
                 select(FreightRate.rate_flat).where(
                     and_(
@@ -174,7 +181,7 @@ async def get_carrier_waterfall(
             entries.append(WaterfallEntry(
                 carrier_id=carrier.id,
                 carrier_name=carrier.name,
-                carrier_code=carrier.code,
+                carrier_code=profile.code if profile else None,
                 rate=float(rate) if rate else 0,
                 priority=cl.priority,
                 acceptance_pct=0.85,

--- a/backend/app/api/endpoints/tms_api.py
+++ b/backend/app/api/endpoints/tms_api.py
@@ -389,7 +389,7 @@ async def get_carrier_detail(
         detail = CarrierDetail(
             id=carrier.id,
             code=profile.code if profile else None,
-            name=carrier.name,
+            name=carrier.display_name,
             carrier_type=_safe_str(carrier.carrier_type),
             scac=carrier.scac,
             mc_number=carrier.mc_number,
@@ -398,7 +398,7 @@ async def get_carrier_detail(
             modes=profile.modes if profile else None,
             equipment_types=profile.equipment_types if profile else None,
             service_regions=profile.service_regions if profile else None,
-            is_active=carrier.is_active,
+            is_active=(carrier.status == "ACTIVE"),
             is_hazmat_certified=(
                 profile.is_hazmat_certified if profile else False
             ),
@@ -1397,17 +1397,33 @@ async def create_carrier(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ):
-    """Create a new carrier for the current tenant."""
+    """Create a new carrier for the current tenant.
+
+    §3.47 Phase 3: Carrier holds canonical identity (Core schema);
+    dispatch fields land on a sibling CarrierTMSProfile row.
+    """
     cfg = await _resolve_config_id(body.config_id, current_user, db)
     c = Carrier(
         tenant_id=current_user.tenant_id,
-        config_id=cfg,
-        code=body.code,
-        name=body.name,
-        carrier_type=body.carrier_type,
         scac=body.scac,
+        display_name=body.name,
+        carrier_type=body.carrier_type,
+        status=(
+            "ACTIVE" if (body.is_active is None or body.is_active) else "INACTIVE"
+        ),
         mc_number=body.mc_number,
         dot_number=body.dot_number,
+        currency="USD",
+        payment_terms_days=30,
+    )
+    db.add(c)
+    await db.flush()  # populate c.id
+
+    profile = CarrierTMSProfile(
+        carrier_id=c.id,
+        tenant_id=current_user.tenant_id,
+        config_id=cfg,
+        code=body.code,
         modes=body.modes or [],
         equipment_types=body.equipment_types or [],
         service_regions=body.service_regions or [],
@@ -1419,14 +1435,13 @@ async def create_carrier(
         primary_contact_phone=body.primary_contact_phone,
         dispatch_email=body.dispatch_email,
         dispatch_phone=body.dispatch_phone,
-        is_active=body.is_active if body.is_active is not None else True,
         onboarding_status=body.onboarding_status or "ACTIVE",
         source="manual",
     )
-    db.add(c)
+    db.add(profile)
     await db.commit()
     await db.refresh(c)
-    return {"id": c.id, "code": c.code, "name": c.name}
+    return {"id": c.id, "code": body.code, "name": c.display_name}
 
 
 @carriers_router.patch("/{carrier_id}", response_model=Dict[str, Any])
@@ -1436,7 +1451,11 @@ async def update_carrier(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ):
-    """Update an existing carrier."""
+    """Update an existing carrier.
+
+    §3.47 Phase 3: split writes between Core's Carrier (canonical
+    identity fields) and TMS's CarrierTMSProfile (dispatch fields).
+    """
     stmt = select(Carrier).where(
         Carrier.id == carrier_id,
         Carrier.tenant_id == current_user.tenant_id,
@@ -1444,17 +1463,42 @@ async def update_carrier(
     c = (await db.execute(stmt)).scalar_one_or_none()
     if not c:
         raise HTTPException(404, f"Carrier {carrier_id} not found")
-    for f in ["code", "name", "carrier_type", "scac", "mc_number", "dot_number",
-              "modes", "equipment_types", "service_regions", "is_hazmat_certified",
-              "is_bonded", "insurance_limit", "primary_contact_name",
-              "primary_contact_email", "primary_contact_phone", "dispatch_email",
-              "dispatch_phone", "is_active", "onboarding_status"]:
+
+    # Core canonical fields on Carrier itself.
+    if body.name is not None:
+        c.display_name = body.name
+    for f in ("carrier_type", "scac", "mc_number", "dot_number"):
         v = getattr(body, f)
         if v is not None:
             setattr(c, f, v)
+    if body.is_active is not None:
+        c.status = "ACTIVE" if body.is_active else "INACTIVE"
+
+    # Dispatch fields on CarrierTMSProfile (upsert).
+    profile_stmt = select(CarrierTMSProfile).where(
+        CarrierTMSProfile.carrier_id == carrier_id,
+        CarrierTMSProfile.tenant_id == current_user.tenant_id,
+    )
+    profile = (await db.execute(profile_stmt)).scalar_one_or_none()
+    if profile is None:
+        profile = CarrierTMSProfile(
+            carrier_id=carrier_id, tenant_id=current_user.tenant_id,
+        )
+        db.add(profile)
+    for f in (
+        "code", "modes", "equipment_types", "service_regions",
+        "is_hazmat_certified", "is_bonded", "insurance_limit",
+        "primary_contact_name", "primary_contact_email",
+        "primary_contact_phone", "dispatch_email", "dispatch_phone",
+        "onboarding_status",
+    ):
+        v = getattr(body, f, None)
+        if v is not None:
+            setattr(profile, f, v)
+
     await db.commit()
     await db.refresh(c)
-    return {"id": c.id, "code": c.code, "name": c.name, "updated": True}
+    return {"id": c.id, "code": profile.code, "name": c.display_name, "updated": True}
 
 
 @carriers_router.delete("/{carrier_id}", response_model=Dict[str, Any])
@@ -1463,7 +1507,12 @@ async def delete_carrier(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ):
-    """Soft-delete a carrier (set is_active=False)."""
+    """Soft-delete a carrier (Core status=INACTIVE; profile
+    onboarding_status=SUSPENDED).
+
+    §3.47 Phase 3: ``status`` lives on Core's Carrier;
+    ``onboarding_status`` lives on TMS's CarrierTMSProfile.
+    """
     stmt = select(Carrier).where(
         Carrier.id == carrier_id,
         Carrier.tenant_id == current_user.tenant_id,
@@ -1471,8 +1520,16 @@ async def delete_carrier(
     c = (await db.execute(stmt)).scalar_one_or_none()
     if not c:
         raise HTTPException(404, f"Carrier {carrier_id} not found")
-    c.is_active = False
-    c.onboarding_status = "SUSPENDED"
+    c.status = "INACTIVE"
+
+    profile_stmt = select(CarrierTMSProfile).where(
+        CarrierTMSProfile.carrier_id == carrier_id,
+        CarrierTMSProfile.tenant_id == current_user.tenant_id,
+    )
+    profile = (await db.execute(profile_stmt)).scalar_one_or_none()
+    if profile is not None:
+        profile.onboarding_status = "SUSPENDED"
+
     await db.commit()
     return {"id": carrier_id, "deleted": True}
 

--- a/backend/app/api/endpoints/tms_api.py
+++ b/backend/app/api/endpoints/tms_api.py
@@ -28,6 +28,7 @@ from app.models.tms_entities import (
     AppointmentStatus,
     AppointmentType,
     Carrier,
+    CarrierTMSProfile,
     CarrierLane,
     CarrierScorecard,
     DockDoor,
@@ -358,6 +359,13 @@ async def get_carrier_detail(
         if carrier is None:
             return {"error": "Carrier not found"}
 
+        # §3.47 Phase 2 — dispatch fields live on CarrierTMSProfile.
+        profile_stmt = select(CarrierTMSProfile).where(
+            CarrierTMSProfile.carrier_id == carrier_id,
+            CarrierTMSProfile.tenant_id == current_user.tenant_id,
+        )
+        profile = (await db.execute(profile_stmt)).scalar_one_or_none()
+
         # Fetch carrier lanes
         lane_stmt = select(CarrierLane).where(
             CarrierLane.carrier_id == carrier_id,
@@ -380,23 +388,25 @@ async def get_carrier_detail(
 
         detail = CarrierDetail(
             id=carrier.id,
-            code=carrier.code,
+            code=profile.code if profile else None,
             name=carrier.name,
             carrier_type=_safe_str(carrier.carrier_type),
             scac=carrier.scac,
             mc_number=carrier.mc_number,
             dot_number=carrier.dot_number,
-            usdot_safety_rating=carrier.usdot_safety_rating,
-            modes=carrier.modes,
-            equipment_types=carrier.equipment_types,
-            service_regions=carrier.service_regions,
+            usdot_safety_rating=profile.usdot_safety_rating if profile else None,
+            modes=profile.modes if profile else None,
+            equipment_types=profile.equipment_types if profile else None,
+            service_regions=profile.service_regions if profile else None,
             is_active=carrier.is_active,
-            is_hazmat_certified=carrier.is_hazmat_certified,
-            onboarding_status=carrier.onboarding_status,
-            primary_contact_name=carrier.primary_contact_name,
-            primary_contact_email=carrier.primary_contact_email,
-            dispatch_email=carrier.dispatch_email,
-            dispatch_phone=carrier.dispatch_phone,
+            is_hazmat_certified=(
+                profile.is_hazmat_certified if profile else False
+            ),
+            onboarding_status=profile.onboarding_status if profile else None,
+            primary_contact_name=profile.primary_contact_name if profile else None,
+            primary_contact_email=profile.primary_contact_email if profile else None,
+            dispatch_email=profile.dispatch_email if profile else None,
+            dispatch_phone=profile.dispatch_phone if profile else None,
             lane_count=len(lanes_data),
             lanes=lanes_data,
         )

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -387,7 +387,7 @@ from .tms_entities import (
     # Commodity
     CommodityHierarchy, Commodity,
     # Carrier & Equipment
-    Carrier, CarrierLane, Equipment, CarrierScorecard,
+    Carrier, CarrierTMSProfile, CarrierLane, Equipment, CarrierScorecard,
     # Shipment & Load
     Shipment, ShipmentLeg, Load, LoadItem,
     # Freight Rates & Tender
@@ -755,7 +755,7 @@ __all__ = [
     'ExceptionType', 'ExceptionSeverity', 'ExceptionResolutionStatus',
     'CarrierType', 'TenderStatus', 'AppointmentType', 'AppointmentStatus', 'RateType',
     'CommodityHierarchy', 'Commodity',
-    'Carrier', 'CarrierLane', 'Equipment', 'CarrierScorecard',
+    'Carrier', 'CarrierTMSProfile', 'CarrierLane', 'Equipment', 'CarrierScorecard',
     'Shipment', 'ShipmentLeg', 'Load', 'LoadItem',
     'FreightRate', 'FreightTender',
     'DockDoor', 'Appointment',

--- a/backend/app/models/tms_entities.py
+++ b/backend/app/models/tms_entities.py
@@ -45,6 +45,11 @@ from typing import Optional
 from enum import Enum as PyEnum
 from .base import Base
 
+# §3.47 — Core owns canonical carrier identity. Re-export so existing
+# `from app.models.tms_entities import ..., Carrier, ...` callsites
+# keep working; new code can import from Core directly.
+from azirella_data_model.settlement.entities import Carrier  # noqa: F401
+
 
 # ============================================================================
 # Enums
@@ -311,75 +316,21 @@ class Commodity(Base):
 # Carrier & Equipment Entities
 # ============================================================================
 
-class Carrier(Base):
-    """
-    Transportation carrier / capacity provider
-    TMS Entity: carrier
-    Maps to Site(MARKET_SUPPLY) in SC context — provides capacity rather than goods
-
-    Extends TradingPartner with carrier-specific attributes.
-    """
-    __tablename__ = "carrier"
-
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    code = Column(String(100), nullable=False, comment="Carrier SCAC or internal code")
-    name = Column(String(200), nullable=False)
-    carrier_type = Column(SAEnum(CarrierType, name="carrier_type_enum"), nullable=False)
-    scac = Column(String(10), comment="Standard Carrier Alpha Code")
-    mc_number = Column(String(20), comment="Motor Carrier number (FMCSA)")
-    dot_number = Column(String(20), comment="USDOT number")
-    usdot_safety_rating = Column(String(20), comment="Satisfactory/Conditional/Unsatisfactory")
-
-    # Capabilities
-    modes = Column(JSON, comment='Supported modes: ["FTL", "LTL", "DRAYAGE"]')
-    equipment_types = Column(JSON, comment='Supported equipment: ["DRY_VAN", "REEFER"]')
-    service_regions = Column(JSON, comment='Geographic coverage: ["US_DOMESTIC", "US_MX", "TRANSPACIFIC"]')
-    is_hazmat_certified = Column(Boolean, default=False)
-    is_bonded = Column(Boolean, default=False)
-    insurance_limit = Column(Double, comment="Cargo insurance limit (USD)")
-
-    # Contact
-    primary_contact_name = Column(String(200))
-    primary_contact_email = Column(String(200))
-    primary_contact_phone = Column(String(50))
-    dispatch_email = Column(String(200))
-    dispatch_phone = Column(String(50))
-    tracking_api_type = Column(String(50), comment="EDI, API, PORTAL, P44, FOURKITES")
-    tracking_api_config = Column(JSON, comment="API credentials and endpoint config")
-
-    # Status
-    is_active = Column(Boolean, default=True)
-    onboarding_status = Column(String(20), default="PENDING", comment="PENDING, IN_PROGRESS, ACTIVE, SUSPENDED")
-    onboarding_date = Column(Date)
-    last_shipment_date = Column(Date)
-
-    # Source tracking
-    source = Column(String(100))
-    external_identifiers = Column(JSON, nullable=True, comment="Typed external IDs: {sap_vendor, p44_id, ...}")
-
-    # p44 integration (aligned with CapacityProviderIdentifier schema)
-    p44_carrier_id = Column(String(100), comment="project44 carrier identifier")
-    p44_identifier_type = Column(String(20), comment="P44 CapacityProviderIdentifier.type: SCAC, DOT_NUMBER, MC_NUMBER, P44_EU, P44_GLOBAL, VAT, SYSTEM")
-    p44_account_group_code = Column(String(100), comment="P44 CapacityProviderAccountGroupInfo.code")
-    p44_account_code = Column(String(100), comment="P44 CapacityProviderAccountInfos.code")
-
-    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False)
-    config_id = Column(Integer, ForeignKey("supply_chain_configs.id", ondelete="CASCADE"))
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
-
-    # Relationships
-    lanes = relationship("CarrierLane", back_populates="carrier", cascade="all, delete-orphan")
-    equipment = relationship("Equipment", back_populates="carrier", cascade="all, delete-orphan")
-    rates = relationship("FreightRate", back_populates="carrier", cascade="all, delete-orphan")
-    scorecards = relationship("CarrierScorecard", back_populates="carrier", cascade="all, delete-orphan")
-    tenders = relationship("FreightTender", back_populates="carrier")
-
-    __table_args__ = (
-        UniqueConstraint('tenant_id', 'code', name='uq_carrier_tenant_code'),
-        Index('idx_carrier_tenant_active', 'tenant_id', 'is_active'),
-        Index('idx_carrier_scac', 'scac'),
-    )
+# §3.47 Phase 3: TMS-side `class Carrier(Base)` deleted. The
+# canonical Carrier identity now lives in Core
+# (`azirella_data_model.settlement.entities.Carrier`); it's
+# re-exported at the top of this file so existing
+# `from app.models.tms_entities import Carrier` imports keep working.
+# The TMS-specific dispatch fields (code, modes, equipment_types,
+# tracking_api_*, p44_*, etc.) live on `CarrierTMSProfile` below,
+# joined to `Carrier` via `carrier_id`.
+#
+# Relationships from CarrierLane / Equipment / FreightRate /
+# CarrierScorecard / FreightTender to Carrier keep their
+# `relationship("Carrier")` declarations but DROP `back_populates`
+# (Core's Carrier doesn't expose `lanes` / `equipment` / etc.
+# collections — those are TMS dispatch concerns and don't belong
+# on a settlement-side identity row).
 
 
 # ============================================================================
@@ -535,7 +486,7 @@ class CarrierLane(Base):
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     # Relationships
-    carrier = relationship("Carrier", back_populates="lanes")
+    carrier = relationship("Carrier")
     lane = relationship("TransportationLane")
 
     __table_args__ = (
@@ -588,7 +539,7 @@ class Equipment(Base):
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     # Relationships
-    carrier = relationship("Carrier", back_populates="equipment")
+    carrier = relationship("Carrier")
     current_site = relationship("Site", foreign_keys=[current_site_id])
 
     __table_args__ = (
@@ -646,7 +597,7 @@ class CarrierScorecard(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
 
     # Relationships
-    carrier = relationship("Carrier", back_populates="scorecards")
+    carrier = relationship("Carrier")
 
     __table_args__ = (
         Index('idx_scorecard_carrier_period', 'carrier_id', 'period_start'),
@@ -997,7 +948,7 @@ class FreightRate(Base):
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     # Relationships
-    carrier = relationship("Carrier", back_populates="rates")
+    carrier = relationship("Carrier")
     lane = relationship("TransportationLane")
 
     __table_args__ = (
@@ -1044,7 +995,7 @@ class FreightTender(Base):
     # Relationships
     shipment = relationship("app.models.tms_entities.TMSShipment", back_populates="tenders")
     load = relationship("Load")
-    carrier = relationship("Carrier", back_populates="tenders")
+    carrier = relationship("Carrier")
     rate = relationship("FreightRate")
 
     __table_args__ = (

--- a/backend/app/models/tms_entities.py
+++ b/backend/app/models/tms_entities.py
@@ -382,6 +382,127 @@ class Carrier(Base):
     )
 
 
+# ============================================================================
+# CarrierTMSProfile — §3.47 Phase 1 substrate
+# ============================================================================
+# Per §3.47, Core (`azirella_data_model.settlement.entities.Carrier`)
+# owns canonical carrier identity (id, scac, display_name, carrier_type,
+# status, mc_number, dot_number, tax_id, currency, payment_terms_days,
+# metadata). TMS owns dispatch / capacity / onboarding extensions in
+# this sibling table, joined via `carrier_id`. Phase 1 lands the
+# substrate (additive); Phase 2 retargets TMS code to read dispatch
+# fields from here; Phase 3 drops the now-duplicated columns from
+# `carrier` and deletes the TMS-side `Carrier` ORM above.
+
+
+class CarrierTMSProfile(Base):
+    """TMS dispatch / capacity / onboarding extension to Core's Carrier.
+
+    One profile row per carrier (1:1, FK + unique). All fields here
+    are TMS-specific dispatch policy that other Autonomy products
+    don't consume — keeping them out of Core respects Rule 1 + the
+    plane-module invariant.
+
+    Phase 1 backfills this table from the existing `carrier` rows in
+    the same Alembic migration. Phase 2's code cutover reads dispatch
+    fields from here. Phase 3 drops the duplicated columns from
+    `carrier`.
+    """
+
+    __tablename__ = "carrier_tms_profile"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    carrier_id = Column(
+        Integer,
+        ForeignKey("carrier.id", ondelete="CASCADE"),
+        nullable=False, unique=True,
+        comment="Core carrier identity FK — exactly one profile per carrier.",
+    )
+    tenant_id = Column(
+        Integer,
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    # TMS-internal carrier code (distinct from SCAC; tenant-scoped uniqueness).
+    code = Column(
+        String(100),
+        comment="TMS-internal carrier code; tenant-scoped unique.",
+    )
+
+    # FMCSA fleet-safety rating (TMS-side dispatch decision input).
+    usdot_safety_rating = Column(
+        String(20),
+        comment="Satisfactory / Conditional / Unsatisfactory",
+    )
+
+    # Capabilities — what modes / equipment / regions the carrier serves.
+    modes = Column(JSON, comment='e.g., ["FTL", "LTL", "DRAYAGE"]')
+    equipment_types = Column(JSON, comment='e.g., ["DRY_VAN", "REEFER"]')
+    service_regions = Column(JSON, comment='e.g., ["US_DOMESTIC", "TRANSPACIFIC"]')
+    is_hazmat_certified = Column(Boolean, default=False)
+    is_bonded = Column(Boolean, default=False)
+    insurance_limit = Column(Double, comment="Cargo insurance limit (USD)")
+
+    # Contact / dispatch.
+    primary_contact_name = Column(String(200))
+    primary_contact_email = Column(String(200))
+    primary_contact_phone = Column(String(50))
+    dispatch_email = Column(String(200))
+    dispatch_phone = Column(String(50))
+    tracking_api_type = Column(
+        String(50),
+        comment="EDI, API, PORTAL, P44, FOURKITES",
+    )
+    tracking_api_config = Column(
+        JSON, comment="API credentials and endpoint config",
+    )
+
+    # Onboarding lifecycle (TMS-side; orthogonal to Core's settlement
+    # `Carrier.status` which tracks settlement-payable state).
+    onboarding_status = Column(
+        String(20), default="PENDING",
+        comment="PENDING, IN_PROGRESS, ACTIVE, SUSPENDED",
+    )
+    onboarding_date = Column(Date)
+    last_shipment_date = Column(Date)
+
+    # Source tracking + external identifiers.
+    source = Column(String(100))
+    external_identifiers = Column(
+        JSON,
+        comment="Typed external IDs: {sap_vendor, p44_id, ...}",
+    )
+
+    # project44 integration (TMS-specific).
+    p44_carrier_id = Column(String(100))
+    p44_identifier_type = Column(String(20))
+    p44_account_group_code = Column(String(100))
+    p44_account_code = Column(String(100))
+
+    # Tenant-config link (TMS-specific).
+    config_id = Column(
+        Integer,
+        ForeignKey("supply_chain_configs.id", ondelete="CASCADE"),
+    )
+
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow,
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id", "code",
+            name="uq_carrier_tms_profile_tenant_code",
+        ),
+        Index(
+            "idx_carrier_tms_profile_tenant_onboarding",
+            "tenant_id", "onboarding_status",
+        ),
+    )
+
+
 class CarrierLane(Base):
     """
     Carrier lane coverage — which origin-destination pairs a carrier serves

--- a/backend/app/services/powell/freight_procurement_trm.py
+++ b/backend/app/services/powell/freight_procurement_trm.py
@@ -301,7 +301,7 @@ class FreightProcurementTRM:
 
             candidates.append({
                 "carrier_id": carrier.id,
-                "carrier_name": carrier.name,
+                "carrier_name": carrier.display_name,
                 "carrier_code": profile.code if profile else None,
                 "rate": float(rate) if rate else 2500.0,
                 "priority": cl.priority,

--- a/backend/app/services/powell/freight_procurement_trm.py
+++ b/backend/app/services/powell/freight_procurement_trm.py
@@ -27,7 +27,7 @@ from sqlalchemy import and_, select, text
 from sqlalchemy.orm import Session
 
 from app.models.tms_entities import (
-    Carrier, CarrierLane, FreightRate, FreightTender,
+    Carrier, CarrierTMSProfile, CarrierLane, FreightRate, FreightTender,
     Load, LoadStatus, TenderStatus, TransportMode, EquipmentType,
     RateType,
 )
@@ -260,12 +260,25 @@ class FreightProcurementTRM:
     # ── Helpers ──────────────────────────────────────────────────────────
 
     def _get_carrier_candidates(self, load: Load) -> List[Dict[str, Any]]:
-        """Build carrier waterfall for a load from CarrierLane + FreightRate."""
-        # Find carrier lanes matching this load's origin→destination
+        """Build carrier waterfall for a load from CarrierLane + FreightRate.
+
+        §3.47 Phase 2: dispatch-side ``code`` lives on
+        ``CarrierTMSProfile`` (1:1 with Carrier via carrier_id). The
+        outer-join keeps the row even when no profile exists yet
+        (graceful for tenants pre-Phase-1 backfill).
+        """
+        # Find carrier lanes matching this load's origin→destination.
+        # OUTER JOIN CarrierTMSProfile so the candidate list survives
+        # carriers without a profile row (defensive — backfill may not
+        # have completed for late-onboarded carriers).
         cls = self.db.execute(
-            select(CarrierLane, Carrier).join(
-                Carrier, CarrierLane.carrier_id == Carrier.id
-            ).where(
+            select(CarrierLane, Carrier, CarrierTMSProfile)
+            .join(Carrier, CarrierLane.carrier_id == Carrier.id)
+            .outerjoin(
+                CarrierTMSProfile,
+                CarrierTMSProfile.carrier_id == Carrier.id,
+            )
+            .where(
                 and_(
                     CarrierLane.tenant_id == self.tenant_id,
                     CarrierLane.is_active.is_(True),
@@ -274,7 +287,7 @@ class FreightProcurementTRM:
         ).all()
 
         candidates = []
-        for cl, carrier in cls:
+        for cl, carrier, profile in cls:
             # Find rate for this carrier
             rate = self.db.execute(
                 select(FreightRate.rate_flat).where(
@@ -289,7 +302,7 @@ class FreightProcurementTRM:
             candidates.append({
                 "carrier_id": carrier.id,
                 "carrier_name": carrier.name,
-                "carrier_code": carrier.code,
+                "carrier_code": profile.code if profile else None,
                 "rate": float(rate) if rate else 2500.0,
                 "priority": cl.priority,
                 "acceptance_pct": 0.85,

--- a/backend/app/services/powell/movement_planner_training_data.py
+++ b/backend/app/services/powell/movement_planner_training_data.py
@@ -42,7 +42,7 @@ from typing import Any, Dict, Iterator, List, Optional
 
 from sqlalchemy.orm import Session
 
-from app.models.tms_planning import (
+from azirella_data_model.transport_plan import (
     PlanStatus,
     PlanItemStatus,
     TransportationPlan,

--- a/backend/app/services/tms/food_dist_tms_overlay.py
+++ b/backend/app/services/tms/food_dist_tms_overlay.py
@@ -394,59 +394,63 @@ class FoodDistTMSOverlay:
             self._lanes.append(lane)
         self.session.flush()
 
-    def _seed_carriers(self) -> None:
-        existing = {
-            c.code: c for c in self.session.execute(
-                select(Carrier).where(Carrier.tenant_id == self.tms_tenant_id)
-            ).scalars().all()
-        }
+    def _dispatch_code_map(self) -> Dict[int, str]:
+        """§3.47 Phase 3 helper — ``{carrier_id: dispatch_code}`` map.
 
+        Dispatch ``code`` lives on ``CarrierTMSProfile`` after the
+        cutover; old ``carrier.code`` reads are replaced with this
+        lookup. Reads only the current tenant's profiles.
+        """
+        return dict(
+            self.session.execute(
+                select(CarrierTMSProfile.carrier_id, CarrierTMSProfile.code)
+                .where(CarrierTMSProfile.tenant_id == self.tms_tenant_id)
+            ).all()
+        )
+
+    def _seed_carriers(self) -> None:
+        # §3.47 Phase 3: dispatch `code` is on CarrierTMSProfile;
+        # join to find which carriers are already seeded by code.
+        existing_rows = self.session.execute(
+            select(Carrier, CarrierTMSProfile.code)
+            .outerjoin(
+                CarrierTMSProfile,
+                CarrierTMSProfile.carrier_id == Carrier.id,
+            )
+            .where(Carrier.tenant_id == self.tms_tenant_id)
+        ).all()
+        existing = {code: carrier for carrier, code in existing_rows if code}
+
+        # §3.47 Phase 3: Carrier construction now uses Core's
+        # canonical-identity fields only (display_name / status /
+        # currency / payment_terms_days / metadata). Dispatch fields
+        # land on CarrierTMSProfile below. Track (carrier, spec) pairs
+        # so we can wire the profile without hunting for spec by code.
+        new_pairs = []  # list of (carrier, spec) for profile seeding
         for spec in TOP_FOODSERVICE_CARRIERS:
             if spec.code in existing:
                 self._carriers.append(existing[spec.code])
                 continue
             carrier = Carrier(
-                code=spec.code,
-                name=spec.name,
-                scac=spec.scac,
-                carrier_type=CarrierType(spec.carrier_type),
-                modes=list(spec.modes),
-                equipment_types=list(spec.equipment_types),
-                service_regions=list(spec.service_regions),
-                is_hazmat_certified=spec.is_hazmat_certified,
-                insurance_limit=spec.insurance_limit,
-                is_active=True,
-                onboarding_status="ACTIVE",
-                onboarding_date=date(2022, 1, 1),
-                source="food_dist_tms_seed",
                 tenant_id=self.tms_tenant_id,
-                config_id=self.sc_config_id,
+                scac=spec.scac,
+                display_name=spec.name,
+                carrier_type=spec.carrier_type,
+                status="ACTIVE",
+                currency="USD",
+                payment_terms_days=30,
             )
             self.session.add(carrier)
             self._carriers.append(carrier)
+            new_pairs.append((carrier, spec))
         self.session.flush()
 
-        # §3.47 Phase 2 — write the dispatch fields to CarrierTMSProfile
-        # too. The seeder's internal `carrier.code` reads still work
-        # against the in-memory Carrier object (column not dropped
-        # until Phase 3); but external consumers query
-        # CarrierTMSProfile, so the substrate has to be populated at
-        # seed time.
-        existing_profile_carrier_ids = set(
-            self.session.execute(
-                select(CarrierTMSProfile.carrier_id)
-                .where(CarrierTMSProfile.tenant_id == self.tms_tenant_id)
-            ).scalars().all()
-        )
-        for carrier in self._carriers:
-            if carrier.id in existing_profile_carrier_ids:
-                continue
-            spec = next(
-                (s for s in TOP_FOODSERVICE_CARRIERS if s.code == carrier.code),
-                None,
-            )
-            if not spec:
-                continue
+        # Seed CarrierTMSProfile rows for newly-created carriers. We
+        # don't need to check existing-profiles here because new_pairs
+        # only contains carriers we just created (existing carriers
+        # already had profiles from Phase 1's Alembic backfill or a
+        # prior run of this seeder).
+        for carrier, spec in new_pairs:
             self.session.add(CarrierTMSProfile(
                 carrier_id=carrier.id,
                 tenant_id=self.tms_tenant_id,
@@ -501,9 +505,13 @@ class FoodDistTMSOverlay:
             ).all()
         )
 
+        # §3.47 Phase 3: dispatch code lives on CarrierTMSProfile.
+        code_by_carrier_id = self._dispatch_code_map()
+
         for carrier in self._carriers:
+            carrier_code = code_by_carrier_id.get(carrier.id)
             spec = next(
-                (s for s in TOP_FOODSERVICE_CARRIERS if s.code == carrier.code), None
+                (s for s in TOP_FOODSERVICE_CARRIERS if s.code == carrier_code), None
             )
             if not spec:
                 continue
@@ -547,7 +555,7 @@ class FoodDistTMSOverlay:
                     eq_type, (53.0, 44000.0, 3489.0, False))
 
                 equipment = Equipment(
-                    equipment_id=f"{carrier.code}-{eq_type[:3]}-{i:04d}",
+                    equipment_id=f"{carrier_code}-{eq_type[:3]}-{i:04d}",
                     equipment_type=EquipmentType(eq_type),
                     carrier_id=carrier.id,
                     length_ft=length,
@@ -586,9 +594,15 @@ class FoodDistTMSOverlay:
         dry_codes = {code for code, eqs in carrier_eq_map.items()
                      if "DRY_VAN" in eqs or "CONTAINER_40" in eqs or "CONTAINER_40HC" in eqs
                      or "FLATBED" in eqs or "CONTAINER_45" in eqs}
+        # §3.47 Phase 3: dispatch code via CarrierTMSProfile.
+        code_by_carrier_id = self._dispatch_code_map()
+
         # If no carriers match (e.g., all ocean/container), use all carriers as dry-capable
         if not dry_codes:
-            dry_codes = {c.code for c in self._carriers}
+            dry_codes = {
+                code_by_carrier_id.get(c.id) for c in self._carriers
+                if code_by_carrier_id.get(c.id)
+            }
 
         for lane in self._lanes:
             from_site = self._sites_by_id.get(lane.from_site_id)
@@ -596,7 +610,10 @@ class FoodDistTMSOverlay:
 
             for equipment in ("REEFER", "DRY_VAN"):
                 candidates = reefer_codes if equipment == "REEFER" else dry_codes
-                eligible = [c for c in self._carriers if c.code in candidates]
+                eligible = [
+                    c for c in self._carriers
+                    if code_by_carrier_id.get(c.id) in candidates
+                ]
 
                 # Shuffle to avoid always picking the same top-N carriers
                 self.rng.shuffle(eligible)
@@ -604,8 +621,9 @@ class FoodDistTMSOverlay:
                 # 3-5 carriers per lane × equipment
                 picks = eligible[: self.rng.randint(3, 5)]
                 for pos, carrier in enumerate(picks):
+                    carrier_code = code_by_carrier_id.get(carrier.id)
                     spec = next(
-                        (s for s in TOP_FOODSERVICE_CARRIERS if s.code == carrier.code),
+                        (s for s in TOP_FOODSERVICE_CARRIERS if s.code == carrier_code),
                         None,
                     )
                     cl = CarrierLane(
@@ -990,14 +1008,18 @@ class FoodDistTMSOverlay:
         tenders_sent = 0
         assigned: Optional[Carrier] = None
 
+        # §3.47 Phase 3: dispatch code via CarrierTMSProfile.
+        code_by_carrier_id = self._dispatch_code_map()
+
         for attempt, cl in enumerate(sorted(cls, key=lambda x: x.priority), start=1):
             if attempt > self.cfg.max_tender_attempts:
                 break
             carrier = next((c for c in self._carriers if c.id == cl.carrier_id), None)
             if carrier is None:
                 continue
+            carrier_code = code_by_carrier_id.get(carrier.id)
             spec = next(
-                (s for s in TOP_FOODSERVICE_CARRIERS if s.code == carrier.code), None
+                (s for s in TOP_FOODSERVICE_CARRIERS if s.code == carrier_code), None
             )
             carrier_reject_bias = (1.0 - spec.typical_acceptance_rate) if spec else 0.15
 

--- a/backend/app/services/tms/food_dist_tms_overlay.py
+++ b/backend/app/services/tms/food_dist_tms_overlay.py
@@ -41,7 +41,7 @@ from sqlalchemy import and_, func, select, text
 from sqlalchemy.orm import Session
 
 from app.models.tms_entities import (
-    Carrier, CarrierLane, CarrierType, Equipment, EquipmentType,
+    Carrier, CarrierTMSProfile, CarrierLane, CarrierType, Equipment, EquipmentType,
     EquipmentMove, EquipmentMoveReason, EquipmentMoveStatus,
     Load, LoadItem, LoadStatus,
     FreightRate, RateType,
@@ -424,6 +424,43 @@ class FoodDistTMSOverlay:
             )
             self.session.add(carrier)
             self._carriers.append(carrier)
+        self.session.flush()
+
+        # §3.47 Phase 2 — write the dispatch fields to CarrierTMSProfile
+        # too. The seeder's internal `carrier.code` reads still work
+        # against the in-memory Carrier object (column not dropped
+        # until Phase 3); but external consumers query
+        # CarrierTMSProfile, so the substrate has to be populated at
+        # seed time.
+        existing_profile_carrier_ids = set(
+            self.session.execute(
+                select(CarrierTMSProfile.carrier_id)
+                .where(CarrierTMSProfile.tenant_id == self.tms_tenant_id)
+            ).scalars().all()
+        )
+        for carrier in self._carriers:
+            if carrier.id in existing_profile_carrier_ids:
+                continue
+            spec = next(
+                (s for s in TOP_FOODSERVICE_CARRIERS if s.code == carrier.code),
+                None,
+            )
+            if not spec:
+                continue
+            self.session.add(CarrierTMSProfile(
+                carrier_id=carrier.id,
+                tenant_id=self.tms_tenant_id,
+                code=spec.code,
+                modes=list(spec.modes),
+                equipment_types=list(spec.equipment_types),
+                service_regions=list(spec.service_regions),
+                is_hazmat_certified=spec.is_hazmat_certified,
+                insurance_limit=spec.insurance_limit,
+                onboarding_status="ACTIVE",
+                onboarding_date=date(2022, 1, 1),
+                source="food_dist_tms_seed",
+                config_id=self.sc_config_id,
+            ))
         self.session.flush()
 
     def _seed_equipment_fleet(self) -> None:

--- a/backend/migrations/versions/20260503_carrier_identity_cleanup.py
+++ b/backend/migrations/versions/20260503_carrier_identity_cleanup.py
@@ -1,0 +1,287 @@
+"""§3.47 Phase 3 — drop TMS-specific columns from carrier; add Core canonical columns.
+
+Revision ID: 20260503_carrier_identity_cleanup
+Revises: 20260503_carrier_tms_profile
+Create Date: 2026-05-03
+
+Background
+----------
+Per docs/MIGRATION_REGISTER.md §3.47, this is the second of two
+Alembic migrations in the carrier-identity cutover. Phase 1
+(``20260503_carrier_tms_profile``) created
+``carrier_tms_profile`` and backfilled it from existing ``carrier``
+columns. Phase 3 (this migration) drops those now-duplicated
+columns from ``carrier`` and adds the Core canonical columns so
+the ``carrier`` table matches Core's
+``azirella_data_model.settlement.entities.Carrier`` shape exactly.
+
+What the cutover does, in order, inside the upgrade()
+transaction:
+
+1. **Add Core columns** (nullable for now to allow backfill):
+   ``display_name``, ``status``, ``tax_id``, ``currency``,
+   ``payment_terms_days``, ``metadata``.
+2. **Backfill** Core columns from existing TMS columns:
+   - ``display_name`` ← ``name``
+   - ``status`` ← ``CASE WHEN is_active THEN 'ACTIVE' ELSE 'INACTIVE' END``
+   - ``currency`` ← ``'USD'`` (constant; TMS Carrier had no currency
+     column).
+   - ``payment_terms_days`` ← ``30`` (constant; ditto).
+   - ``metadata`` ← ``'{}'::json`` (constant; ditto).
+3. **Tighten** Core columns to NOT NULL where Core's ORM expects.
+4. **Drop the TMS-specific columns** (the 18 dispatch fields plus
+   ``code``, ``name``, ``is_active``, ``usdot_safety_rating``).
+   Their data lives in ``carrier_tms_profile`` after Phase 1 backfill.
+5. **Reshape constraints + indexes**:
+   - DROP CONSTRAINT ``uq_carrier_tenant_code`` (depends on ``code``).
+   - DROP INDEX ``idx_carrier_tenant_active`` (depends on ``is_active``).
+   - ADD UNIQUE CONSTRAINT ``uq_carrier_tenant_scac`` (matches Core).
+   - ADD INDEX ``ix_carrier_tenant_status``.
+6. **Convert ``carrier_type``** from the PG enum
+   ``carrier_type_enum`` to ``VARCHAR(32)`` (matches Core's
+   String(32) representation). The enum type itself stays — other
+   tables may reference it via ``create_type=False``; it can be
+   dropped in a follow-on once nothing else is bound to it.
+
+Pre-production safety: there are 3 test tenants and no live
+customers. The user authorised the in-place column drops with no
+soak window. If real production data ever shows up before this
+ships, this migration must be split into "add+backfill" and "drop"
+runs separated by deploy-soak-verify.
+
+Idempotency
+-----------
+Each step guards against re-application. ``information_schema``
+checks for column existence before adding/dropping; the
+``has_column`` helper handles both directions.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260503_carrier_identity_cleanup"
+down_revision = "20260503_carrier_tms_profile"
+branch_labels = None
+depends_on = None
+
+
+def _has_column(conn, table: str, column: str) -> bool:
+    return bool(
+        conn.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema = 'public' AND table_name = :t "
+                "AND column_name = :c"
+            ),
+            {"t": table, "c": column},
+        ).scalar()
+    )
+
+
+def _has_constraint(conn, table: str, constraint: str) -> bool:
+    return bool(
+        conn.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.table_constraints "
+                "WHERE table_schema = 'public' AND table_name = :t "
+                "AND constraint_name = :c"
+            ),
+            {"t": table, "c": constraint},
+        ).scalar()
+    )
+
+
+def _has_index(conn, table: str, index: str) -> bool:
+    return bool(
+        conn.execute(
+            sa.text(
+                "SELECT 1 FROM pg_indexes "
+                "WHERE schemaname = 'public' "
+                "AND tablename = :t AND indexname = :i"
+            ),
+            {"t": table, "i": index},
+        ).scalar()
+    )
+
+
+# Columns being dropped in step 4. Listed once for symmetry between
+# upgrade and downgrade (downgrade re-adds them as nullable).
+_TMS_DISPATCH_COLUMNS = [
+    "code", "name", "is_active", "usdot_safety_rating",
+    "modes", "equipment_types", "service_regions",
+    "is_hazmat_certified", "is_bonded", "insurance_limit",
+    "primary_contact_name", "primary_contact_email", "primary_contact_phone",
+    "dispatch_email", "dispatch_phone",
+    "tracking_api_type", "tracking_api_config",
+    "onboarding_status", "onboarding_date", "last_shipment_date",
+    "source", "external_identifiers",
+    "p44_carrier_id", "p44_identifier_type",
+    "p44_account_group_code", "p44_account_code",
+    "config_id",
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # ── Step 1 — add Core canonical columns (nullable initially). ──
+    if not _has_column(conn, "carrier", "display_name"):
+        op.add_column("carrier", sa.Column("display_name", sa.String(255)))
+    if not _has_column(conn, "carrier", "status"):
+        op.add_column("carrier", sa.Column("status", sa.String(32)))
+    if not _has_column(conn, "carrier", "tax_id"):
+        op.add_column("carrier", sa.Column("tax_id", sa.String(64)))
+    if not _has_column(conn, "carrier", "currency"):
+        op.add_column(
+            "carrier",
+            sa.Column(
+                "currency", sa.String(8),
+                server_default="USD", nullable=True,
+            ),
+        )
+    if not _has_column(conn, "carrier", "payment_terms_days"):
+        op.add_column(
+            "carrier",
+            sa.Column(
+                "payment_terms_days", sa.Integer,
+                server_default="30", nullable=True,
+            ),
+        )
+    if not _has_column(conn, "carrier", "metadata"):
+        op.add_column(
+            "carrier",
+            sa.Column(
+                "metadata", sa.JSON,
+                server_default=sa.text("'{}'::json"), nullable=True,
+            ),
+        )
+
+    # ── Step 2 — backfill Core columns from TMS columns. ──
+    # Only run if the source columns still exist (idempotent re-run
+    # protection).
+    if _has_column(conn, "carrier", "name"):
+        op.execute(
+            "UPDATE carrier SET display_name = COALESCE(display_name, name) "
+            "WHERE display_name IS NULL"
+        )
+    if _has_column(conn, "carrier", "is_active"):
+        op.execute(
+            "UPDATE carrier SET status = COALESCE("
+            "  status, "
+            "  CASE WHEN is_active THEN 'ACTIVE' ELSE 'INACTIVE' END"
+            ") WHERE status IS NULL"
+        )
+    op.execute(
+        "UPDATE carrier SET currency = 'USD' WHERE currency IS NULL"
+    )
+    op.execute(
+        "UPDATE carrier SET payment_terms_days = 30 "
+        "WHERE payment_terms_days IS NULL"
+    )
+    op.execute(
+        "UPDATE carrier SET metadata = '{}'::json WHERE metadata IS NULL"
+    )
+
+    # ── Step 3 — tighten Core columns to NOT NULL. ──
+    op.alter_column(
+        "carrier", "display_name", nullable=False,
+        existing_type=sa.String(255),
+    )
+    op.alter_column(
+        "carrier", "status", nullable=False,
+        existing_type=sa.String(32),
+        server_default=sa.text("'ACTIVE'"),
+    )
+    op.alter_column(
+        "carrier", "currency", nullable=False,
+        existing_type=sa.String(8),
+        server_default=sa.text("'USD'"),
+    )
+    op.alter_column(
+        "carrier", "payment_terms_days", nullable=False,
+        existing_type=sa.Integer,
+        server_default=sa.text("30"),
+    )
+    op.alter_column(
+        "carrier", "metadata", nullable=False,
+        existing_type=sa.JSON,
+        server_default=sa.text("'{}'::json"),
+    )
+
+    # ── Step 5 (before drop) — drop UC + index that reference cols
+    # we're about to drop. ──
+    if _has_constraint(conn, "carrier", "uq_carrier_tenant_code"):
+        op.drop_constraint(
+            "uq_carrier_tenant_code", "carrier", type_="unique",
+        )
+    if _has_index(conn, "carrier", "idx_carrier_tenant_active"):
+        op.drop_index("idx_carrier_tenant_active", table_name="carrier")
+
+    # ── Step 6 — convert carrier_type from PG enum to VARCHAR(32). ──
+    # Use the column-type cast pattern; doesn't drop the enum type so
+    # other tables still bound to ``carrier_type_enum`` keep working.
+    op.execute(
+        "ALTER TABLE carrier ALTER COLUMN carrier_type "
+        "TYPE VARCHAR(32) USING carrier_type::text"
+    )
+
+    # ── Step 4 — drop the TMS-specific columns. ──
+    for col in _TMS_DISPATCH_COLUMNS:
+        if _has_column(conn, "carrier", col):
+            op.drop_column("carrier", col)
+
+    # ── Step 5 (after drop) — add Core's UC + index. ──
+    if not _has_constraint(conn, "carrier", "uq_carrier_tenant_scac"):
+        op.create_unique_constraint(
+            "uq_carrier_tenant_scac", "carrier", ["tenant_id", "scac"],
+        )
+    if not _has_index(conn, "carrier", "ix_carrier_tenant_status"):
+        op.create_index(
+            "ix_carrier_tenant_status", "carrier",
+            ["tenant_id", "status"],
+        )
+    if not _has_index(conn, "carrier", "ix_carrier_tenant_id"):
+        op.create_index(
+            "ix_carrier_tenant_id", "carrier", ["tenant_id"],
+        )
+
+
+def downgrade() -> None:
+    """Restore TMS-specific columns. Data is NOT recovered — the
+    ``carrier_tms_profile`` rows from Phase 1 have to be re-merged
+    by hand if a real rollback is needed. Pre-production safety
+    only.
+    """
+    conn = op.get_bind()
+
+    if _has_index(conn, "carrier", "ix_carrier_tenant_status"):
+        op.drop_index("ix_carrier_tenant_status", table_name="carrier")
+    if _has_constraint(conn, "carrier", "uq_carrier_tenant_scac"):
+        op.drop_constraint(
+            "uq_carrier_tenant_scac", "carrier", type_="unique",
+        )
+
+    # Re-add the dropped columns (nullable; downgrade is best-effort).
+    if not _has_column(conn, "carrier", "code"):
+        op.add_column("carrier", sa.Column("code", sa.String(100)))
+    if not _has_column(conn, "carrier", "name"):
+        op.add_column("carrier", sa.Column("name", sa.String(200)))
+    if not _has_column(conn, "carrier", "is_active"):
+        op.add_column("carrier", sa.Column("is_active", sa.Boolean))
+    for col in _TMS_DISPATCH_COLUMNS[3:]:  # everything after is_active
+        if not _has_column(conn, "carrier", col):
+            op.add_column("carrier", sa.Column(col, sa.String(255)))
+    # carrier_type stays VARCHAR(32) — the PG enum type still exists
+    # but the column isn't bound back to it.
+    if not _has_constraint(conn, "carrier", "uq_carrier_tenant_code"):
+        op.create_unique_constraint(
+            "uq_carrier_tenant_code", "carrier", ["tenant_id", "code"],
+        )
+
+    # Drop the Core columns.
+    for col in (
+        "display_name", "status", "tax_id",
+        "currency", "payment_terms_days", "metadata",
+    ):
+        if _has_column(conn, "carrier", col):
+            op.drop_column("carrier", col)

--- a/backend/migrations/versions/20260503_carrier_tms_profile.py
+++ b/backend/migrations/versions/20260503_carrier_tms_profile.py
@@ -1,0 +1,186 @@
+"""§3.47 Phase 1 — carrier_tms_profile substrate (additive, no drops).
+
+Revision ID: 20260503_carrier_tms_profile
+Revises: 20260501_role_templates
+Create Date: 2026-05-03
+
+Background
+----------
+Per docs/MIGRATION_REGISTER.md §3.47, this migration creates the
+``carrier_tms_profile`` table — the TMS-side dispatch / capacity /
+onboarding extension to Core's ``Carrier`` identity. Phase 1 is
+additive only: creates the new table and backfills it from existing
+``carrier`` rows. **No columns are dropped from ``carrier``** — the
+TMS-side ``Carrier`` ORM keeps its current shape; downstream code
+continues to read dispatch fields off ``carrier`` rows.
+
+Phase 2 (TMS code cutover, separate commit) retargets the 4 known
+TMS callsites that read dispatch fields to query
+``carrier_tms_profile`` instead. Phase 3 (separate commit + Alembic
+migration) drops the duplicate columns from ``carrier``, deletes
+the TMS-side ``Carrier`` ORM, and retargets all imports to Core's
+``azirella_data_model.settlement.entities.Carrier``.
+
+Schema parity check (column-by-column) is in the §3.47 register
+entry. The 18 fields moving to ``carrier_tms_profile`` are:
+
+  code, usdot_safety_rating, modes, equipment_types, service_regions,
+  is_hazmat_certified, is_bonded, insurance_limit,
+  primary_contact_name, primary_contact_email, primary_contact_phone,
+  dispatch_email, dispatch_phone, tracking_api_type, tracking_api_config,
+  onboarding_status, onboarding_date, last_shipment_date,
+  source, external_identifiers,
+  p44_carrier_id, p44_identifier_type, p44_account_group_code,
+  p44_account_code, config_id
+
+Plus carrier_id FK + tenant_id + standard timestamps.
+
+Idempotency
+-----------
+Guarded by ``information_schema.tables`` (matches the established
+TMS migration pattern). Re-running on an environment that already
+has ``carrier_tms_profile`` is a no-op.
+
+Backfill
+--------
+``INSERT INTO carrier_tms_profile (...) SELECT (...) FROM carrier``
+runs unconditionally inside the upgrade — but the FK target
+(``carrier.id``) must exist; `ON CONFLICT (carrier_id) DO NOTHING`
+makes the backfill safe to retry.
+
+Downgrade
+---------
+Drops the table + indexes. ``carrier`` rows keep all their data
+(Phase 1 hasn't dropped anything from ``carrier``).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260503_carrier_tms_profile"
+down_revision = "20260501_role_templates"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(conn, table: str) -> bool:
+    return bool(
+        conn.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.tables "
+                "WHERE table_schema = 'public' AND table_name = :t"
+            ),
+            {"t": table},
+        ).scalar()
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if _table_exists(conn, "carrier_tms_profile"):
+        return
+
+    op.create_table(
+        "carrier_tms_profile",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column(
+            "carrier_id", sa.Integer,
+            sa.ForeignKey("carrier.id", ondelete="CASCADE"),
+            nullable=False, unique=True,
+        ),
+        sa.Column(
+            "tenant_id", sa.Integer,
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("code", sa.String(100)),
+        sa.Column("usdot_safety_rating", sa.String(20)),
+        sa.Column("modes", sa.JSON),
+        sa.Column("equipment_types", sa.JSON),
+        sa.Column("service_regions", sa.JSON),
+        sa.Column("is_hazmat_certified", sa.Boolean, server_default="false"),
+        sa.Column("is_bonded", sa.Boolean, server_default="false"),
+        sa.Column("insurance_limit", sa.Double),
+        sa.Column("primary_contact_name", sa.String(200)),
+        sa.Column("primary_contact_email", sa.String(200)),
+        sa.Column("primary_contact_phone", sa.String(50)),
+        sa.Column("dispatch_email", sa.String(200)),
+        sa.Column("dispatch_phone", sa.String(50)),
+        sa.Column("tracking_api_type", sa.String(50)),
+        sa.Column("tracking_api_config", sa.JSON),
+        sa.Column("onboarding_status", sa.String(20), server_default="PENDING"),
+        sa.Column("onboarding_date", sa.Date),
+        sa.Column("last_shipment_date", sa.Date),
+        sa.Column("source", sa.String(100)),
+        sa.Column("external_identifiers", sa.JSON),
+        sa.Column("p44_carrier_id", sa.String(100)),
+        sa.Column("p44_identifier_type", sa.String(20)),
+        sa.Column("p44_account_group_code", sa.String(100)),
+        sa.Column("p44_account_code", sa.String(100)),
+        sa.Column(
+            "config_id", sa.Integer,
+            sa.ForeignKey("supply_chain_configs.id", ondelete="CASCADE"),
+        ),
+        sa.Column(
+            "created_at", sa.DateTime,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("updated_at", sa.DateTime),
+        sa.UniqueConstraint(
+            "tenant_id", "code",
+            name="uq_carrier_tms_profile_tenant_code",
+        ),
+    )
+    op.create_index(
+        "idx_carrier_tms_profile_tenant_onboarding",
+        "carrier_tms_profile",
+        ["tenant_id", "onboarding_status"],
+    )
+
+    # Backfill from existing `carrier` rows. Safe to retry: the
+    # carrier_id UNIQUE constraint + ON CONFLICT DO NOTHING make
+    # repeat invocations idempotent. The column list mirrors the
+    # 18 dispatch fields documented at the top of this file plus
+    # carrier_id and timestamps.
+    op.execute(
+        """
+        INSERT INTO carrier_tms_profile (
+            carrier_id, tenant_id, code, usdot_safety_rating,
+            modes, equipment_types, service_regions,
+            is_hazmat_certified, is_bonded, insurance_limit,
+            primary_contact_name, primary_contact_email, primary_contact_phone,
+            dispatch_email, dispatch_phone,
+            tracking_api_type, tracking_api_config,
+            onboarding_status, onboarding_date, last_shipment_date,
+            source, external_identifiers,
+            p44_carrier_id, p44_identifier_type,
+            p44_account_group_code, p44_account_code,
+            config_id, created_at, updated_at
+        )
+        SELECT
+            c.id, c.tenant_id, c.code, c.usdot_safety_rating,
+            c.modes, c.equipment_types, c.service_regions,
+            c.is_hazmat_certified, c.is_bonded, c.insurance_limit,
+            c.primary_contact_name, c.primary_contact_email, c.primary_contact_phone,
+            c.dispatch_email, c.dispatch_phone,
+            c.tracking_api_type, c.tracking_api_config,
+            c.onboarding_status, c.onboarding_date, c.last_shipment_date,
+            c.source, c.external_identifiers,
+            c.p44_carrier_id, c.p44_identifier_type,
+            c.p44_account_group_code, c.p44_account_code,
+            c.config_id, c.created_at, c.updated_at
+        FROM carrier c
+        ON CONFLICT (carrier_id) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    if _table_exists(conn, "carrier_tms_profile"):
+        op.drop_index(
+            "idx_carrier_tms_profile_tenant_onboarding",
+            table_name="carrier_tms_profile",
+        )
+        op.drop_table("carrier_tms_profile")

--- a/backend/tests/powell/test_l3_planning_services.py
+++ b/backend/tests/powell/test_l3_planning_services.py
@@ -100,16 +100,41 @@ def db() -> Session:
             id = Column(Integer, primary_key=True)
 
     engine = create_engine("sqlite:///:memory:")
+    # §3.47: Core's settlement Carrier / Contract / RateCard /
+    # CarrierCapacityCommitment register on the same Base.metadata as
+    # TMS ORMs after the carrier-identity cutover. They're imported
+    # by the test body, so they're already in metadata by the time
+    # this fixture runs.
+    # TMS-side LaneProfile (used by _seed_lane_profile helper) needs
+    # to be loaded so its table is in metadata at create_all time.
+    # The services lazy-import it; here we eagerly preload.
+    try:
+        import app.models.transportation_config  # noqa: F401
+    except ImportError:
+        pass
+
+    settlement_tables = []
+    for tbl_name in (
+        "carrier", "contract", "rate_card", "carrier_capacity_commitment",
+    ):
+        if tbl_name in Base.metadata.tables:
+            settlement_tables.append(Base.metadata.tables[tbl_name])
+    # LaneProfile when loaded; falls back gracefully when not.
+    if "lane_profile" in Base.metadata.tables:
+        settlement_tables.append(Base.metadata.tables["lane_profile"])
     tables = [
         Base.metadata.tables[t] for t in [
             "supply_chain_configs", "scenarios", "transportation_lane",
-            "site", "tenants", "users", "carrier", "freight_rate", "load",
+            "site", "tenants", "users", "freight_rate", "load",
         ]
-    ] + [
+    ] + settlement_tables + [
         LaneVolumePlan.__table__,
         TransportationPlan.__table__,
         TransportationPlanItem.__table__,
     ]
+    # CarrierTMSProfile (added in §3.47 Phase 1) — included when present.
+    if "carrier_tms_profile" in Base.metadata.tables:
+        tables.append(Base.metadata.tables["carrier_tms_profile"])
     Base.metadata.create_all(bind=engine, tables=tables)
     Sess = sessionmaker(bind=engine)
     s = Sess()


### PR DESCRIPTION
## Summary

Resolves the duplicate-`Carrier` ORM situation that had been silently breaking Core settlement code and blocking L3 tests. Core's `azirella_data_model.settlement.entities.Carrier` is now the canonical identity row; TMS's new `CarrierTMSProfile` (sibling table joined via `carrier_id`) holds the 18 dispatch / capacity / onboarding fields that don't belong on a settlement substrate.

Three commits, each independently rollback-able:

- **f0b3819** — Phase 1 (substrate). New `CarrierTMSProfile` ORM + Alembic `20260503_carrier_tms_profile` (creates table + backfills from `carrier`; idempotent, no drops). **No breaking change at this commit.**
- **f895995** — Phase 2 (cutover). 4 TMS callsites that read dispatch fields off `Carrier` retargeted to outer-join `CarrierTMSProfile` instead. Seeder also creates a profile row alongside each carrier.
- **18834d8** — Phase 3 (cleanup). Alembic `20260503_carrier_identity_cleanup` adds Core columns (`display_name` / `status` / `tax_id` / `currency` / `payment_terms_days` / `metadata`), backfills, drops 28 TMS-specific columns, replaces UC + indexes. Deletes TMS `class Carrier`; re-exports Core's. Construction sites split writes between Carrier (canonical) and CarrierTMSProfile (dispatch). `carrier.name` → `carrier.display_name`; `carrier.is_active` → `carrier.status == 'ACTIVE'`.

## Test plan

- [x] Direct module-load smoke confirms `te.Carrier is azirella_data_model.settlement.entities.Carrier` is True.
- [x] Schema convergence verified: `te.Carrier.__table__.columns` = Core canonical only; `te.CarrierTMSProfile.__table__.columns` includes all 18 dispatch fields.
- [x] Duplicate-Carrier "Table 'carrier' is already defined" error in `Base.metadata` no longer reproducible.
- [ ] L3 test suite hit the next layer of fixture debt (`lane_profile.tenant_id` NOT NULL but `_seed_lane_profile` doesn't pass it). Pre-existing, separate workstream.
- [ ] After merge: run both Alembic migrations against the 3 test tenants (pre-production cutover; user authorised in-place column drops with no soak window).

## Pre-existing fix shipped alongside

`app/services/powell/movement_planner_training_data.py:45` retargeted from broken `app.models.tms_planning.TransportationPlan` re-export to `azirella_data_model.transport_plan` directly. Same pattern as PR #20 housekeeping.

## Companion

`azirella-ltd/Autonomy-Core` PR: docs entries in `MIGRATION_REGISTER.md` §3.47 + `CONSUMER_ADOPTION_LOG.md` 2026-05-03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)