### PR TITLE
feat(heuristics/cross_plane): AD-12 Phase 1 — port azirella-tms-stub content into TMS

### DIFF
--- a/backend/app/heuristics/__init__.py
+++ b/backend/app/heuristics/__init__.py
@@ -1,0 +1,13 @@
+"""TMS heuristics — fallback implementations for HEURISTIC-tier responses.
+
+Two sub-modules:
+
+- :mod:`.cross_plane` — heuristics that answer cross-plane skill calls
+  (e.g., from SCP/DP) when the tenant is at HEURISTIC tier per AD-12.
+- (Future) :mod:`.internal` — self-fallback heuristics for when TMS's
+  own TRMs / agents aren't ready (training failed, no checkpoint, etc.).
+  This space is currently served by ``app/services/powell/tms_heuristic_library/``;
+  we don't move it here in Phase 1 of the AD-12 migration.
+
+See ``cross_plane/README.md`` for the AD-12 migration story.
+"""

--- a/backend/app/heuristics/cross_plane/README.md
+++ b/backend/app/heuristics/cross_plane/README.md
@@ -1,0 +1,75 @@
+# TMS cross-plane heuristics
+
+**Status:** Phase 1 of [AD-12 migration](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/architecture/ARCHITECTURE_DECISIONS.md#ad-12-target-side-license-driven-plane-routing--each-app-owns-its-three-modes) — content moved from `azirella-tms-stub` (Autonomy-Core package) into TMS-the-product. Phase 2 (the per-request tier dispatcher) is a separate PR.
+
+## What this module does
+
+When TMS runs in **HEURISTIC tier** for a tenant — i.e. the customer has not licensed full TMS planning — calls into TMS's cross-plane skills (`transport.lane.estimate_eta`, `transport.load.evaluate_consolidation`, `transport.carrier.recommend`) return conservative-defaults answers from this module instead of from real planning agents.
+
+The HEURISTIC-tier responder is **co-located with the real TMS code** (this repo, this team) so that as the real TMS planning evolves, the heuristic floor evolves in lockstep — no drift across separate packages.
+
+## Public API
+
+```python
+from app.heuristics.cross_plane import (
+    HEURISTIC_HANDLERS,             # {skill_id: handler} registry
+    HEURISTIC_WRITE_SKILLS,         # frozenset of write-side skill IDs
+    HEURISTIC_PRODUCER_SIGNATURE,   # "autonomy-tms-heuristics:v0.1.0"
+    HeuristicWriteRefused,          # exception for write-skill calls
+    estimate_lane_eta,              # direct callable
+    evaluate_consolidation,         # direct callable
+    recommend_carrier,              # direct callable
+    refuse_write,                   # raises HeuristicWriteRefused
+    stamp_heuristic_response,       # 4-place warning helper
+)
+```
+
+Handlers take `(tenant_id, plane_config, inp)` keyword args and return a dict already stamped with the four canonical heuristic markers (`producer_tier="HEURISTIC"`, `producer_signature`, `heuristic_warning`, `heuristic_plane`).
+
+## Skills covered
+
+| Skill | Heuristic |
+|---|---|
+| `transport.lane.estimate_eta` | Haversine × parametric speed (DOT-HOS / ATRI / FHWA defaults) + dispatch buffer; returns wide ConformalBand |
+| `transport.load.evaluate_consolidation` | Always `recommend_consolidation=False` |
+| `transport.carrier.recommend` | Tenant default-carrier from config, or `"unknown"` |
+
+Write-side skills (`transport.load.dispatch`, `transport.shipment.tender`, `transport.dock.schedule`, `transport.equipment.reposition`) are NOT in `HEURISTIC_HANDLERS`. Phase 2's dispatcher refuses them with `HeuristicWriteRefused` when called against a HEURISTIC-tier tenant.
+
+## What's NOT here yet (Phase 2)
+
+The **dispatcher** that:
+
+1. Reads the calling tenant's `producer_tier` from `plane_registration`.
+2. If `AZIRELLA`, routes to the real TMS planning code.
+3. If `THIRD_PARTY`, routes to the MCP adapter (deferred — `NotImplementedError` for the demo).
+4. If `HEURISTIC` (or `STUB` in the legacy enum), looks up the skill in `HEURISTIC_HANDLERS` and calls it with the tenant's plane_config.
+
+The dispatcher lives in the TMS A2A request handler — a single small `async def handle_a2a_request(...)` that branches by tier.
+
+## What's NOT here ever (out of scope)
+
+- The legacy `azirella-tms-stub` package's FastAPI mount + sidecar startup. Under AD-12 we don't run a sidecar — the heuristic answers come from the TMS backend itself running in HEURISTIC mode. The Phase 1 port keeps the heuristic *content* and drops the *transport* layer.
+
+## Default values
+
+Speed model defaults from [HEURISTIC_DEFAULTS_REGISTRY.md](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/HEURISTIC_DEFAULTS_REGISTRY.md):
+
+- `transit_speed_mph_p10` = 600 mi/day (DOT-HOS + ATRI best-case OTR)
+- `transit_speed_mph_p50` = 500 mi/day (median solo OTR throughput)
+- `transit_speed_mph_p90` = 350 mi/day (LTL / multi-stop / congested)
+- `road_distance_multiplier` = 1.3 (FHWA conservative midpoint)
+- `dispatch_buffer_days` = 1.0 (origin + delivery dwell)
+
+All overridable per-tenant via `plane_config` (passed in by Phase 2's dispatcher).
+
+## Decommission of `azirella-tms-stub`
+
+The stub package is not removed by this PR. Phase 5 of the [AD-12 migration plan](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/architecture/AD12_MIGRATION_PLAN.md) decommissions it after every consumer has migrated through Phases 2 and 3. This PR is the content move; the stub stays deployed in parallel until Phase 5.
+
+## See also
+
+- [AD-12 in ARCHITECTURE_DECISIONS.md](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/architecture/ARCHITECTURE_DECISIONS.md#ad-12-target-side-license-driven-plane-routing--each-app-owns-its-three-modes)
+- [AD-12 migration plan](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/architecture/AD12_MIGRATION_PLAN.md)
+- [HEURISTIC_DEFAULTS_REGISTRY.md](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/HEURISTIC_DEFAULTS_REGISTRY.md)
+- Legacy: [azirella-tms-stub README](https://github.com/azirella-ltd/Autonomy-Core/blob/main/packages/azirella-tms-stub/README.md)

--- a/backend/app/heuristics/cross_plane/__init__.py
+++ b/backend/app/heuristics/cross_plane/__init__.py
@@ -1,0 +1,52 @@
+"""TMS cross-plane heuristics — direct-call module for AD-12 HEURISTIC tier.
+
+Public API
+----------
+
+Skill handlers (one per cross-plane TMS skill consumers expect):
+
+- :func:`estimate_lane_eta`
+- :func:`evaluate_consolidation`
+- :func:`recommend_carrier`
+
+Plus the registry and write-refusal helpers Phase 2's dispatcher uses:
+
+- :data:`HEURISTIC_HANDLERS` — ``{skill_id: handler}`` for read skills.
+- :data:`HEURISTIC_WRITE_SKILLS` — write-side skill IDs to refuse.
+- :func:`refuse_write` — raises :class:`HeuristicWriteRefused`.
+- :data:`HEURISTIC_PRODUCER_SIGNATURE` — base producer signature.
+
+Plus the warning-stamp helper for any handler outside the registry
+that wants to participate in the four-place warning regime:
+
+- :func:`stamp_heuristic_response`
+
+See ``README.md`` in this directory for the AD-12 migration story.
+"""
+from .handlers import (
+    HEURISTIC_HANDLERS,
+    HEURISTIC_PRODUCER_SIGNATURE,
+    HEURISTIC_WRITE_SKILLS,
+    HeuristicWriteRefused,
+    estimate_lane_eta,
+    evaluate_consolidation,
+    recommend_carrier,
+    refuse_write,
+)
+from .warning import (
+    heuristic_warning_text,
+    stamp_heuristic_response,
+)
+
+__all__ = [
+    "HEURISTIC_HANDLERS",
+    "HEURISTIC_PRODUCER_SIGNATURE",
+    "HEURISTIC_WRITE_SKILLS",
+    "HeuristicWriteRefused",
+    "estimate_lane_eta",
+    "evaluate_consolidation",
+    "heuristic_warning_text",
+    "recommend_carrier",
+    "refuse_write",
+    "stamp_heuristic_response",
+]

--- a/backend/app/heuristics/cross_plane/_eta.py
+++ b/backend/app/heuristics/cross_plane/_eta.py
@@ -1,0 +1,278 @@
+"""ETA math for TMS HEURISTIC-tier responses.
+
+Ported from the legacy ``azirella-tms-stub`` package as part of the
+AD-12 migration (Phase 1, 2026-05-04). When TMS runs in HEURISTIC
+tier for a tenant — i.e. the customer hasn't licensed full TMS
+planning — calls into ``transport.lane.estimate_eta`` return ETAs
+derived from haversine distance and a parametric speed model rather
+than from the real planning agents.
+
+This module has no real lane-history data, no live carrier feeds,
+no geofence telemetry. It exists to satisfy cross-plane contracts
+(SCP's ATP promise math, DP's arrival-window forecasts) when full
+TMS isn't deployed for the tenant.
+
+Speed defaults are pulled from public US-trucking averages:
+
+- **DOT regulations** cap solo OTR drivers at 11 hours driving in a
+  14-hour on-duty window with a 30-minute break after 8 hours
+  driving (49 CFR §395.3). Practical solo OTR throughput is
+  ~500–600 miles/day on long lanes (American Transportation
+  Research Institute, *An Analysis of the Operational Costs of
+  Trucking*, recent editions; FMCSA driver-day surveys).
+- **Effective truck speed** in steady cruise is ~55–60 mph; net of
+  HOS, dock dwell, fueling, traffic, and en-route inspections,
+  effective progress drops to roughly the per-day numbers above.
+- **Road-vs-great-circle distance** for typical North-American
+  highway routes runs ~1.2–1.4× great-circle (FHWA freight-flow
+  studies). The stub uses 1.3× as a conservative midpoint.
+- **Mode mix** spreads the band: short-haul / single-day deliveries
+  cluster near 600 mi/day; LTL with multiple stops drops to
+  ~250–350 mi/day; intermodal rail moves containers at 350–450
+  mi/day on long lanes; ocean freight is days of dwell + ~500
+  nautical miles/day at sea.
+
+The default p10 / p50 / p90 speeds (600 / 500 / 350 mi/day) are
+deliberately wide to widen the conformal band — stubs MUST err
+toward conservative confidence so consumers don't trust them like
+real data.
+
+Plus a fixed dispatch buffer to cover origin-side dwell + the
+scheduling lead time from order entry to truck-rolling. ATRI's
+*Operational Costs of Trucking* and ProductionMetrics dock-dwell
+surveys put detention at 1.5–4 hours per shipment median; the stub
+uses half-day dispatch + half-day delivery dwell as a conservative
+combined buffer.
+
+Tenant overrides (per ``StubTenantConfig.plane_config``):
+
+- ``transit_speed_mph_p10`` (default 600): best-case effective speed.
+- ``transit_speed_mph_p50`` (default 500): median effective speed.
+- ``transit_speed_mph_p90`` (default 350): worst-case effective speed.
+- ``road_distance_multiplier`` (default 1.3): great-circle → road km.
+- ``dispatch_buffer_days`` (default 1.0): origin + delivery dwell.
+- ``minimum_transit_days_p50`` (default 1.0): floor for p50; same-day
+  delivery is rare on the OTR network the stub models.
+- ``default_transit_days_p50`` (default 3.0): used when neither lat/lng
+  nor a configured site-coordinate map can resolve a pair of sites.
+- ``site_coordinates`` (default ``{}``): map of ``site_id`` (string) →
+  ``{"lat": float, "lon": float}``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from azirella_data_model.conformal import ConformalBand
+from azirella_data_model.planes import ProducerTier
+from azirella_data_model.visibility.geofence_emitter import haversine_meters
+
+
+# Conservative built-in defaults (see module docstring).
+BUILT_IN_DEFAULTS: Dict[str, Any] = {
+    "transit_speed_mph_p10": 600.0,    # best case (hot lane, OTR cruise)
+    "transit_speed_mph_p50": 500.0,    # median solo OTR throughput
+    "transit_speed_mph_p90": 350.0,    # LTL / multi-stop / congested
+    "road_distance_multiplier": 1.3,   # great-circle → road
+    "dispatch_buffer_days": 1.0,       # origin + delivery dwell
+    "minimum_transit_days_p50": 1.0,   # same-day OTR is rare
+    "default_transit_days_p50": 3.0,   # fallback when no coords
+    "default_transit_days_p10": 2.0,
+    "default_transit_days_p90": 5.0,
+    "site_coordinates": {},
+}
+
+
+@dataclass(frozen=True)
+class ETAResult:
+    """Stub ETA decision.
+
+    :param departure_at: when the shipment leaves the origin.
+    :param p10_at: optimistic arrival (10th percentile of arrival
+        time = early). Mapped from ``p10_days`` (small days = early).
+    :param p50_at: median arrival.
+    :param p90_at: pessimistic arrival.
+    :param p10_days: transit days at the 10th percentile (small).
+    :param p50_days: median transit days.
+    :param p90_days: transit days at the 90th percentile (large).
+    :param road_distance_miles: estimated road distance (haversine ×
+        road multiplier). ``None`` when neither coordinates nor
+        config could resolve the lane and the stub used the flat
+        ``default_transit_days_*`` config.
+    :param resolution_path: how the stub resolved the lane —
+        ``"caller_coordinates"`` / ``"config_coordinates"`` /
+        ``"flat_default"``. Useful for audit / debugging.
+    """
+
+    departure_at: datetime
+    p10_at: datetime
+    p50_at: datetime
+    p90_at: datetime
+    p10_days: float
+    p50_days: float
+    p90_days: float
+    road_distance_miles: Optional[float]
+    resolution_path: str
+
+    def as_band(self, *, producer_signature: str) -> ConformalBand:
+        """Wrap transit-day estimates as a :class:`ConformalBand`.
+
+        Bands are in DAYS. Stamps ``producer_tier=STUB`` so consumer
+        TRMs widen confidence automatically per §3.32a / §3.31.
+        """
+        return ConformalBand(
+            p10=float(self.p10_days),
+            p50=float(self.p50_days),
+            p90=float(self.p90_days),
+            coverage_target=0.95,  # wide — stubs are low-confidence
+            producer_signature=producer_signature,
+            producer_tier=ProducerTier.STUB,
+        )
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "departure_at": self.departure_at.isoformat(),
+            "p10_at": self.p10_at.isoformat(),
+            "p50_at": self.p50_at.isoformat(),
+            "p90_at": self.p90_at.isoformat(),
+            "p10_days": self.p10_days,
+            "p50_days": self.p50_days,
+            "p90_days": self.p90_days,
+            "road_distance_miles": self.road_distance_miles,
+            "resolution_path": self.resolution_path,
+        }
+
+
+def estimate_eta(
+    *,
+    from_site_id: str,
+    to_site_id: str,
+    departure_at: datetime,
+    plane_config: Dict[str, Any],
+    from_coords: Optional[Dict[str, float]] = None,
+    to_coords: Optional[Dict[str, float]] = None,
+) -> ETAResult:
+    """Compute a stub ETA from haversine + speed × buffer math.
+
+    Resolution order for site coordinates:
+
+    1. ``from_coords`` / ``to_coords`` passed by the caller
+       (``{"lat": float, "lon": float}``).
+    2. ``plane_config["site_coordinates"][site_id]`` for each side.
+    3. Flat-default: use ``default_transit_days_p10/p50/p90`` from
+       config without computing distance.
+
+    Either both endpoints' coordinates resolve from the same source
+    (caller or config) or we fall through to flat-default. Mixing
+    a caller-provided origin with a config-resolved destination is
+    accepted — both sides need a lat/lon, the source doesn't have
+    to be uniform.
+    """
+    cfg = {**BUILT_IN_DEFAULTS, **(plane_config or {})}
+
+    coords_from = from_coords or _coords_from_config(
+        cfg, from_site_id,
+    )
+    coords_to = to_coords or _coords_from_config(
+        cfg, to_site_id,
+    )
+
+    if coords_from is None or coords_to is None:
+        # Fall back to flat-default — no distance computed.
+        p10 = float(cfg["default_transit_days_p10"])
+        p50 = max(
+            float(cfg["minimum_transit_days_p50"]),
+            float(cfg["default_transit_days_p50"]),
+        )
+        p90 = float(cfg["default_transit_days_p90"])
+        return _build_result(
+            departure_at=departure_at,
+            p10_days=p10,
+            p50_days=p50,
+            p90_days=p90,
+            road_distance_miles=None,
+            resolution_path="flat_default",
+        )
+
+    # Distance — meters → miles, scaled by road-distance multiplier.
+    great_circle_meters = haversine_meters(
+        coords_from["lat"], coords_from["lon"],
+        coords_to["lat"], coords_to["lon"],
+    )
+    great_circle_miles = great_circle_meters / 1609.344
+    road_miles = great_circle_miles * float(cfg["road_distance_multiplier"])
+
+    buffer_days = float(cfg["dispatch_buffer_days"])
+    min_p50 = float(cfg["minimum_transit_days_p50"])
+
+    p10_days = (road_miles / float(cfg["transit_speed_mph_p10"])) + buffer_days
+    p50_days = max(
+        min_p50,
+        (road_miles / float(cfg["transit_speed_mph_p50"])) + buffer_days,
+    )
+    p90_days = (road_miles / float(cfg["transit_speed_mph_p90"])) + buffer_days
+
+    # Sanity check: ConformalBand requires p10 <= p50 <= p90.
+    # Numeric edge cases (very short lanes after the min-p50 floor)
+    # can push p10 below the floored p50; clamp to preserve order.
+    p10_days = min(p10_days, p50_days)
+    p90_days = max(p90_days, p50_days)
+
+    resolution_path = (
+        "caller_coordinates"
+        if (from_coords is not None and to_coords is not None)
+        else "config_coordinates"
+        if (from_coords is None and to_coords is None)
+        else "mixed_coordinates"
+    )
+
+    return _build_result(
+        departure_at=departure_at,
+        p10_days=p10_days,
+        p50_days=p50_days,
+        p90_days=p90_days,
+        road_distance_miles=road_miles,
+        resolution_path=resolution_path,
+    )
+
+
+def _coords_from_config(
+    cfg: Dict[str, Any], site_id: str,
+) -> Optional[Dict[str, float]]:
+    site_map = cfg.get("site_coordinates", {}) or {}
+    if not isinstance(site_map, dict):
+        return None
+    entry = site_map.get(str(site_id))
+    if not isinstance(entry, dict):
+        return None
+    if "lat" not in entry or "lon" not in entry:
+        return None
+    return {"lat": float(entry["lat"]), "lon": float(entry["lon"])}
+
+
+def _build_result(
+    *,
+    departure_at: datetime,
+    p10_days: float,
+    p50_days: float,
+    p90_days: float,
+    road_distance_miles: Optional[float],
+    resolution_path: str,
+) -> ETAResult:
+    if departure_at.tzinfo is None:
+        departure_at = departure_at.replace(tzinfo=timezone.utc)
+    return ETAResult(
+        departure_at=departure_at,
+        p10_at=departure_at + timedelta(days=p10_days),
+        p50_at=departure_at + timedelta(days=p50_days),
+        p90_at=departure_at + timedelta(days=p90_days),
+        p10_days=p10_days,
+        p50_days=p50_days,
+        p90_days=p90_days,
+        road_distance_miles=road_distance_miles,
+        resolution_path=resolution_path,
+    )
+
+
+__all__ = ["BUILT_IN_DEFAULTS", "ETAResult", "estimate_eta"]

--- a/backend/app/heuristics/cross_plane/handlers.py
+++ b/backend/app/heuristics/cross_plane/handlers.py
@@ -1,0 +1,319 @@
+"""TMS cross-plane heuristic handlers — direct-call API.
+
+Ported from ``azirella-tms-stub.skills`` as part of the AD-12
+migration (Phase 1). The legacy stub package wrapped these as A2A
+``SkillContext``-based handlers mounted on a FastAPI router on a
+sidecar container. Under AD-12 they're called **directly** from
+inside the TMS backend's request handler when the tenant's
+license tier is HEURISTIC — no separate sidecar, no A2A round-trip.
+
+Three skills covered (mirror the legacy stub package):
+
+- ``estimate_lane_eta``           — haversine × parametric speed.
+- ``evaluate_consolidation``      — always ship-as-is; the
+                                    heuristic has no lane economics.
+- ``recommend_carrier``           — tenant default-carrier from
+                                    config, or ``"unknown"``.
+
+Write-side skills (``transport.load.dispatch``,
+``transport.shipment.tender``, ``transport.dock.schedule``,
+``transport.equipment.reposition``) intentionally have no handler
+here. Phase 2's dispatcher should refuse them with a typed error
+when the tenant is at HEURISTIC tier — see ``refuse_write`` below.
+
+Phase 2 (separate PR) wires these handlers into the TMS A2A
+request handler so they get called when the resolver determines
+the tenant is at HEURISTIC tier. This file is the content; Phase 2
+is the dispatch glue.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from azirella_data_model.planes import ProducerTier
+
+from ._eta import BUILT_IN_DEFAULTS, estimate_eta
+from .warning import stamp_heuristic_response
+
+logger = logging.getLogger(__name__)
+
+
+# Producer-signature head. Per-skill suffix appended in handlers.
+HEURISTIC_PRODUCER_SIGNATURE = "autonomy-tms-heuristics:v0.1.0"
+
+
+class HeuristicWriteRefused(RuntimeError):
+    """Raised when a write-side skill is called against a tenant at
+    HEURISTIC tier. The TMS request handler MUST translate this to
+    a clean error code on the wire — heuristic-tier customers get
+    no TMS write paths.
+    """
+
+    def __init__(self, skill_id: str) -> None:
+        super().__init__(
+            f"skill {skill_id!r} not available at HEURISTIC tier — "
+            "license a full TMS plane (AZIRELLA) or configure a THIRD_PARTY "
+            "MCP adapter to a real TMS"
+        )
+        self.skill_id = skill_id
+
+
+# ---------------------------------------------------------------------------
+# transport.lane.estimate_eta
+# ---------------------------------------------------------------------------
+
+
+def estimate_lane_eta(
+    *,
+    tenant_id: int,
+    plane_config: Dict[str, Any],
+    inp: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Heuristic ETA — haversine × speed × dispatch buffer.
+
+    :param tenant_id: caller tenant. Used by the dispatcher's caller
+        identity but not consumed by the heuristic math itself.
+    :param plane_config: the tenant's heuristic-mode config (dict
+        layered over ``BUILT_IN_DEFAULTS``). Phase 2's dispatcher
+        builds this from ``plane_registration.heuristic_config`` or
+        the per-tenant override file; for Phase 1 the test seed
+        passes ``BUILT_IN_DEFAULTS`` directly.
+    :param inp: skill input. Required: ``from_site_id``,
+        ``to_site_id``, ``departure_at``. Optional: ``from_lat``,
+        ``from_lon``, ``to_lat``, ``to_lon``.
+    """
+    for required in ("from_site_id", "to_site_id", "departure_at"):
+        if not inp.get(required):
+            raise ValueError(f"missing required input: {required}")
+
+    departure = _parse_datetime(inp["departure_at"])
+    from_coords = _coords_from_input(inp, "from_lat", "from_lon")
+    to_coords = _coords_from_input(inp, "to_lat", "to_lon")
+
+    result = estimate_eta(
+        from_site_id=str(inp["from_site_id"]),
+        to_site_id=str(inp["to_site_id"]),
+        departure_at=departure,
+        plane_config=plane_config,
+        from_coords=from_coords,
+        to_coords=to_coords,
+    )
+
+    band = result.as_band(
+        producer_signature=f"{HEURISTIC_PRODUCER_SIGNATURE}:lane.estimate_eta",
+    )
+    payload = {
+        "from_site_id": str(inp["from_site_id"]),
+        "to_site_id": str(inp["to_site_id"]),
+        **result.as_dict(),
+        "eta_band": band.as_dict(),
+    }
+    return stamp_heuristic_response(
+        payload,
+        skill_id="transport.lane.estimate_eta",
+        producer_signature=f"{HEURISTIC_PRODUCER_SIGNATURE}:lane.estimate_eta",
+    )
+
+
+# ---------------------------------------------------------------------------
+# transport.load.evaluate_consolidation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_consolidation(
+    *,
+    tenant_id: int,
+    plane_config: Dict[str, Any],
+    inp: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Heuristic consolidation — always recommend ship-as-is.
+
+    Consolidation has real trade-offs: hold-back time vs. service
+    level, customer-mix compatibility, equipment fit, lane economics.
+    None of these are observable from a heuristic — so the safe
+    answer is "don't consolidate; ship each shipment as-is". The
+    cost-savings field is filled with a conservative null; consumers
+    that need real consolidation analysis MUST upgrade to a full
+    TMS or third-party adapter.
+    """
+    config_id = inp.get("config_id")
+    shipment_ids = inp.get("shipment_ids") or []
+    if config_id is None:
+        raise ValueError("missing required input: config_id")
+    if not shipment_ids:
+        raise ValueError(
+            "missing required input: shipment_ids (non-empty list)"
+        )
+
+    payload = {
+        "config_id": int(config_id),
+        "shipment_ids": [str(s) for s in shipment_ids],
+        "shipment_count": len(shipment_ids),
+        "recommend_consolidation": False,
+        "score": 0.0,
+        "utilisation_estimate": None,
+        "consolidation_cost_savings_estimate": None,
+        "reasoning": (
+            "TMS heuristic tier: no consolidation analysis available. "
+            "Default decision is ship-as-is — every shipment dispatched "
+            "individually. Real consolidation analysis requires lane "
+            "economics, equipment fit, customer-mix compatibility, and "
+            "hold-back time analysis the heuristic does not have."
+        ),
+    }
+    return stamp_heuristic_response(
+        payload,
+        skill_id="transport.load.evaluate_consolidation",
+        producer_signature=(
+            f"{HEURISTIC_PRODUCER_SIGNATURE}:load.evaluate_consolidation"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# transport.carrier.recommend
+# ---------------------------------------------------------------------------
+
+
+def recommend_carrier(
+    *,
+    tenant_id: int,
+    plane_config: Dict[str, Any],
+    inp: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Heuristic carrier recommendation — tenant default or
+    ``"unknown"``.
+
+    Real carrier procurement runs a multi-criteria waterfall (cost,
+    OTIF, asset compatibility, capacity availability, contract
+    coverage). The heuristic returns the tenant's default-carrier
+    from config as a single-recommendation list. If no default is
+    configured, returns ``"unknown"`` with a low confidence score.
+    """
+    config_id = inp.get("config_id")
+    load_id = inp.get("load_id")
+    if config_id is None or load_id is None:
+        raise ValueError(
+            "missing required input: config_id and load_id"
+        )
+    top_n = int(inp.get("top_n", 3))
+
+    default_carrier_id = plane_config.get("default_carrier_id")
+
+    if default_carrier_id:
+        recommendations = [
+            {
+                "carrier_id": str(default_carrier_id),
+                "score": 0.5,
+                "reasoning": (
+                    "Tenant default carrier from heuristic config; no real "
+                    "procurement waterfall executed."
+                ),
+            }
+        ]
+    else:
+        recommendations = [
+            {
+                "carrier_id": "unknown",
+                "score": 0.0,
+                "reasoning": (
+                    "No default carrier configured for tenant; heuristic "
+                    "tier cannot select a real carrier."
+                ),
+            }
+        ]
+
+    payload = {
+        "load_id": str(load_id),
+        "config_id": int(config_id),
+        "top_n": top_n,
+        "recommendations": recommendations,
+    }
+    return stamp_heuristic_response(
+        payload,
+        skill_id="transport.carrier.recommend",
+        producer_signature=(
+            f"{HEURISTIC_PRODUCER_SIGNATURE}:carrier.recommend"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Write-side refusal helper
+# ---------------------------------------------------------------------------
+
+
+def refuse_write(skill_id: str) -> None:
+    """Raise :class:`HeuristicWriteRefused` for any write-side skill.
+
+    Phase 2's dispatcher calls this when the tenant is at HEURISTIC
+    tier and the requested skill is one of the write-side ones.
+    Heuristic tier doesn't support writes — by design.
+    """
+    raise HeuristicWriteRefused(skill_id=skill_id)
+
+
+# ---------------------------------------------------------------------------
+# Skill registry — the names Phase 2's dispatcher will look up by
+# ---------------------------------------------------------------------------
+
+
+HEURISTIC_HANDLERS: Dict[str, Any] = {
+    "transport.lane.estimate_eta": estimate_lane_eta,
+    "transport.load.evaluate_consolidation": evaluate_consolidation,
+    "transport.carrier.recommend": recommend_carrier,
+}
+"""Handler registry. Phase 2's tier dispatcher looks up the
+incoming ``skill_id`` and calls the matching handler with the
+tenant's heuristic plane_config and the request input."""
+
+
+HEURISTIC_WRITE_SKILLS = frozenset({
+    "transport.load.dispatch",
+    "transport.shipment.tender",
+    "transport.dock.schedule",
+    "transport.equipment.reposition",
+})
+"""Write-side skill IDs that Phase 2's dispatcher refuses with
+``HeuristicWriteRefused`` when called against a HEURISTIC-tier
+tenant."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_datetime(raw: Any) -> datetime:
+    if isinstance(raw, datetime):
+        return raw
+    if isinstance(raw, str):
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    raise ValueError(
+        f"departure_at must be ISO-8601 string or datetime; got "
+        f"{type(raw).__name__}"
+    )
+
+
+def _coords_from_input(
+    inp: Dict[str, Any], lat_key: str, lon_key: str,
+) -> Optional[Dict[str, float]]:
+    lat = inp.get(lat_key)
+    lon = inp.get(lon_key)
+    if lat is None or lon is None:
+        return None
+    return {"lat": float(lat), "lon": float(lon)}
+
+
+__all__ = [
+    "HEURISTIC_HANDLERS",
+    "HEURISTIC_PRODUCER_SIGNATURE",
+    "HEURISTIC_WRITE_SKILLS",
+    "HeuristicWriteRefused",
+    "estimate_lane_eta",
+    "evaluate_consolidation",
+    "recommend_carrier",
+    "refuse_write",
+]

--- a/backend/app/heuristics/cross_plane/warning.py
+++ b/backend/app/heuristics/cross_plane/warning.py
@@ -1,0 +1,69 @@
+"""Four-place warning regime for HEURISTIC-tier responses.
+
+Ported from ``azirella-stub-common.response`` into TMS as part of
+the AD-12 migration (Phase 1). When this app's request handler
+runs in HEURISTIC tier for a given tenant — i.e. the customer
+hasn't licensed full TMS — every response from the cross-plane
+heuristics MUST carry these markers so consumer planes know they're
+consuming heuristic data, not real planning.
+
+Four canonical markers in every response:
+
+1. ``producer_tier="HEURISTIC"`` (the AD-12 tier classification;
+   formerly ``STUB`` under §3.32a).
+2. ``producer_signature`` — app + skill + version, e.g.
+   ``"autonomy-tms:lane.estimate_eta:heuristic:v0.1.0"``.
+3. ``heuristic_warning`` — canonical audit-grep-friendly warning
+   text. Same head phrase (``AZIRELLA-STUB-WARNING``) as the
+   pre-AD-12 stub package so existing log pipelines, dashboards,
+   and runbooks keep matching.
+4. ``heuristic_plane`` — namespaced source identifier
+   (``autonomy-tms-heuristics``).
+
+Plus the structural propagation: every ``ConformalBand`` and
+``OutcomeEvent`` returned by these handlers carries
+``producer_tier=ProducerTier.HEURISTIC``.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+# Canonical warning phrase. Stays stable across the AD-12 migration
+# so log search pipelines, dashboards, and customer-support runbooks
+# can keep matching on the substring "AZIRELLA-STUB-WARNING".
+_CANONICAL_WARNING_HEAD = "AZIRELLA-STUB-WARNING"
+
+
+def heuristic_warning_text(*, skill_id: str) -> str:
+    """Canonical heuristic-warning string for TMS cross-plane skills."""
+    return (
+        f"{_CANONICAL_WARNING_HEAD}: response from autonomy-tms heuristics "
+        f"(producer_tier=HEURISTIC) for skill={skill_id!r}. Values are "
+        "conservative defaults synthesized in lieu of a real planning "
+        "agent. Consumer planes MUST treat outputs as low-confidence: "
+        "widen ConformalBand coverage, discount BSC reward weights, "
+        "never auto-execute decisions derived from HEURISTIC-tier data "
+        "without a human-in-the-loop."
+    )
+
+
+def stamp_heuristic_response(
+    payload: Dict[str, Any],
+    *,
+    skill_id: str,
+    producer_signature: str,
+) -> Dict[str, Any]:
+    """Inject the four canonical heuristic markers into a response.
+
+    Handlers build their domain payload, then call this helper once at
+    the return boundary. Existing keys are preserved unless they
+    collide with the four reserved names — in which case heuristic-side
+    values win, because the four markers are the audit contract.
+    """
+    out = dict(payload)
+    out["producer_tier"] = "HEURISTIC"
+    out["producer_signature"] = producer_signature
+    out["heuristic_warning"] = heuristic_warning_text(skill_id=skill_id)
+    out["heuristic_plane"] = "autonomy-tms-heuristics"
+    return out

--- a/backend/tests/heuristics/test_cross_plane_handlers.py
+++ b/backend/tests/heuristics/test_cross_plane_handlers.py
@@ -1,0 +1,197 @@
+"""Smoke tests for the AD-12 Phase 1 TMS cross-plane heuristics.
+
+These exercise the direct-call API ported from ``azirella-tms-stub``
+into ``app.heuristics.cross_plane``. Phase 2's dispatcher tests will
+sit alongside this file once that PR lands.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.heuristics.cross_plane import (
+    HEURISTIC_HANDLERS,
+    HEURISTIC_PRODUCER_SIGNATURE,
+    HEURISTIC_WRITE_SKILLS,
+    HeuristicWriteRefused,
+    estimate_lane_eta,
+    evaluate_consolidation,
+    recommend_carrier,
+    refuse_write,
+)
+from app.heuristics.cross_plane._eta import BUILT_IN_DEFAULTS
+
+
+# ---------------------------------------------------------------------------
+# Four-place warning regime
+# ---------------------------------------------------------------------------
+# Every read-skill response must carry these four markers so consumer
+# planes know they're consuming heuristic data, not real planning.
+
+REQUIRED_MARKERS = {
+    "producer_tier",
+    "producer_signature",
+    "heuristic_warning",
+    "heuristic_plane",
+}
+
+
+def _assert_markers(payload: dict, expected_skill_id: str) -> None:
+    assert REQUIRED_MARKERS.issubset(payload.keys()), (
+        f"missing markers: {REQUIRED_MARKERS - set(payload.keys())}"
+    )
+    assert payload["producer_tier"] == "HEURISTIC"
+    assert payload["producer_signature"].startswith(
+        HEURISTIC_PRODUCER_SIGNATURE,
+    )
+    assert "AZIRELLA-STUB-WARNING" in payload["heuristic_warning"]
+    assert expected_skill_id in payload["heuristic_warning"]
+    assert payload["heuristic_plane"] == "autonomy-tms-heuristics"
+
+
+# ---------------------------------------------------------------------------
+# transport.lane.estimate_eta
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_lane_eta_with_explicit_coords() -> None:
+    """Caller supplies lat/lon → handler computes haversine + speed
+    model + dispatch buffer and returns a stamped response."""
+    response = estimate_lane_eta(
+        tenant_id=1,
+        plane_config=BUILT_IN_DEFAULTS,
+        inp={
+            "from_site_id": "S001",
+            "to_site_id": "S002",
+            "departure_at": datetime(2026, 5, 4, 8, 0, tzinfo=timezone.utc),
+            "from_lat": 41.8781,
+            "from_lon": -87.6298,  # Chicago
+            "to_lat": 32.7767,
+            "to_lon": -96.7970,    # Dallas
+        },
+    )
+
+    _assert_markers(response, "transport.lane.estimate_eta")
+    assert response["from_site_id"] == "S001"
+    assert response["to_site_id"] == "S002"
+    assert response["p50_days"] >= 1.0  # minimum_transit_days_p50 floor
+    assert response["p50_days"] < response["p90_days"]
+    assert response["p10_days"] < response["p50_days"]
+    assert "eta_band" in response
+    band = response["eta_band"]
+    assert band["producer_tier"] == "STUB"  # ConformalBand still uses STUB enum value
+
+
+def test_estimate_lane_eta_missing_required_field_raises() -> None:
+    with pytest.raises(ValueError, match="missing required input"):
+        estimate_lane_eta(
+            tenant_id=1,
+            plane_config=BUILT_IN_DEFAULTS,
+            inp={"from_site_id": "S001"},  # missing to_site_id, departure_at
+        )
+
+
+def test_estimate_lane_eta_no_coords_uses_default_transit_days() -> None:
+    """When neither call-time coords nor configured site_coordinates
+    resolve, falls back to ``default_transit_days_p50`` (3.0)."""
+    response = estimate_lane_eta(
+        tenant_id=1,
+        plane_config=BUILT_IN_DEFAULTS,
+        inp={
+            "from_site_id": "S_unknown",
+            "to_site_id": "S_also_unknown",
+            "departure_at": "2026-05-04T08:00:00Z",
+        },
+    )
+    assert response["p50_days"] == BUILT_IN_DEFAULTS["default_transit_days_p50"]
+
+
+# ---------------------------------------------------------------------------
+# transport.load.evaluate_consolidation
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_consolidation_always_ship_as_is() -> None:
+    response = evaluate_consolidation(
+        tenant_id=1,
+        plane_config=BUILT_IN_DEFAULTS,
+        inp={
+            "config_id": 7,
+            "shipment_ids": ["SH-001", "SH-002", "SH-003"],
+        },
+    )
+    _assert_markers(response, "transport.load.evaluate_consolidation")
+    assert response["recommend_consolidation"] is False
+    assert response["score"] == 0.0
+    assert response["shipment_count"] == 3
+    assert response["consolidation_cost_savings_estimate"] is None
+
+
+def test_evaluate_consolidation_missing_required_raises() -> None:
+    with pytest.raises(ValueError, match="missing required input"):
+        evaluate_consolidation(
+            tenant_id=1,
+            plane_config=BUILT_IN_DEFAULTS,
+            inp={"config_id": 7},  # missing shipment_ids
+        )
+
+
+# ---------------------------------------------------------------------------
+# transport.carrier.recommend
+# ---------------------------------------------------------------------------
+
+
+def test_recommend_carrier_uses_tenant_default() -> None:
+    response = recommend_carrier(
+        tenant_id=1,
+        plane_config={**BUILT_IN_DEFAULTS, "default_carrier_id": "carrier:fleet-A"},
+        inp={"config_id": 7, "load_id": "L-99"},
+    )
+    _assert_markers(response, "transport.carrier.recommend")
+    assert response["recommendations"][0]["carrier_id"] == "carrier:fleet-A"
+    assert response["recommendations"][0]["score"] == 0.5
+
+
+def test_recommend_carrier_no_default_returns_unknown() -> None:
+    response = recommend_carrier(
+        tenant_id=1,
+        plane_config=BUILT_IN_DEFAULTS,
+        inp={"config_id": 7, "load_id": "L-99"},
+    )
+    _assert_markers(response, "transport.carrier.recommend")
+    assert response["recommendations"][0]["carrier_id"] == "unknown"
+    assert response["recommendations"][0]["score"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Write-side refusal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("skill_id", sorted(HEURISTIC_WRITE_SKILLS))
+def test_refuse_write_raises(skill_id: str) -> None:
+    with pytest.raises(HeuristicWriteRefused) as exc_info:
+        refuse_write(skill_id)
+    assert exc_info.value.skill_id == skill_id
+    assert "HEURISTIC tier" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Registry shape
+# ---------------------------------------------------------------------------
+
+
+def test_handler_registry_keys_match_skill_ids() -> None:
+    expected = {
+        "transport.lane.estimate_eta",
+        "transport.load.evaluate_consolidation",
+        "transport.carrier.recommend",
+    }
+    assert set(HEURISTIC_HANDLERS.keys()) == expected
+
+
+def test_write_skill_set_is_disjoint_from_handler_registry() -> None:
+    """A handler is never a write skill; a write skill is never a
+    handler. The dispatcher branches on this disjointness."""
+    assert not (set(HEURISTIC_HANDLERS.keys()) & HEURISTIC_WRITE_SKILLS)


### PR DESCRIPTION
## Summary

Phase 1 of the [AD-12 migration](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/architecture/AD12_MIGRATION_PLAN.md): ports the heuristic content out of the legacy `azirella-tms-stub` package (which lived in Autonomy-Core) into TMS-the-product, where it belongs per the single-home rule.

**This PR is the content move only.** Phase 2 (the per-request tier dispatcher in the TMS A2A request handler) is a separate PR and is owned by the TMS team going forward.

## What this delivers

- `app/heuristics/cross_plane/` — direct-call API for the three read-side TMS skills:
  - `transport.lane.estimate_eta` (haversine × parametric speed + dispatch buffer + ConformalBand)
  - `transport.load.evaluate_consolidation` (always ship-as-is; no lane economics)
  - `transport.carrier.recommend` (tenant default-carrier or `unknown`)
- `HEURISTIC_HANDLERS` registry + `HEURISTIC_WRITE_SKILLS` frozenset + `HeuristicWriteRefused` exception for the four write-side skills (`dispatch`, `tender`, `dock.schedule`, `equipment.reposition`).
- Four-place warning regime preserved end-to-end (`producer_tier`, `producer_signature`, `heuristic_warning`, `heuristic_plane`); canonical `AZIRELLA-STUB-WARNING` audit-grep phrase preserved.
- 13 smoke tests covering markers, math, refusal, registry shape — all passing.

## What this does NOT change

- Wire format: consumers (SCP, DP) keep calling the existing TMS skill URLs. No A2A surface changes.
- Producer enum: `ProducerTier.STUB` remains for ConformalBand callsites; `HEURISTIC` is the new tier label exposed in payloads.
- The legacy `packages/azirella-tms-stub/` package is unchanged — Phase 5 of the migration plan decommissions it after every consumer cuts over.

## Demo context — Microsoft demo 2026-05-11

This PR unblocks the TMS-team-owned Phase 2 + Phase 4 work that the demo depends on. Per [CONSUMER_ADOPTION_LOG.md 2026-05-04](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/CONSUMER_ADOPTION_LOG.md), TMS prioritisation order is **heuristics → MCP → full app**. This is the heuristics piece, ready for the TMS team to take ownership of.

## Test plan

- [x] `pytest backend/tests/heuristics/test_cross_plane_handlers.py` — 13 passed
- [ ] Phase 2 PR (separate): wire `HEURISTIC_HANDLERS` into `handle_a2a_request` with tier branching
- [ ] Phase 4 PR (separate): `HEURISTIC_ONLY` runtime mode for license-restricted deployments

## See also

- [AD-12 in ARCHITECTURE_DECISIONS.md](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/architecture/ARCHITECTURE_DECISIONS.md)
- [AD-12 migration plan](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/architecture/AD12_MIGRATION_PLAN.md)
- [HEURISTIC_DEFAULTS_REGISTRY.md](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/HEURISTIC_DEFAULTS_REGISTRY.md)
- `backend/app/heuristics/cross_plane/README.md` — full Phase 1 / Phase 2 boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)