### PR TITLE
feat(twin/q4): ETAResult.as_band stamps ProducerTier.HEURISTIC

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 absl-py==2.3.1
 aiofiles==0.7.0
-azirella-data-model @ git+https://github.com/azirella-ltd/Autonomy-Core.git@6e0dfaa#subdirectory=packages/data-model
+azirella-data-model @ git+https://github.com/azirella-ltd/Autonomy-Core.git@37d22c7#subdirectory=packages/data-model
 azirella-integrations @ git+https://github.com/azirella-ltd/Autonomy-Core.git@0ea03b8#subdirectory=packages/integrations
 azirella-demand-planning-contract @ git+https://github.com/azirella-ltd/Autonomy-Core.git@0ea03b8#subdirectory=packages/demand-planning-contract
 azirella-transfer-order-envelope-contract @ git+https://github.com/azirella-ltd/Autonomy-Core.git@0ea03b8#subdirectory=packages/transfer-order-envelope-contract

--- a/packages/autonomy-tms-heuristics/src/autonomy_tms_heuristics/eta.py
+++ b/packages/autonomy-tms-heuristics/src/autonomy_tms_heuristics/eta.py
@@ -77,17 +77,26 @@ class ETAResult:
     resolution_path: str
 
     def as_band(self, *, producer_signature: str) -> ConformalBand:
-        """Wrap as ConformalBand. ``ProducerTier.STUB`` is the legacy enum
-        value preserved for back-compat with TRMs that pattern-match on it;
-        the response payload separately carries ``producer_tier="HEURISTIC"``
-        per the four-place warning regime."""
+        """Wrap as :class:`ConformalBand` stamped with
+        ``ProducerTier.HEURISTIC``.
+
+        Pre-§3.48 Phase 5 this stamped ``ProducerTier.STUB`` for
+        back-compat with consumer code that pattern-matched the legacy
+        enum. As of 2026-05-04 (msi-stealth queue #4) Phase 5 deleted
+        the legacy stub packages from Core, and an audit confirmed
+        zero TMS consumers pattern-match ``ProducerTier.STUB`` on a
+        :class:`ConformalBand`. ``STUB`` remains in the enum as a
+        documented alias of ``HEURISTIC`` (read-side back-compat for
+        any older persisted band rows) but every new write uses
+        ``HEURISTIC``.
+        """
         return ConformalBand(
             p10=float(self.p10_days),
             p50=float(self.p50_days),
             p90=float(self.p90_days),
             coverage_target=0.95,
             producer_signature=producer_signature,
-            producer_tier=ProducerTier.STUB,
+            producer_tier=ProducerTier.HEURISTIC,
         )
 
     def as_dict(self) -> Dict[str, Any]:

--- a/packages/autonomy-tms-heuristics/tests/test_handlers.py
+++ b/packages/autonomy-tms-heuristics/tests/test_handlers.py
@@ -51,6 +51,10 @@ def test_estimate_lane_eta_with_explicit_coords() -> None:
     _assert_markers(response, "transport.lane.estimate_eta")
     assert response["p50_days"] >= 1.0
     assert response["p10_days"] < response["p50_days"] < response["p90_days"]
+    # Queue #4 — the inner ConformalBand also stamps HEURISTIC, not STUB.
+    # The four-place warning regime carries HEURISTIC on the outer
+    # payload; the band on the wire-format ConformalBand must agree.
+    assert response["eta_band"]["producer_tier"] == "HEURISTIC"
 
 
 def test_estimate_lane_eta_missing_required_raises() -> None:


### PR DESCRIPTION
## Summary

Closes msi-stealth queue #4 from the 2026-05-04 review of PR #48.

Pre-§3.48 Phase 5, [`ETAResult.as_band`](packages/autonomy-tms-heuristics/src/autonomy_tms_heuristics/eta.py#L79) stamped `ProducerTier.STUB` on the inner `ConformalBand` for back-compat with consumer code that pattern-matched the legacy enum. As of Core [ae24626](https://github.com/azirella-ltd/Autonomy-Core/commit/ae24626) (Phase 5 stub-package delete) the legacy stubs are gone, and an audit of TMS confirms **zero consumers** pattern-match `ProducerTier.STUB` on a `ConformalBand`:

```
$ grep -RIn "ProducerTier\.STUB\|producer_tier.*==.*['\"]STUB" backend --include="*.py" | grep -v "test_\|/tests/"
(empty)
$ grep -RIn "\.producer_tier" backend --include="*.py" | grep -v "test_\|/tests/"
(empty)
```

The back-compat reasoning that originally deferred this flip has no actual basis. Flip to `HEURISTIC`.

## What changed

- **[`packages/autonomy-tms-heuristics/.../eta.py`](packages/autonomy-tms-heuristics/src/autonomy_tms_heuristics/eta.py)** — `ProducerTier.STUB` → `ProducerTier.HEURISTIC`. Docstring records the rationale + references §3.48 Phase 5.
- **[`backend/requirements.txt`](backend/requirements.txt)** — bump `azirella-data-model` pin `6e0dfaa` → `37d22c7`. Picks up Core PR #71 (`ProducerTier.HEURISTIC` enum value), PR #72 (numpy fix), §3.51 (conformal-band column substrate), §3.52 (heuristic-libraries pattern), Phase 5 stub delete, and the recent docs landings.
- **[`packages/autonomy-tms-heuristics/tests/test_handlers.py`](packages/autonomy-tms-heuristics/tests/test_handlers.py)** — extend `test_estimate_lane_eta_with_explicit_coords` to assert `response["eta_band"]["producer_tier"] == "HEURISTIC"`. The outer payload's `HEURISTIC` stamp comes from `stamp_heuristic_response` (verified by `_assert_markers`); this new assertion verifies the inner wire-format `ConformalBand` also agrees.

## Tests

12/12 pass against Core `37d22c7` (data-model pulled fresh into a clean validation venv).

## Independence

Independent of PR #49 / #50 / #51 — they all touch different code surfaces:

| PR | Surface |
|---|---|
| [#49](https://github.com/azirella-ltd/Autonomy-TMS/pull/49) | `lifecycle_reactor_factory.py` (RouterClient cutover) |
| [#50](https://github.com/azirella-ltd/Autonomy-TMS/pull/50) | SCP-fork residue delete (4,323 lines) |
| [#51](https://github.com/azirella-ltd/Autonomy-TMS/pull/51) | Canonical heuristic library (§3.52 Phase 1A) |
| **#52 (this)** | `ETAResult.as_band` STUB→HEURISTIC flip |

The only shared surface is `backend/requirements.txt`'s `azirella-data-model` pin — PR #49 bumps to `12e47c4`, this PR bumps to `37d22c7`. Whichever lands first wins; the other rebases by accepting the higher SHA. Both are descendants of `12e47c4` so behaviour is upward-compatible.

## acer-nitro lane (TMS-only)

Phase 5 stub-package delete (Core), §3.51 conformal-band ORM substrate, §3.52 heuristic-libraries doc — all msi-stealth's lane and already landed. This PR is the small TMS-side follow-up that closes the loose end identified during PR #48 validation.

## Test plan

- [x] Audit: zero consumers pattern-match `ProducerTier.STUB` in TMS backend
- [x] Flip the enum value + update docstring
- [x] Bump `azirella-data-model` pin to a SHA carrying `ProducerTier.HEURISTIC`
- [x] Add inner-band assertion to existing happy-path test
- [x] 12/12 tests pass in clean venv against Core `37d22c7`
- [ ] CI green (no checks configured on this repo today)
- [ ] Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)