### PR TITLE
feat(§3.46 Phase 4 + Phase 5): L3 cascade HTTP API + operator-role authority

### DIFF
--- a/backend/app/api/endpoints/l3_cascade.py
+++ b/backend/app/api/endpoints/l3_cascade.py
@@ -20,11 +20,18 @@ Two endpoints:
 
 Both endpoints honour the same idempotency the runner enforces (an
 existing L3 plan for the period skips with status="SKIPPED" unless
-``force=true``). Auth: ``get_current_active_user`` — any authenticated
-user can trigger a cascade for their own tenant; cross-tenant invocation
-requires the request body's ``tenant_id`` to match the user's
-``tenant_id`` (or the user is a superuser, when that machinery exists
-— Phase 5 follow-on).
+``force=true``).
+
+Auth (§3.46 Phase 4 + Phase 5 — 2026-05-03):
+``get_current_active_user`` is required. Cross-tenant invocation
+requires *operator-level* authority — either ``is_superuser=True``
+or ``user_type == UserTypeEnum.SYSTEM_ADMIN``. ``TENANT_ADMIN`` is
+explicitly NOT operator-level: a tenant admin's authority is scoped
+to *their own* tenant and they get the same same-tenant constraint
+as a regular user. This matches how cross-tenant operations are
+authorised elsewhere (see ``app/api/deps.py::require_tenant_admin``,
+which gates on tenant-scope; the cascade's cross-tenant flavour
+needs the strictly broader system-level role).
 
 Plane-module placement: TMS-side decision-policy surface (mirrors
 ``scripts/l3_cascade_cli.py`` which is also TMS plane-specific). No
@@ -41,6 +48,10 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import get_current_active_user
+from app.services._l3_cascade_auth import (
+    enforce_tenant_scope as _enforce_tenant_scope,
+    is_operator as _is_operator,
+)
 from app.db.session import get_db, sync_session_factory
 from app.models.user import User
 from app.services.powell.l3_cascade_runner import (
@@ -167,24 +178,6 @@ def _to_response(result: CascadeRunResult) -> L3CascadeRunResponse:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _enforce_tenant_scope(user: User, requested_tenant_id: int) -> None:
-    """Caller may only invoke cascades for their own tenant.
-
-    Cross-tenant invocation needs the operator role (Phase 5 follow-on
-    when role-based authority is wired in). For now, strict
-    same-tenant enforcement.
-    """
-    user_tenant = getattr(user, "tenant_id", None)
-    if user_tenant is not None and user_tenant != requested_tenant_id:
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                f"User tenant_id={user_tenant} cannot invoke cascade "
-                f"for tenant_id={requested_tenant_id}"
-            ),
-        )
 
 
 def _resolve_config_id(

--- a/backend/app/services/_l3_cascade_auth.py
+++ b/backend/app/services/_l3_cascade_auth.py
@@ -1,0 +1,84 @@
+"""§3.46 Phase 5 — auth helpers for the L3 cascade HTTP endpoint.
+
+Lives under ``services/`` (NOT under ``services/powell/`` or
+``api/endpoints/``) so unit tests can import the helpers without
+triggering either of those packages' eager re-export ``__init__``s,
+which transitively pull in the FastAPI app's auth + DB stack. The
+helpers themselves are pure: they only need ``UserTypeEnum`` from
+Core's ``tenant`` package and FastAPI's ``HTTPException`` class.
+
+Public helpers:
+- :func:`is_operator` — operator-level authority predicate.
+- :func:`enforce_tenant_scope` — same-tenant gate with operator escape.
+
+The helpers take a ``user`` argument duck-typed via ``getattr``: any
+object exposing ``id``, ``tenant_id``, ``is_superuser``, ``user_type``
+attributes works (the real ``User`` ORM class, ``ServiceAccountUser``
+sentinel, or a ``SimpleNamespace`` test fixture). This is why
+``User`` is only imported under :data:`TYPE_CHECKING`.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import HTTPException
+
+from azirella_data_model.tenant import UserTypeEnum
+
+if TYPE_CHECKING:
+    from app.models.user import User
+
+
+logger = logging.getLogger(__name__)
+
+
+def is_operator(user: "User") -> bool:
+    """§3.46 Phase 5 — operator-level authority for cross-tenant
+    cascade invocation.
+
+    Two equivalent paths to operator authority:
+    - ``is_superuser=True`` — legacy account flag, still honoured.
+    - ``user_type == UserTypeEnum.SYSTEM_ADMIN`` — the canonical
+      role-based path, set during user provisioning for ops engineers
+      and SRE accounts.
+
+    ``TENANT_ADMIN`` is explicitly NOT operator-level: a tenant admin's
+    authority is scoped to *their own* tenant. They use the same
+    same-tenant path as a regular ``USER``.
+    """
+    if getattr(user, "is_superuser", False):
+        return True
+    user_type = getattr(user, "user_type", None)
+    return user_type == UserTypeEnum.SYSTEM_ADMIN
+
+
+def enforce_tenant_scope(user: "User", requested_tenant_id: int) -> None:
+    """Caller may only invoke cascades for their own tenant — unless
+    they have operator authority (§3.46 Phase 5).
+
+    Same-tenant invocation: any authenticated active user.
+    Cross-tenant invocation: ``is_superuser=True`` or
+    ``user_type=SYSTEM_ADMIN`` (see :func:`is_operator`).
+    """
+    user_tenant = getattr(user, "tenant_id", None)
+    if user_tenant is not None and user_tenant != requested_tenant_id:
+        if is_operator(user):
+            logger.info(
+                "L3 cascade — cross-tenant invocation by operator user_id=%s "
+                "(home_tenant=%s) targeting tenant_id=%s",
+                getattr(user, "id", None), user_tenant, requested_tenant_id,
+            )
+            return
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"User tenant_id={user_tenant} cannot invoke cascade "
+                f"for tenant_id={requested_tenant_id}; cross-tenant "
+                "invocation requires operator authority "
+                "(is_superuser or SYSTEM_ADMIN)"
+            ),
+        )
+
+
+__all__ = ["enforce_tenant_scope", "is_operator"]

--- a/backend/tests/powell/test_l3_cascade_auth.py
+++ b/backend/tests/powell/test_l3_cascade_auth.py
@@ -1,0 +1,135 @@
+"""§3.46 Phase 5 — operator-role authority for cross-tenant L3 cascade.
+
+Unit tests for the auth helpers on the L3 cascade HTTP endpoint
+(``app.api.endpoints.l3_cascade``):
+
+- ``_is_operator`` — returns True for ``is_superuser=True`` OR
+  ``user_type == SYSTEM_ADMIN``; False otherwise (USER, TENANT_ADMIN,
+  unset).
+- ``_enforce_tenant_scope`` — same-tenant always passes; cross-tenant
+  raises 403 unless the caller is an operator; operator path logs but
+  passes.
+
+The endpoint body itself stays exercised via CLI tests + scheduled-job
+tests (which share the runner code path); the auth surface is the
+Phase 5 contribution and tested directly here.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from azirella_data_model.tenant import UserTypeEnum
+
+from app.services._l3_cascade_auth import (
+    enforce_tenant_scope as _enforce_tenant_scope,
+    is_operator as _is_operator,
+)
+
+
+def _user(
+    *,
+    id: int = 1,
+    tenant_id: int = 42,
+    is_superuser: bool = False,
+    user_type: Any = UserTypeEnum.USER,
+) -> SimpleNamespace:
+    """Build a User-shaped sentinel — the helpers only access
+    attributes via ``getattr``, so SimpleNamespace covers the contract
+    without booting the ORM."""
+    return SimpleNamespace(
+        id=id,
+        tenant_id=tenant_id,
+        is_superuser=is_superuser,
+        user_type=user_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _is_operator
+# ---------------------------------------------------------------------------
+
+
+def test_operator_via_is_superuser() -> None:
+    assert _is_operator(_user(is_superuser=True)) is True
+
+
+def test_operator_via_system_admin_role() -> None:
+    assert _is_operator(_user(user_type=UserTypeEnum.SYSTEM_ADMIN)) is True
+
+
+def test_operator_both_paths_compose() -> None:
+    """A user who is both is_superuser AND SYSTEM_ADMIN is still
+    operator (no AND-of-two-conditions trap)."""
+    assert _is_operator(_user(
+        is_superuser=True, user_type=UserTypeEnum.SYSTEM_ADMIN,
+    )) is True
+
+
+def test_tenant_admin_is_not_operator() -> None:
+    """TENANT_ADMIN's authority is scoped to their own tenant — they
+    use the same same-tenant path as USER for the cascade endpoint."""
+    assert _is_operator(_user(user_type=UserTypeEnum.TENANT_ADMIN)) is False
+
+
+def test_regular_user_is_not_operator() -> None:
+    assert _is_operator(_user(user_type=UserTypeEnum.USER)) is False
+
+
+def test_unset_user_type_is_not_operator() -> None:
+    """A user object without ``user_type`` attribute (e.g., legacy
+    test fixtures) is treated as non-operator."""
+    user = SimpleNamespace(id=1, tenant_id=42, is_superuser=False)
+    assert _is_operator(user) is False
+
+
+# ---------------------------------------------------------------------------
+# _enforce_tenant_scope
+# ---------------------------------------------------------------------------
+
+
+def test_same_tenant_invocation_passes_for_regular_user() -> None:
+    """USER targeting their own tenant_id → no exception."""
+    user = _user(tenant_id=42, user_type=UserTypeEnum.USER)
+    _enforce_tenant_scope(user, requested_tenant_id=42)  # no raise
+
+
+def test_cross_tenant_blocked_for_regular_user() -> None:
+    """USER targeting a different tenant → 403."""
+    user = _user(tenant_id=42, user_type=UserTypeEnum.USER)
+    with pytest.raises(HTTPException) as exc_info:
+        _enforce_tenant_scope(user, requested_tenant_id=99)
+    assert exc_info.value.status_code == 403
+    assert "operator authority" in exc_info.value.detail.lower()
+
+
+def test_cross_tenant_blocked_for_tenant_admin() -> None:
+    """TENANT_ADMIN's authority is scoped to their own tenant — no
+    cross-tenant cascade invocation, even for admins of other tenants."""
+    user = _user(tenant_id=42, user_type=UserTypeEnum.TENANT_ADMIN)
+    with pytest.raises(HTTPException) as exc_info:
+        _enforce_tenant_scope(user, requested_tenant_id=99)
+    assert exc_info.value.status_code == 403
+
+
+def test_cross_tenant_passes_for_superuser() -> None:
+    """is_superuser=True → cross-tenant invocation allowed."""
+    user = _user(tenant_id=42, is_superuser=True)
+    _enforce_tenant_scope(user, requested_tenant_id=99)  # no raise
+
+
+def test_cross_tenant_passes_for_system_admin() -> None:
+    """user_type=SYSTEM_ADMIN → cross-tenant invocation allowed."""
+    user = _user(tenant_id=42, user_type=UserTypeEnum.SYSTEM_ADMIN)
+    _enforce_tenant_scope(user, requested_tenant_id=99)  # no raise
+
+
+def test_user_without_tenant_id_passes() -> None:
+    """A user whose ``tenant_id`` attribute is None (e.g., a system
+    service account) bypasses the same-tenant gate. The original
+    Phase 4 helper had this branch; Phase 5 preserves it."""
+    user = _user(tenant_id=None)
+    _enforce_tenant_scope(user, requested_tenant_id=99)  # no raise


### PR DESCRIPTION
## Summary

Two §3.46 phases on the same branch — the original Phase 4 endpoint (commit `d9ba120`) plus the Phase 5 operator-role authority follow-on it flagged.

### Phase 4 — HTTP API endpoint

`POST /api/v1/l3-cascade/run` and `POST /api/v1/l3-cascade/backfill` mirror the CLI vocabulary (`scripts/l3_cascade_cli.py`). Honours runner idempotency (existing L3 plan for the period → `SKIPPED` unless `force=true`).

### Phase 5 — operator-role authority

Cross-tenant cascade invocation now allowed for operator-level users; same-tenant scope stays in force for everyone else.

- **`services/_l3_cascade_auth.py`** — new module, extracted from `l3_cascade.py` so unit tests can import the helpers without booting the FastAPI app (the endpoint module pulls in `app.core.config` + `app.core.security` which need pyotp + DB URL at import time). Lives under `services/` (not `services/powell/` or `api/endpoints/`) to bypass eager re-export `__init__`s.
  - `is_operator(user)` → True when `is_superuser=True` OR `user_type == UserTypeEnum.SYSTEM_ADMIN`. **TENANT_ADMIN is explicitly NOT operator-level** — a tenant admin's authority is scoped to their own tenant.
  - `enforce_tenant_scope(user, requested_tenant_id)` → same-tenant always passes; cross-tenant raises 403 unless caller is an operator; operator path logs the cross-tenant invocation.
- **`api/endpoints/l3_cascade.py`** — imports the helpers from the new module; module-docstring updated to document the Phase 5 auth model. Both `/run` and `/backfill` share the same scope helper.

## Test plan

- [x] `pytest backend/tests/powell/test_l3_cascade_auth.py` — 12 passing (no DATABASE_URL required since the helper module has no DB / FastAPI-app dependency)
- [ ] End-to-end: hit `/api/v1/l3-cascade/run` as a USER targeting their own tenant → 200; targeting a different tenant → 403
- [ ] End-to-end: hit `/api/v1/l3-cascade/run` as a SYSTEM_ADMIN targeting any tenant → 200; verify the cross-tenant invocation gets logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)