### PR TITLE
ui: rename user-visible "P50" → "Median" in conformal-prediction surfaces

### DIFF
--- a/frontend/src/components/scenario/ATPHistoryChart.jsx
+++ b/frontend/src/components/scenario/ATPHistoryChart.jsx
@@ -94,7 +94,7 @@ const ATPHistoryChart = ({
               <span className="font-semibold">{data.atp_p90} units</span>
             </div>
             <div className="flex justify-between gap-4">
-              <span className="text-primary">P50 (Median):</span>
+              <span className="text-primary">Median:</span>
               <span className="font-semibold">{data.atp_p50} units</span>
             </div>
             <div className="flex justify-between gap-4">
@@ -137,7 +137,7 @@ const ATPHistoryChart = ({
               <span className="font-semibold">{data.ctp_p90} units</span>
             </div>
             <div className="flex justify-between gap-4">
-              <span className="text-primary">P50 (Median):</span>
+              <span className="text-primary">Median:</span>
               <span className="font-semibold">{data.ctp_p50} units</span>
             </div>
             <div className="flex justify-between gap-4">
@@ -334,7 +334,7 @@ const ATPHistoryChart = ({
                     stroke="hsl(var(--primary))"
                     strokeWidth={3}
                     dot={{ fill: 'hsl(var(--primary))', r: 4 }}
-                    name="P50 Median"
+                    name="Median"
                   />
 
                   {/* Zero line */}
@@ -390,7 +390,7 @@ const ATPHistoryChart = ({
                     stroke="hsl(var(--primary))"
                     strokeWidth={3}
                     dot={{ fill: 'hsl(var(--primary))', r: 4 }}
-                    name="P50 Median"
+                    name="Median"
                   />
 
                   {/* Capacity line */}
@@ -503,7 +503,7 @@ const ATPHistoryChart = ({
             <p className="text-xs text-muted-foreground">
               <strong className="text-emerald-600">P90</strong>: 90% probability ATP/CTP will be at or below this value
               <br />
-              <strong className="text-primary">P50</strong>: Median expected value (most likely outcome)
+              <strong className="text-primary">Median</strong>: Most likely outcome (50th percentile of the predictive distribution)
               <br />
               <strong className="text-amber-600">P10</strong>: 10% probability ATP/CTP will be at or below this value
             </p>

--- a/frontend/src/components/scenario/ProbabilisticATPChart.jsx
+++ b/frontend/src/components/scenario/ProbabilisticATPChart.jsx
@@ -96,7 +96,7 @@ const ProbabilisticATPChart = ({
               <span className="font-semibold text-emerald-600">{data?.atp_p90} units</span>
             </div>
             <div className="flex justify-between gap-4">
-              <span className="text-muted-foreground">P50 (Median):</span>
+              <span className="text-muted-foreground">Median:</span>
               <span className="font-semibold text-primary">{data?.atp_p50} units</span>
             </div>
             <div className="flex justify-between gap-4">
@@ -320,7 +320,7 @@ const ProbabilisticATPChart = ({
                   stroke="hsl(var(--primary))"
                   strokeWidth={2}
                   fill="rgba(59, 130, 246, 0.3)"
-                  name="P50 (Median)"
+                  name="Median"
                 />
                 <Area
                   type="monotone"
@@ -372,7 +372,7 @@ const ProbabilisticATPChart = ({
             <p className="text-xs text-muted-foreground">
               <strong className="text-emerald-600">P90</strong>: 90% probability ATP will be at or below this value (optimistic scenario)
               <br />
-              <strong className="text-primary">P50</strong>: Median expected ATP (most likely outcome)
+              <strong className="text-primary">Median</strong>: Most likely ATP (50th percentile of the predictive distribution)
               <br />
               <strong className="text-amber-600">P10</strong>: 10% probability ATP will be at or below this value (pessimistic scenario)
             </p>

--- a/frontend/src/components/scenario/ProbabilisticPipelineChart.jsx
+++ b/frontend/src/components/scenario/ProbabilisticPipelineChart.jsx
@@ -112,7 +112,7 @@ const ProbabilisticPipelineChart = ({
               <span className="font-semibold text-amber-600">Round {data.arrival_p10_round}</span>
             </div>
             <div className="flex justify-between gap-4">
-              <span className="text-muted-foreground">P50 Arrival:</span>
+              <span className="text-muted-foreground">Median Arrival:</span>
               <span className="font-semibold text-primary">Round {data.arrival_p50_round}</span>
             </div>
             <div className="flex justify-between gap-4">
@@ -235,7 +235,7 @@ const ProbabilisticPipelineChart = ({
             </Card>
             <Card className="bg-primary/10">
               <CardContent className="pt-3 pb-2 text-center">
-                <p className="text-xs text-primary">P50</p>
+                <p className="text-xs text-primary">Median</p>
                 <p className="text-lg font-bold text-primary">
                   {lead_time_stats?.p50 || 'N/A'}
                 </p>
@@ -353,7 +353,7 @@ const ProbabilisticPipelineChart = ({
                     />
                     <Bar
                       dataKey="p50"
-                      name="P50 (Median)"
+                      name="Median"
                       fill="#3b82f6"
                     />
                     <Bar
@@ -383,7 +383,7 @@ const ProbabilisticPipelineChart = ({
             <p className="text-xs text-muted-foreground">
               <strong className="text-amber-600">P10</strong>: 10% probability arrival will be at or before this round (earliest)
               <br />
-              <strong className="text-primary">P50</strong>: Median expected arrival round
+              <strong className="text-primary">Median</strong>: Most likely arrival round (50th percentile)
               <br />
               <strong className="text-emerald-600">P90</strong>: 90% probability arrival will be at or before this round (latest)
             </p>

--- a/frontend/src/components/supply-chain-config/DecisionProposalManager.jsx
+++ b/frontend/src/components/supply-chain-config/DecisionProposalManager.jsx
@@ -561,7 +561,7 @@ const DecisionProposalManager = ({ configId, scenarioName, onProposalChange }) =
                           <TableRow>
                             <TableHead>Metric</TableHead>
                             <TableHead className="text-right">P10</TableHead>
-                            <TableHead className="text-right">P50</TableHead>
+                            <TableHead className="text-right">Median</TableHead>
                             <TableHead className="text-right">P90</TableHead>
                           </TableRow>
                         </TableHeader>
@@ -599,7 +599,7 @@ const DecisionProposalManager = ({ configId, scenarioName, onProposalChange }) =
                           <TableRow>
                             <TableHead>Metric</TableHead>
                             <TableHead className="text-right">P10</TableHead>
-                            <TableHead className="text-right">P50</TableHead>
+                            <TableHead className="text-right">Median</TableHead>
                             <TableHead className="text-right">P90</TableHead>
                           </TableRow>
                         </TableHeader>

--- a/frontend/src/pages/planning/DemandPlanEdit.jsx
+++ b/frontend/src/pages/planning/DemandPlanEdit.jsx
@@ -922,7 +922,7 @@ const DemandPlanEdit = () => {
       URL.revokeObjectURL(url);
     } catch {
       // Fallback: export current page data as CSV
-      const rows = [['Product', 'Site', 'Date', 'P10', 'P50', 'P90', 'Granularity']];
+      const rows = [['Product', 'Site', 'Date', 'P10', 'Median', 'P90', 'Granularity']];
       rows.push(['Note: Connect to API for full export']);
       const blob = new Blob([rows.map((r) => r.join(',')).join('\n')], { type: 'text/csv' });
       const url = URL.createObjectURL(blob);

--- a/frontend/src/pages/planning/DemandPlanView.jsx
+++ b/frontend/src/pages/planning/DemandPlanView.jsx
@@ -587,10 +587,10 @@ const DemandPlanView = () => {
                   fill="#ffffff" fillOpacity={1} name="P10 (Low)"
                   dot={false} activeDot={false}
                 />
-                {/* P50 forecast line */}
+                {/* Median forecast line */}
                 <Line
                   type="monotone" dataKey="p50" stroke="#6366f1"
-                  strokeWidth={2.5} name="Forecast (P50)" dot={false}
+                  strokeWidth={2.5} name="Forecast (Median)" dot={false}
                 />
                 {/* P10/P90 boundary lines */}
                 <Line
@@ -778,7 +778,7 @@ const DemandPlanView = () => {
                 <TableHead>Site ID</TableHead>
                 <TableHead>Forecast Date</TableHead>
                 <TableHead className="text-right">P10 (Low)</TableHead>
-                <TableHead className="text-right">P50 (Most Likely)</TableHead>
+                <TableHead className="text-right">Median (Most Likely)</TableHead>
                 <TableHead className="text-right">Forecast Median</TableHead>
                 <TableHead className="text-right">P90 (High)</TableHead>
                 <TableHead className="text-center">Confidence</TableHead>
@@ -962,8 +962,8 @@ const DemandPlanView = () => {
                   <TableHead>Product</TableHead>
                   <TableHead>Site</TableHead>
                   <TableHead>Date</TableHead>
-                  <TableHead className="text-right">Previous (P50)</TableHead>
-                  <TableHead className="text-right">Current (P50)</TableHead>
+                  <TableHead className="text-right">Previous (Median)</TableHead>
+                  <TableHead className="text-right">Current (Median)</TableHead>
                   <TableHead className="text-right">Previous (Median)</TableHead>
                   <TableHead className="text-right">Current (Median)</TableHead>
                   <TableHead className="text-right">Delta</TableHead>
@@ -1057,7 +1057,7 @@ const DemandPlanView = () => {
                   />
                 </div>
                 <div>
-                  <Label>P50 (Most Likely)</Label>
+                  <Label>Median (Most Likely)</Label>
                   <Input
                     type="number"
                     value={editValues.p50}

--- a/frontend/src/pages/planning/ScenarioComparison.jsx
+++ b/frontend/src/pages/planning/ScenarioComparison.jsx
@@ -133,7 +133,7 @@ export default function ScenarioComparison() {
                 <YAxis tick={{ fontSize: 10 }} />
                 <Tooltip contentStyle={{ fontSize: 11 }} />
                 <Legend wrapperStyle={{ fontSize: 10 }} />
-                <Bar dataKey="p50" fill="#6366f1" fillOpacity={0.3} name="Plan of Record (P50)" />
+                <Bar dataKey="p50" fill="#6366f1" fillOpacity={0.3} name="Plan of Record (Median)" />
                 {series[0]?.actual != null && (
                   <Line type="monotone" dataKey="actual" stroke="#ef4444" strokeWidth={2} name="Actual Demand" dot={{ r: 2 }} />
                 )}

--- a/frontend/src/pages/planning/SupplyPlanGeneration.jsx
+++ b/frontend/src/pages/planning/SupplyPlanGeneration.jsx
@@ -224,7 +224,7 @@ export default function SupplyPlanGeneration() {
                     <Legend wrapperStyle={{ fontSize: 10 }} />
                     <Area type="monotone" dataKey="p90" stroke="none" fill="#8884d8" fillOpacity={0.12} name="P90 (High)" />
                     <Area type="monotone" dataKey="p10" stroke="none" fill="#ffffff" fillOpacity={1} name="P10 (Low)" />
-                    <Line type="monotone" dataKey="p50" stroke="#6366f1" strokeWidth={2.5} name="Plan of Record (P50)" dot={false} />
+                    <Line type="monotone" dataKey="p50" stroke="#6366f1" strokeWidth={2.5} name="Plan of Record (Median)" dot={false} />
                     <Line type="monotone" dataKey="p10" stroke="#86efac" strokeWidth={1} strokeDasharray="4 3" name="P10" dot={false} />
                     <Line type="monotone" dataKey="p90" stroke="#fbbf24" strokeWidth={1} strokeDasharray="4 3" name="P90" dot={false} />
                     {series[0]?.actual != null && (
@@ -246,7 +246,7 @@ export default function SupplyPlanGeneration() {
                       <TableRow>
                         <TableHead className="sticky left-0 bg-white">Period</TableHead>
                         <TableHead className="text-right">P10</TableHead>
-                        <TableHead className="text-right font-bold">P50 (Plan)</TableHead>
+                        <TableHead className="text-right font-bold">Median (Plan)</TableHead>
                         <TableHead className="text-right">P90</TableHead>
                         <TableHead className="text-right">Actual</TableHead>
                         <TableHead className="text-right">Products</TableHead>


### PR DESCRIPTION
P50 is ambiguous between median and mean. Our producers all emit the median; the label was a false percentile signal. 10 surfaces renamed across 8 files. System-observability P50/P95/P99 stacks left as-is (different domain).