### PR TITLE
feat(autonomy-tms-heuristics+autonomy-tms-mcp-adapters): AD-12 v3 plane-repo packages

### DIFF
--- a/packages/autonomy-tms-heuristics/README.md
+++ b/packages/autonomy-tms-heuristics/README.md
@@ -1,0 +1,74 @@
+# autonomy-tms-heuristics
+
+**TMS-team-owned heuristic policies, per [AD-12](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/architecture/ARCHITECTURE_DECISIONS.md).**
+
+The same heuristic content (haversine ETA, ship-as-is consolidation, tenant-default carrier) is consumed in two places:
+
+1. **HEURISTIC-tier runtime dispatch** by `azirella-router`. When a tenant's TMS plane resolves to HEURISTIC tier, the consumer (SCP backend, DP backend) calls into this package in-process. The router discovers the package via Python entry point.
+2. **Training-baseline policies** for TMS RL training. The training script imports `HEURISTIC_HANDLERS` directly and wraps in a baseline policy adapter for `RolloutHarness`.
+
+This package depends only on `azirella-data-model` (for `ConformalBand` and the geofence math) and `azirella-heuristics-common` (for the four-place warning regime + exceptions). It does NOT depend on the TMS backend app — it ships separately so SCP / DP backends can pip-install it without pulling in the full TMS app.
+
+## Public API
+
+```python
+from autonomy_tms_heuristics import (
+    HEURISTIC_HANDLERS,            # {skill_id: handler}
+    HEURISTIC_WRITE_SKILLS,        # frozenset of refused write skill IDs
+    HEURISTIC_PRODUCER_SIGNATURE,  # "autonomy-tms-heuristics:v0.1.0"
+    estimate_lane_eta,             # transport.lane.estimate_eta
+    evaluate_consolidation,        # transport.load.evaluate_consolidation
+    recommend_carrier,             # transport.carrier.recommend
+    refuse_write,                  # raises HeuristicWriteRefused
+    get_handler_bundle,            # entry-point factory for azirella-router
+)
+```
+
+## Entry-point registration
+
+`pyproject.toml`:
+
+```toml
+[project.entry-points."azirella_router.heuristics"]
+tms = "autonomy_tms_heuristics:get_handler_bundle"
+```
+
+When this package is installed in the consumer's image, `azirella-router` discovers it automatically — no explicit registration call needed.
+
+## Skills covered
+
+| Skill | Heuristic |
+|---|---|
+| `transport.lane.estimate_eta` | Haversine × parametric speed (DOT-HOS / ATRI / FHWA defaults) + dispatch buffer; returns wide ConformalBand |
+| `transport.load.evaluate_consolidation` | Always `recommend_consolidation=False` |
+| `transport.carrier.recommend` | Tenant default-carrier from config, or `"unknown"` |
+
+Write skills refused with `HeuristicWriteRefused`: `transport.load.dispatch`, `transport.shipment.tender`, `transport.dock.schedule`, `transport.equipment.reposition`.
+
+## Four-place warning regime
+
+Every read response carries:
+
+1. `producer_tier="HEURISTIC"`
+2. `producer_signature="autonomy-tms-heuristics:<skill>:v0.1.0"`
+3. `heuristic_warning` — string starting with the canonical `AZIRELLA-STUB-WARNING` audit-grep phrase (preserved from the legacy stub packages)
+4. `heuristic_plane="autonomy-tms-heuristics"`
+
+## Default values
+
+Speed model defaults from the [HEURISTIC_DEFAULTS_REGISTRY](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/HEURISTIC_DEFAULTS_REGISTRY.md):
+
+- `transit_speed_mph_p10` = 600 mi/day (DOT-HOS + ATRI best-case OTR)
+- `transit_speed_mph_p50` = 500 mi/day (median solo OTR throughput)
+- `transit_speed_mph_p90` = 350 mi/day (LTL / multi-stop / congested)
+- `road_distance_multiplier` = 1.3 (FHWA conservative midpoint)
+- `dispatch_buffer_days` = 1.0 (origin + delivery dwell)
+
+Overridable per-tenant via `plane_config`.
+
+## See also
+
+- [azirella-router](https://github.com/azirella-ltd/Autonomy-Core/tree/main/packages/azirella-router) — the consumer-side dispatcher.
+- [azirella-heuristics-common](https://github.com/azirella-ltd/Autonomy-Core/tree/main/packages/azirella-heuristics-common) — warning regime + exceptions.
+- [autonomy-tms-mcp-adapters](../autonomy-tms-mcp-adapters/) — vendor MCP adapters for THIRD_PARTY tier.
+- [AD-12 in ARCHITECTURE_DECISIONS.md](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/architecture/ARCHITECTURE_DECISIONS.md)

--- a/packages/autonomy-tms-heuristics/pyproject.toml
+++ b/packages/autonomy-tms-heuristics/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "autonomy-tms-heuristics"
+version = "0.1.0"
+description = "TMS-team-owned heuristic policies for HEURISTIC-tier responses + RL training baselines (per AD-12). Discovered by azirella-router via Python entry point."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "UNLICENSED" }
+authors = [{ name = "Azirella Ltd — TMS Team" }]
+keywords = ["autonomy", "tms", "heuristics", "ad-12"]
+
+dependencies = [
+    "azirella-data-model>=0.13.0",
+    "azirella-heuristics-common>=0.1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
+# Entry-point registration for azirella-router plugin discovery.
+[project.entry-points."azirella_router.heuristics"]
+tms = "autonomy_tms_heuristics:get_handler_bundle"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/autonomy_tms_heuristics"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"

--- a/packages/autonomy-tms-heuristics/src/autonomy_tms_heuristics/__init__.py
+++ b/packages/autonomy-tms-heuristics/src/autonomy_tms_heuristics/__init__.py
@@ -1,0 +1,68 @@
+"""autonomy-tms-heuristics — TMS-team-owned heuristic policies (AD-12).
+
+Same content (haversine ETA, ship-as-is consolidation, tenant-default
+carrier) is consumed in two places:
+
+1. **HEURISTIC-tier runtime dispatch** by ``azirella-router``, when a
+   tenant's TMS plane resolves to HEURISTIC. The router discovers this
+   package via Python entry point (``azirella_router.heuristics`` →
+   ``tms``) and calls :func:`get_handler_bundle` to fetch the dispatch
+   surface.
+
+2. **Training-baseline policies** for TMS RL training pipelines. The
+   training script imports :data:`HEURISTIC_HANDLERS` directly and
+   wraps it in a baseline policy adapter for ``RolloutHarness``.
+
+This package depends only on:
+- ``azirella-data-model`` (for ``ConformalBand``, geofence haversine math)
+- ``azirella-heuristics-common`` (for the four-place warning regime + exceptions)
+
+It does NOT depend on the TMS backend app — it ships separately so
+SCP / DP backends can pip-install it for in-process HEURISTIC dispatch
+without pulling in the TMS app.
+"""
+from .handlers import (
+    HEURISTIC_HANDLERS,
+    HEURISTIC_PRODUCER_SIGNATURE,
+    HEURISTIC_WRITE_SKILLS,
+    estimate_lane_eta,
+    evaluate_consolidation,
+    recommend_carrier,
+    refuse_write,
+)
+from .eta import BUILT_IN_DEFAULTS, ETAResult, estimate_eta
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "BUILT_IN_DEFAULTS",
+    "ETAResult",
+    "HEURISTIC_HANDLERS",
+    "HEURISTIC_PRODUCER_SIGNATURE",
+    "HEURISTIC_WRITE_SKILLS",
+    "estimate_eta",
+    "estimate_lane_eta",
+    "evaluate_consolidation",
+    "get_handler_bundle",
+    "recommend_carrier",
+    "refuse_write",
+]
+
+
+def get_handler_bundle():
+    """Entry-point factory for ``azirella-router``'s plugin discovery.
+
+    Wraps :data:`HEURISTIC_HANDLERS`, :data:`HEURISTIC_WRITE_SKILLS`, and
+    :func:`refuse_write` into a :class:`HeuristicPlaneBundle` the router
+    can consume. Lazy-imports ``azirella_router`` so this package can be
+    imported without it (e.g. by training scripts using the handlers
+    directly).
+    """
+    from azirella_router import HeuristicPlaneBundle
+    return HeuristicPlaneBundle(
+        plane="tms",
+        handlers=HEURISTIC_HANDLERS,
+        write_skills=HEURISTIC_WRITE_SKILLS,
+        refuse_write=refuse_write,
+        producer_signature=HEURISTIC_PRODUCER_SIGNATURE,
+    )

--- a/packages/autonomy-tms-heuristics/src/autonomy_tms_heuristics/eta.py
+++ b/packages/autonomy-tms-heuristics/src/autonomy_tms_heuristics/eta.py
@@ -1,0 +1,203 @@
+"""ETA math — haversine × parametric speed × dispatch buffer.
+
+Speed defaults from public US-trucking averages:
+
+- **DOT regulations** cap solo OTR drivers at 11 hours driving in a 14-hour
+  on-duty window with a 30-minute break after 8 hours driving (49 CFR §395.3).
+  Practical solo OTR throughput is ~500–600 miles/day (ATRI *Operational
+  Costs of Trucking*; FMCSA driver-day surveys).
+- **Effective truck speed** in steady cruise is ~55–60 mph; net of HOS, dock
+  dwell, fueling, traffic, and en-route inspections, effective progress drops
+  to roughly the per-day numbers above.
+- **Road-vs-great-circle distance** for typical North-American highway routes
+  runs ~1.2–1.4× great-circle (FHWA freight-flow studies). The heuristic
+  uses 1.3× as a conservative midpoint.
+- **Mode mix** spreads the band: short-haul / single-day deliveries cluster
+  near 600 mi/day; LTL with multiple stops drops to ~250–350 mi/day;
+  intermodal rail moves containers at 350–450 mi/day on long lanes.
+
+The default p10 / p50 / p90 speeds (600 / 500 / 350 mi/day) are deliberately
+wide to widen the conformal band — heuristics MUST err toward conservative
+confidence so consumers don't trust them like real data.
+
+Plus a fixed dispatch buffer to cover origin-side dwell + the scheduling lead
+time from order entry to truck-rolling. ATRI's *Operational Costs of
+Trucking* and ProductionMetrics dock-dwell surveys put detention at
+1.5–4 hours per shipment median; the heuristic uses half-day dispatch
++ half-day delivery dwell as a conservative combined buffer.
+
+Tenant overrides (per ``plane_config``):
+
+- ``transit_speed_mph_p10`` (default 600): best-case effective speed.
+- ``transit_speed_mph_p50`` (default 500): median effective speed.
+- ``transit_speed_mph_p90`` (default 350): worst-case effective speed.
+- ``road_distance_multiplier`` (default 1.3): great-circle → road km.
+- ``dispatch_buffer_days`` (default 1.0): origin + delivery dwell.
+- ``minimum_transit_days_p50`` (default 1.0): floor for p50.
+- ``default_transit_days_p50`` (default 3.0): used when neither lat/lng nor a
+  configured site-coordinate map can resolve a pair of sites.
+- ``site_coordinates`` (default ``{}``): map of ``site_id`` (string) →
+  ``{"lat": float, "lon": float}``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from azirella_data_model.conformal import ConformalBand
+from azirella_data_model.planes import ProducerTier
+from azirella_data_model.visibility.geofence_emitter import haversine_meters
+
+
+BUILT_IN_DEFAULTS: Dict[str, Any] = {
+    "transit_speed_mph_p10": 600.0,
+    "transit_speed_mph_p50": 500.0,
+    "transit_speed_mph_p90": 350.0,
+    "road_distance_multiplier": 1.3,
+    "dispatch_buffer_days": 1.0,
+    "minimum_transit_days_p50": 1.0,
+    "default_transit_days_p50": 3.0,
+    "default_transit_days_p10": 2.0,
+    "default_transit_days_p90": 5.0,
+    "site_coordinates": {},
+}
+
+
+@dataclass(frozen=True)
+class ETAResult:
+    departure_at: datetime
+    p10_at: datetime
+    p50_at: datetime
+    p90_at: datetime
+    p10_days: float
+    p50_days: float
+    p90_days: float
+    road_distance_miles: Optional[float]
+    resolution_path: str
+
+    def as_band(self, *, producer_signature: str) -> ConformalBand:
+        """Wrap as ConformalBand. ``ProducerTier.STUB`` is the legacy enum
+        value preserved for back-compat with TRMs that pattern-match on it;
+        the response payload separately carries ``producer_tier="HEURISTIC"``
+        per the four-place warning regime."""
+        return ConformalBand(
+            p10=float(self.p10_days),
+            p50=float(self.p50_days),
+            p90=float(self.p90_days),
+            coverage_target=0.95,
+            producer_signature=producer_signature,
+            producer_tier=ProducerTier.STUB,
+        )
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "departure_at": self.departure_at.isoformat(),
+            "p10_at": self.p10_at.isoformat(),
+            "p50_at": self.p50_at.isoformat(),
+            "p90_at": self.p90_at.isoformat(),
+            "p10_days": self.p10_days,
+            "p50_days": self.p50_days,
+            "p90_days": self.p90_days,
+            "road_distance_miles": self.road_distance_miles,
+            "resolution_path": self.resolution_path,
+        }
+
+
+def estimate_eta(
+    *,
+    from_site_id: str,
+    to_site_id: str,
+    departure_at: datetime,
+    plane_config: Dict[str, Any],
+    from_coords: Optional[Dict[str, float]] = None,
+    to_coords: Optional[Dict[str, float]] = None,
+) -> ETAResult:
+    cfg = {**BUILT_IN_DEFAULTS, **(plane_config or {})}
+
+    coords_from = from_coords or _coords_from_config(cfg, from_site_id)
+    coords_to = to_coords or _coords_from_config(cfg, to_site_id)
+
+    if coords_from is None or coords_to is None:
+        p10 = float(cfg["default_transit_days_p10"])
+        p50 = max(
+            float(cfg["minimum_transit_days_p50"]),
+            float(cfg["default_transit_days_p50"]),
+        )
+        p90 = float(cfg["default_transit_days_p90"])
+        return _build_result(
+            departure_at=departure_at,
+            p10_days=p10, p50_days=p50, p90_days=p90,
+            road_distance_miles=None,
+            resolution_path="flat_default",
+        )
+
+    great_circle_meters = haversine_meters(
+        coords_from["lat"], coords_from["lon"],
+        coords_to["lat"], coords_to["lon"],
+    )
+    great_circle_miles = great_circle_meters / 1609.344
+    road_miles = great_circle_miles * float(cfg["road_distance_multiplier"])
+
+    buffer_days = float(cfg["dispatch_buffer_days"])
+    min_p50 = float(cfg["minimum_transit_days_p50"])
+
+    p10_days = (road_miles / float(cfg["transit_speed_mph_p10"])) + buffer_days
+    p50_days = max(
+        min_p50,
+        (road_miles / float(cfg["transit_speed_mph_p50"])) + buffer_days,
+    )
+    p90_days = (road_miles / float(cfg["transit_speed_mph_p90"])) + buffer_days
+
+    p10_days = min(p10_days, p50_days)
+    p90_days = max(p90_days, p50_days)
+
+    resolution_path = (
+        "caller_coordinates"
+        if (from_coords is not None and to_coords is not None)
+        else "config_coordinates"
+        if (from_coords is None and to_coords is None)
+        else "mixed_coordinates"
+    )
+
+    return _build_result(
+        departure_at=departure_at,
+        p10_days=p10_days, p50_days=p50_days, p90_days=p90_days,
+        road_distance_miles=road_miles,
+        resolution_path=resolution_path,
+    )
+
+
+def _coords_from_config(cfg: Dict[str, Any], site_id: str) -> Optional[Dict[str, float]]:
+    site_map = cfg.get("site_coordinates", {}) or {}
+    if not isinstance(site_map, dict):
+        return None
+    entry = site_map.get(str(site_id))
+    if not isinstance(entry, dict):
+        return None
+    if "lat" not in entry or "lon" not in entry:
+        return None
+    return {"lat": float(entry["lat"]), "lon": float(entry["lon"])}
+
+
+def _build_result(
+    *,
+    departure_at: datetime,
+    p10_days: float, p50_days: float, p90_days: float,
+    road_distance_miles: Optional[float],
+    resolution_path: str,
+) -> ETAResult:
+    if departure_at.tzinfo is None:
+        departure_at = departure_at.replace(tzinfo=timezone.utc)
+    return ETAResult(
+        departure_at=departure_at,
+        p10_at=departure_at + timedelta(days=p10_days),
+        p50_at=departure_at + timedelta(days=p50_days),
+        p90_at=departure_at + timedelta(days=p90_days),
+        p10_days=p10_days, p50_days=p50_days, p90_days=p90_days,
+        road_distance_miles=road_distance_miles,
+        resolution_path=resolution_path,
+    )
+
+
+__all__ = ["BUILT_IN_DEFAULTS", "ETAResult", "estimate_eta"]

--- a/packages/autonomy-tms-heuristics/src/autonomy_tms_heuristics/handlers.py
+++ b/packages/autonomy-tms-heuristics/src/autonomy_tms_heuristics/handlers.py
@@ -1,0 +1,235 @@
+"""TMS heuristic handlers — direct-call API.
+
+Three read-side skills + four write-side skills (refused). Each handler
+takes ``(tenant_id, plane_config, inp)`` keyword args and returns a dict
+already stamped with the four-place warning regime.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from azirella_heuristics_common import (
+    HeuristicWriteRefused,
+    stamp_heuristic_response,
+)
+
+from .eta import BUILT_IN_DEFAULTS, estimate_eta
+
+logger = logging.getLogger(__name__)
+
+
+HEURISTIC_PRODUCER_SIGNATURE = "autonomy-tms-heuristics:v0.1.0"
+_PLANE = "tms"
+
+
+# ---------------------------------------------------------------------------
+# transport.lane.estimate_eta
+# ---------------------------------------------------------------------------
+
+
+def estimate_lane_eta(
+    *,
+    tenant_id: int,
+    plane_config: Dict[str, Any],
+    inp: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Heuristic ETA — haversine × speed × dispatch buffer."""
+    for required in ("from_site_id", "to_site_id", "departure_at"):
+        if not inp.get(required):
+            raise ValueError(f"missing required input: {required}")
+
+    departure = _parse_datetime(inp["departure_at"])
+    from_coords = _coords_from_input(inp, "from_lat", "from_lon")
+    to_coords = _coords_from_input(inp, "to_lat", "to_lon")
+
+    result = estimate_eta(
+        from_site_id=str(inp["from_site_id"]),
+        to_site_id=str(inp["to_site_id"]),
+        departure_at=departure,
+        plane_config=plane_config,
+        from_coords=from_coords,
+        to_coords=to_coords,
+    )
+
+    skill_signature = f"{HEURISTIC_PRODUCER_SIGNATURE}:lane.estimate_eta"
+    band = result.as_band(producer_signature=skill_signature)
+    payload = {
+        "from_site_id": str(inp["from_site_id"]),
+        "to_site_id": str(inp["to_site_id"]),
+        **result.as_dict(),
+        "eta_band": band.as_dict(),
+    }
+    return stamp_heuristic_response(
+        payload,
+        plane=_PLANE,
+        skill_id="transport.lane.estimate_eta",
+        producer_signature=skill_signature,
+    )
+
+
+# ---------------------------------------------------------------------------
+# transport.load.evaluate_consolidation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_consolidation(
+    *,
+    tenant_id: int,
+    plane_config: Dict[str, Any],
+    inp: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Heuristic consolidation — always recommend ship-as-is."""
+    config_id = inp.get("config_id")
+    shipment_ids = inp.get("shipment_ids") or []
+    if config_id is None:
+        raise ValueError("missing required input: config_id")
+    if not shipment_ids:
+        raise ValueError("missing required input: shipment_ids (non-empty list)")
+
+    payload = {
+        "config_id": int(config_id),
+        "shipment_ids": [str(s) for s in shipment_ids],
+        "shipment_count": len(shipment_ids),
+        "recommend_consolidation": False,
+        "score": 0.0,
+        "utilisation_estimate": None,
+        "consolidation_cost_savings_estimate": None,
+        "reasoning": (
+            "TMS heuristic tier: no consolidation analysis available. "
+            "Default decision is ship-as-is — every shipment dispatched "
+            "individually. Real consolidation analysis requires lane "
+            "economics, equipment fit, customer-mix compatibility, and "
+            "hold-back time analysis the heuristic does not have."
+        ),
+    }
+    return stamp_heuristic_response(
+        payload,
+        plane=_PLANE,
+        skill_id="transport.load.evaluate_consolidation",
+        producer_signature=(
+            f"{HEURISTIC_PRODUCER_SIGNATURE}:load.evaluate_consolidation"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# transport.carrier.recommend
+# ---------------------------------------------------------------------------
+
+
+def recommend_carrier(
+    *,
+    tenant_id: int,
+    plane_config: Dict[str, Any],
+    inp: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Heuristic carrier recommendation — tenant default or ``"unknown"``."""
+    config_id = inp.get("config_id")
+    load_id = inp.get("load_id")
+    if config_id is None or load_id is None:
+        raise ValueError("missing required input: config_id and load_id")
+    top_n = int(inp.get("top_n", 3))
+
+    default_carrier_id = plane_config.get("default_carrier_id")
+
+    if default_carrier_id:
+        recommendations = [{
+            "carrier_id": str(default_carrier_id),
+            "score": 0.5,
+            "reasoning": (
+                "Tenant default carrier from heuristic config; no real "
+                "procurement waterfall executed."
+            ),
+        }]
+    else:
+        recommendations = [{
+            "carrier_id": "unknown",
+            "score": 0.0,
+            "reasoning": (
+                "No default carrier configured for tenant; heuristic tier "
+                "cannot select a real carrier."
+            ),
+        }]
+
+    payload = {
+        "load_id": str(load_id),
+        "config_id": int(config_id),
+        "top_n": top_n,
+        "recommendations": recommendations,
+    }
+    return stamp_heuristic_response(
+        payload,
+        plane=_PLANE,
+        skill_id="transport.carrier.recommend",
+        producer_signature=(
+            f"{HEURISTIC_PRODUCER_SIGNATURE}:carrier.recommend"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Write-side refusal
+# ---------------------------------------------------------------------------
+
+
+def refuse_write(skill_id: str) -> None:
+    raise HeuristicWriteRefused(skill_id=skill_id, plane=_PLANE)
+
+
+# ---------------------------------------------------------------------------
+# Registries
+# ---------------------------------------------------------------------------
+
+
+HEURISTIC_HANDLERS: Dict[str, Any] = {
+    "transport.lane.estimate_eta": estimate_lane_eta,
+    "transport.load.evaluate_consolidation": evaluate_consolidation,
+    "transport.carrier.recommend": recommend_carrier,
+}
+
+
+HEURISTIC_WRITE_SKILLS = frozenset({
+    "transport.load.dispatch",
+    "transport.shipment.tender",
+    "transport.dock.schedule",
+    "transport.equipment.reposition",
+})
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_datetime(raw: Any) -> datetime:
+    if isinstance(raw, datetime):
+        return raw
+    if isinstance(raw, str):
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    raise ValueError(
+        f"departure_at must be ISO-8601 string or datetime; got "
+        f"{type(raw).__name__}"
+    )
+
+
+def _coords_from_input(
+    inp: Dict[str, Any], lat_key: str, lon_key: str,
+) -> Optional[Dict[str, float]]:
+    lat = inp.get(lat_key)
+    lon = inp.get(lon_key)
+    if lat is None or lon is None:
+        return None
+    return {"lat": float(lat), "lon": float(lon)}
+
+
+__all__ = [
+    "HEURISTIC_HANDLERS",
+    "HEURISTIC_PRODUCER_SIGNATURE",
+    "HEURISTIC_WRITE_SKILLS",
+    "estimate_lane_eta",
+    "evaluate_consolidation",
+    "recommend_carrier",
+    "refuse_write",
+]

--- a/packages/autonomy-tms-heuristics/tests/test_handlers.py
+++ b/packages/autonomy-tms-heuristics/tests/test_handlers.py
@@ -1,0 +1,126 @@
+"""Smoke tests for autonomy-tms-heuristics."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from azirella_heuristics_common import HeuristicWriteRefused
+from autonomy_tms_heuristics import (
+    BUILT_IN_DEFAULTS,
+    HEURISTIC_HANDLERS,
+    HEURISTIC_PRODUCER_SIGNATURE,
+    HEURISTIC_WRITE_SKILLS,
+    estimate_lane_eta,
+    evaluate_consolidation,
+    recommend_carrier,
+    refuse_write,
+    get_handler_bundle,
+)
+
+
+REQUIRED_MARKERS = {
+    "producer_tier",
+    "producer_signature",
+    "heuristic_warning",
+    "heuristic_plane",
+}
+
+
+def _assert_markers(payload: dict, expected_skill_id: str) -> None:
+    assert REQUIRED_MARKERS.issubset(payload.keys())
+    assert payload["producer_tier"] == "HEURISTIC"
+    assert payload["producer_signature"].startswith(HEURISTIC_PRODUCER_SIGNATURE)
+    assert "AZIRELLA-STUB-WARNING" in payload["heuristic_warning"]
+    assert expected_skill_id in payload["heuristic_warning"]
+    assert payload["heuristic_plane"] == "autonomy-tms-heuristics"
+
+
+def test_estimate_lane_eta_with_explicit_coords() -> None:
+    response = estimate_lane_eta(
+        tenant_id=1,
+        plane_config=BUILT_IN_DEFAULTS,
+        inp={
+            "from_site_id": "S001",
+            "to_site_id": "S002",
+            "departure_at": datetime(2026, 5, 4, 8, 0, tzinfo=timezone.utc),
+            "from_lat": 41.8781, "from_lon": -87.6298,
+            "to_lat": 32.7767, "to_lon": -96.7970,
+        },
+    )
+    _assert_markers(response, "transport.lane.estimate_eta")
+    assert response["p50_days"] >= 1.0
+    assert response["p10_days"] < response["p50_days"] < response["p90_days"]
+
+
+def test_estimate_lane_eta_missing_required_raises() -> None:
+    with pytest.raises(ValueError, match="missing required input"):
+        estimate_lane_eta(
+            tenant_id=1, plane_config=BUILT_IN_DEFAULTS,
+            inp={"from_site_id": "S001"},
+        )
+
+
+def test_estimate_lane_eta_no_coords_uses_default() -> None:
+    response = estimate_lane_eta(
+        tenant_id=1, plane_config=BUILT_IN_DEFAULTS,
+        inp={
+            "from_site_id": "S_unknown",
+            "to_site_id": "S_also_unknown",
+            "departure_at": "2026-05-04T08:00:00Z",
+        },
+    )
+    assert response["p50_days"] == BUILT_IN_DEFAULTS["default_transit_days_p50"]
+
+
+def test_evaluate_consolidation_always_ship_as_is() -> None:
+    response = evaluate_consolidation(
+        tenant_id=1, plane_config=BUILT_IN_DEFAULTS,
+        inp={"config_id": 7, "shipment_ids": ["A", "B", "C"]},
+    )
+    _assert_markers(response, "transport.load.evaluate_consolidation")
+    assert response["recommend_consolidation"] is False
+
+
+def test_recommend_carrier_uses_tenant_default() -> None:
+    response = recommend_carrier(
+        tenant_id=1,
+        plane_config={**BUILT_IN_DEFAULTS, "default_carrier_id": "carrier:fleet-A"},
+        inp={"config_id": 7, "load_id": "L-99"},
+    )
+    _assert_markers(response, "transport.carrier.recommend")
+    assert response["recommendations"][0]["carrier_id"] == "carrier:fleet-A"
+
+
+def test_recommend_carrier_no_default_returns_unknown() -> None:
+    response = recommend_carrier(
+        tenant_id=1, plane_config=BUILT_IN_DEFAULTS,
+        inp={"config_id": 7, "load_id": "L-99"},
+    )
+    assert response["recommendations"][0]["carrier_id"] == "unknown"
+
+
+@pytest.mark.parametrize("skill_id", sorted(HEURISTIC_WRITE_SKILLS))
+def test_refuse_write_raises(skill_id: str) -> None:
+    with pytest.raises(HeuristicWriteRefused) as exc_info:
+        refuse_write(skill_id)
+    assert exc_info.value.plane == "tms"
+
+
+def test_handler_registry_keys() -> None:
+    assert set(HEURISTIC_HANDLERS) == {
+        "transport.lane.estimate_eta",
+        "transport.load.evaluate_consolidation",
+        "transport.carrier.recommend",
+    }
+
+
+def test_get_handler_bundle_returns_registered_shape() -> None:
+    """The entry-point factory must return a HeuristicPlaneBundle the
+    router can consume. Skipped if azirella-router isn't installed."""
+    pytest.importorskip("azirella_router")
+    bundle = get_handler_bundle()
+    assert bundle.plane == "tms"
+    assert bundle.handlers is HEURISTIC_HANDLERS
+    assert bundle.write_skills == HEURISTIC_WRITE_SKILLS
+    assert bundle.refuse_write is refuse_write

--- a/packages/autonomy-tms-mcp-adapters/README.md
+++ b/packages/autonomy-tms-mcp-adapters/README.md
@@ -1,0 +1,64 @@
+# autonomy-tms-mcp-adapters
+
+**TMS-team-owned vendor MCP adapters** for the THIRD_PARTY tier of [AD-12](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/architecture/ARCHITECTURE_DECISIONS.md).
+
+When a tenant has TMS at `producer_tier=THIRD_PARTY` and `plane_config.mcp_adapter_vendor` set (e.g. `sap_tm`), `azirella-router` discovers the matching vendor sub-package via Python entry point and calls its handlers in-process to translate the canonical TMS skill call to the vendor's API.
+
+## Status — v0.1.0
+
+**Skeleton only.** No vendor adapters yet. The Microsoft 2026-05-11 demo runs entirely on AZIRELLA + HEURISTIC tiers; THIRD_PARTY isn't on the demo path. First vendor adapter (likely SAP TM) lands post-demo.
+
+## Adding a vendor adapter
+
+Per-vendor sub-package layout:
+
+```
+src/autonomy_tms_mcp_adapters/
+└── sap_tm/
+    ├── __init__.py        ← exposes get_adapter_bundle()
+    ├── handlers.py        ← skill_id → handler dict
+    └── translator.py      ← Azirella-canonical ↔ SAP TM API translation
+```
+
+Register the entry point in `pyproject.toml`:
+
+```toml
+[project.entry-points."azirella_router.mcp_adapters"]
+tms_sap_tm = "autonomy_tms_mcp_adapters.sap_tm:get_adapter_bundle"
+```
+
+The factory returns an `MCPAdapterBundle`:
+
+```python
+def get_adapter_bundle():
+    from azirella_router import MCPAdapterBundle
+    from .handlers import HANDLERS
+    return MCPAdapterBundle(
+        plane="tms",
+        vendor="sap_tm",
+        handlers=HANDLERS,
+        producer_signature="autonomy-tms-mcp-adapters:sap_tm:v0.1.0",
+    )
+```
+
+## Skills covered
+
+Same canonical TMS skill IDs as `autonomy-tms-heuristics`:
+
+| Skill | Notes |
+|---|---|
+| `transport.lane.estimate_eta` | Translate to vendor's lane-ETA endpoint |
+| `transport.load.evaluate_consolidation` | Translate to vendor's consolidation analysis |
+| `transport.carrier.recommend` | Translate to vendor's procurement waterfall |
+| `transport.load.dispatch` (write) | Translate to vendor's dispatch endpoint |
+| `transport.shipment.tender` (write) | Translate to vendor's tender endpoint |
+| `transport.dock.schedule` (write) | Translate to vendor's dock scheduler |
+| `transport.equipment.reposition` (write) | Translate to vendor's equipment repositioning |
+
+Vendor adapters MAY support fewer skills than this; the router raises `RouterCallFailed` if a tenant resolves to a vendor that doesn't expose the requested skill.
+
+## See also
+
+- [autonomy-tms-heuristics](../autonomy-tms-heuristics/) — HEURISTIC-tier handlers (same skill IDs, conservative defaults).
+- [azirella-router](https://github.com/azirella-ltd/Autonomy-Core/tree/main/packages/azirella-router) — the consumer-side dispatcher.
+- [AD-12](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/architecture/ARCHITECTURE_DECISIONS.md)

--- a/packages/autonomy-tms-mcp-adapters/pyproject.toml
+++ b/packages/autonomy-tms-mcp-adapters/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "autonomy-tms-mcp-adapters"
+version = "0.1.0"
+description = "TMS-team-owned MCP adapters for THIRD_PARTY tier (SAP TM, Manhattan, Oracle OTM, MercuryGate, BlueYonder TMS). Skeleton only in v0.1.0; vendor adapters ship per-customer."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "UNLICENSED" }
+authors = [{ name = "Azirella Ltd — TMS Team" }]
+keywords = ["autonomy", "tms", "mcp", "third-party-adapter", "ad-12"]
+
+dependencies = [
+    "azirella-data-model>=0.13.0",
+    "azirella-heuristics-common>=0.1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
+# Per-vendor entry points are registered in vendor sub-packages once
+# they ship. v0.1.0 has none.
+[project.entry-points."azirella_router.mcp_adapters"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/autonomy_tms_mcp_adapters"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"

--- a/packages/autonomy-tms-mcp-adapters/src/autonomy_tms_mcp_adapters/__init__.py
+++ b/packages/autonomy-tms-mcp-adapters/src/autonomy_tms_mcp_adapters/__init__.py
@@ -1,0 +1,37 @@
+"""autonomy-tms-mcp-adapters — TMS vendor MCP adapters (AD-12 THIRD_PARTY tier).
+
+Each vendor (SAP TM, Manhattan TM, Oracle OTM, MercuryGate, BlueYonder TMS)
+ships as a sub-package under ``autonomy_tms_mcp_adapters.<vendor>``. Each
+sub-package's ``__init__.py`` exposes ``get_adapter_bundle()`` which returns
+an :class:`MCPAdapterBundle` consumed by ``azirella-router``.
+
+Entry-point registration (in pyproject.toml) per vendor:
+
+.. code-block:: toml
+
+    [project.entry-points."azirella_router.mcp_adapters"]
+    tms_sap_tm = "autonomy_tms_mcp_adapters.sap_tm:get_adapter_bundle"
+
+v0.1.0 status
+-------------
+
+**Skeleton only.** No vendor adapters ship yet. This package establishes
+the home so the first adapter (likely SAP TM, post-2026-05-11 demo) lands
+in the right place. The Microsoft demo runs entirely on AZIRELLA + HEURISTIC
+tiers; THIRD_PARTY isn't on the demo path.
+
+Each vendor adapter that lands MUST:
+
+- Match the canonical TMS skill IDs (``transport.lane.estimate_eta`` etc.).
+- Use ``azirella_heuristics_common.stamp_heuristic_response`` semantics
+  but with ``producer_tier="THIRD_PARTY"`` and a vendor-specific
+  ``producer_signature`` — the helper's tier label is parameterised in
+  v0.2.0 (currently ``"HEURISTIC"`` only); until then the adapter
+  stamps responses manually.
+- Translate the Azirella-canonical input dict to the vendor's protocol
+  (REST, MCP server, SOAP) and translate the response back to the
+  canonical output shape.
+- Implement timeouts + retries appropriate for the vendor.
+"""
+
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary

TMS-team-owned heuristic + MCP-adapter packages per [AD-12 v3](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/architecture/ARCHITECTURE_DECISIONS.md). Plane teams own their plane-specific code end-to-end out of their own repo; Core azirella-router discovers these packages via Python entry points.

## Adds

- `packages/autonomy-tms-heuristics/` — TMS-side heuristic handlers (12 tests)
- `packages/autonomy-tms-mcp-adapters/` — vendor MCP adapter skeleton (no vendors yet)

## Companion PRs

- [Autonomy-Core PR #71](https://github.com/azirella-ltd/Autonomy-Core/pull/71) — router + heuristics-common substrate
- Autonomy-DP `feat/autonomy-dp-heuristics-package`
- Autonomy-SCP `feat/autonomy-scp-heuristics-package`

## Test plan

- [x] 12 tests pass against the TMS-side handlers
- [x] End-to-end verified: with this package + azirella-router installed, plugin discovery surfaces a HeuristicPlaneBundle for plane=tms; RouterClient.call_skill returns a HEURISTIC-stamped response

🤖 Generated with [Claude Code](https://claude.com/claude-code)