### PR TITLE
fix: §3.47 follow-ons — _seed_lane_profile.tenant_id + drop carrier_type_enum

### DIFF
--- a/backend/migrations/versions/20260503_drop_carrier_type_enum.py
+++ b/backend/migrations/versions/20260503_drop_carrier_type_enum.py
@@ -1,0 +1,53 @@
+"""§3.47 follow-on — drop the orphaned carrier_type_enum PG type.
+
+Revision ID: 20260503_drop_carrier_type_enum
+Revises: 20260503_carrier_identity_cleanup
+Create Date: 2026-05-03
+
+Background
+----------
+§3.47 Phase 3 (`20260503_carrier_identity_cleanup`) ran
+``ALTER TABLE carrier ALTER COLUMN carrier_type TYPE VARCHAR(32)``
+to match Core's settlement schema. That left the
+``carrier_type_enum`` PG type itself in place — the cleanup
+migration deferred the drop because other tables might still bind
+to it via ``create_type=False``.
+
+Audit (2026-05-03): no ORM column anywhere in the codebase still
+binds to ``carrier_type_enum``. The Python ``CarrierType`` enum
+class in ``app/models/tms_entities.py`` is a ``str``-based
+``PyEnum`` (used as a Python-side typed value for callers; values
+get serialised as strings into Core's ``Carrier.carrier_type``
+``String(32)`` column). The only references to
+``carrier_type_enum`` are in historical Alembic files
+(``20260409_tms_entities.py``) and the §3.47 cleanup file's
+docstring — neither binds the type to a live table column.
+
+This migration drops the orphan PG type. Idempotent
+(``DROP TYPE IF EXISTS``).
+"""
+from alembic import op
+
+
+revision = "20260503_drop_carrier_type_enum"
+down_revision = "20260503_carrier_identity_cleanup"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # IF EXISTS is idempotent; safe to re-run on environments where
+    # the type was already dropped manually.
+    op.execute("DROP TYPE IF EXISTS carrier_type_enum")
+
+
+def downgrade() -> None:
+    # Re-create the type with its original 9 members. Downgrade is
+    # best-effort: any column that wants to bind to it again must
+    # ALTER its TYPE separately (no live consumer expected).
+    op.execute(
+        "CREATE TYPE carrier_type_enum AS ENUM ("
+        "'ASSET', 'BROKER', 'THREE_PL', 'FOUR_PL', 'OCEAN_LINE', "
+        "'AIRLINE', 'RAILROAD', 'COURIER', 'DRAYAGE_CARRIER'"
+        ")"
+    )

--- a/backend/tests/powell/test_l3_planning_services.py
+++ b/backend/tests/powell/test_l3_planning_services.py
@@ -543,13 +543,24 @@ def _seed_carrier_and_rate_cards(db: Session) -> None:
     db.flush()
 
 
-def _seed_lane_profile(db: Session, lane_id: int = 10, distance: float = 750.0) -> None:
-    """Seed a TMS-side LaneProfile with a known distance."""
+def _seed_lane_profile(
+    db: Session,
+    lane_id: int = 10,
+    distance: float = 750.0,
+    tenant_id: int = 1,
+) -> None:
+    """Seed a TMS-side LaneProfile with a known distance.
+
+    ``tenant_id`` is NOT NULL on the underlying table; the parameter
+    defaults to the same fixture-tenant the L3 service tests use, so
+    existing call sites that pass only ``db`` continue to work.
+    """
     from app.models.transportation_config import LaneProfile
 
     db.add(LaneProfile(
         lane_id=lane_id, config_id=1,
         distance_miles=distance, primary_mode="FTL",
+        tenant_id=tenant_id,
     ))
     db.flush()
 


### PR DESCRIPTION
## Summary

Closes the two follow-ons flagged at the bottom of [#22](https://github.com/azirella-ltd/Autonomy-TMS/pull/22):

- **Fix 1 — `_seed_lane_profile` test helper** now passes `tenant_id` (default 1, matching the rest of the L3 fixture). Pre-existing breakage that surfaced once §3.47 unblocked the duplicate-Carrier issue. Backwards-compatible.
- **Fix 2 — Alembic `20260503_drop_carrier_type_enum`** drops the orphan PG type that §3.47 Phase 3's `ALTER COLUMN ... TYPE VARCHAR(32)` left in place. Audit confirmed no ORM still binds to it. Idempotent (`DROP TYPE IF EXISTS`).

## Test plan

- [x] **Before**: 0/56 L3 tests passed (all crashed on duplicate-Carrier or `lane_profile.tenant_id`).
- [x] **After**: 53/56 pass.
- [ ] Run `20260503_drop_carrier_type_enum` against the 3 test tenants (idempotent; safe).

The remaining 3 failures are unrelated to either fix here and worth small separate PRs:

1. `test_phase_3_42_dict_override_takes_precedence` — `TypeError: '<' not supported between 'NoneType' and 'str'` at `integrated_balancer_service.py:635`. Real bug in the LP-projection capacity sort.
2. `test_phase_3_42_p3_prorating_weekly_over_quarter` — `assert 8 == 7`. Off-by-one or rounding in the Q2 weekly-commitment prorating math.
3. `test_phase_3_41_trainer_returns_run_result_with_zero_examples` — test expects `model_version` to contain `'no_training_data'` but gets `'graphsage_untrained'`. Test-expectation drift since the §3.41 Phase 3.3 trainer shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)