### PR TITLE
fix: three L3 test failures (None-vs-str sort, prorate floor, trainer version)

### DIFF
--- a/backend/app/services/powell/integrated_balancer_service.py
+++ b/backend/app/services/powell/integrated_balancer_service.py
@@ -632,17 +632,36 @@ class IntegratedBalancerService:
         # When equipment_type is None, the row sums all items on that
         # carrier (carrier-wide cap). When equipment_type is set, the
         # row sums only items matching that equipment.
-        capacity_keys = sorted(normalised.keys())  # deterministic order
+        # Deterministic order. Capacity keys are ``(carrier_id,
+        # equipment_type)`` tuples where ``equipment_type`` may be
+        # ``None`` (carrier-wide cap) or a string (per-equipment cap).
+        # Sort with ``""`` as the None-substitute so Python 3 doesn't
+        # raise on ``None`` vs ``str`` comparison when both shapes
+        # appear in the dict.
+        capacity_keys = sorted(
+            normalised.keys(),
+            key=lambda k: (k[0], k[1] or ""),
+        )
         n_capacity_constraints = len(capacity_keys)
         A_ub = np.zeros((n_capacity_constraints, n_vars))
         b_ub = np.zeros(n_capacity_constraints)
         carrier_idx_by_id = {c: idx for idx, c in enumerate(carriers)}
+        import math as _math
         for k, (carrier_id, equipment_type) in enumerate(capacity_keys):
             j = carrier_idx_by_id[carrier_id]
             for i, item in enumerate(items):
                 if equipment_type is None or item.equipment_type == equipment_type:
                     A_ub[k, i * n_carriers + j] = 1
-            b_ub[k] = float(normalised[(carrier_id, equipment_type)])
+            # Floor fractional caps before feeding the LP. The
+            # transportation-style polytope has integer vertices only
+            # when caps are integers; passing a fractional cap (e.g.,
+            # 7.69 from §3.42 Phase 3.3 prorating) lets the LP relax
+            # to fractional ``x_ij`` and the argmax-rounding then
+            # over-assigns items beyond the integer-feasible cap.
+            # Flooring matches the semantics described in the
+            # §3.42 Phase 3.3 register entry ("100 × 7/91 = 7.69 →
+            # floor to 7 fittable items").
+            b_ub[k] = float(_math.floor(normalised[(carrier_id, equipment_type)]))
 
         bounds = [(0, 1)] * n_vars
 

--- a/backend/app/services/powell/movement_planner_trainer.py
+++ b/backend/app/services/powell/movement_planner_trainer.py
@@ -153,11 +153,13 @@ class MovementPlannerTrainer:
         kwargs.setdefault("learning_rate", learning_rate)
         model = TorchGraphSAGEMovementPlanner(**kwargs)
 
-        # Convert examples to per-plan training batches.
+        # Convert examples to per-plan training batches. Call
+        # ``model.fit`` unconditionally — when the batch list is
+        # empty the model itself short-circuits and sets its
+        # ``model_version`` to ``"graphsage_no_training_data"``,
+        # which is the state the no-examples result should reflect.
         train_batches = self._examples_to_training_batches(train_examples)
-
-        if train_batches:
-            model.fit(train_batches)
+        model.fit(train_batches)
 
         # Held-out val loss (basic; Phase 3.5 adds proper metrics).
         val_loss: Optional[float] = None


### PR DESCRIPTION
## Summary

After #22 (§3.47 carrier-identity cutover) and #23 (`_seed_lane_profile.tenant_id` + `carrier_type_enum` drop) the L3 test suite went from **0/56 → 53/56**. The 3 remaining failures all turned out to be real findings, not flaky tests. **After this PR: 56/56 pass.**

- **Fix #1** — `integrated_balancer_service.py:635` `TypeError: '<' not supported between 'NoneType' and 'str'`. Capacity-dict keys are `(carrier_id, equipment_type)` tuples where `equipment_type` may be `None` (carrier-wide cap) or a string (per-equipment cap). Sort key now substitutes `""` for `None` so both shapes coexist.

- **Fix #2** — `_solve_lp_projection` over-assigned past fractional caps (e.g., 7.69 from §3.42 Phase 3.3 prorating). The transportation-style LP polytope has integer vertices only when caps are integers; with a fractional cap the LP relaxed to fractional `x_ij` and argmax-rounding over-assigned. Floor the cap at the LP boundary so vertices stay integer-feasible. Matches the "floor 7.69 to 7" semantics in the §3.42 Phase 3.3 register entry.

- **Fix #3** — `MovementPlannerTrainer.train` left `model_version` at `"graphsage_untrained"` when zero examples were extracted. The trainer's `if train_batches: model.fit(...)` skipped `fit()` on the empty path, so the model's no-training-data branch never set `self._version = "graphsage_no_training_data"`. Call `model.fit(train_batches)` unconditionally — `fit()` itself short-circuits on empty input and sets the right version string.

## Test plan

- [x] All 3 affected tests now pass individually.
- [x] Full L3 suite: **56/56 pass** (4.74s).
- [x] No regressions in passing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)