### PR TITLE
feat(trm): native TMS reward weights for 4 transport-KPI TRMs

### DIFF
--- a/backend/app/services/powell/tms_reward_weights.py
+++ b/backend/app/services/powell/tms_reward_weights.py
@@ -1,0 +1,385 @@
+"""Native TMS TRM reward weights — transport-KPI signals.
+
+Closes Open Item #1 from
+[TMS_TRM_TRAINING_DATA_SPECIFICATION.md §8](../../../../docs/TMS_TRM_TRAINING_DATA_SPECIFICATION.md):
+replaces the SCP-proxy reward weights (ATP_EXECUTOR / REBALANCING /
+PO_CREATION / TO_EXECUTION) previously used by four TMS TRMs with
+native transport KPIs — dwell, detention, throughput, intermodal
+savings, fleet utilisation, fill rate, consolidation economics.
+
+The other seven TMS TRMs continue to use the generic action-based
+reward in ``backend/scripts/pretraining/generate_tms_corpus.compute_reward``;
+spec §6 considers those SCP-proxy mappings appropriate.
+
+Consumers:
+
+- ``backend/scripts/pretraining/generate_tms_corpus.py`` — BC corpus
+  reward column. Used downstream for weighted resampling and backtest
+  scoring; not the BC training signal itself (that is the action
+  label).
+- Future RL fine-tune loop — these weights become the live training
+  signal once PPO over the lane-flow twin lands. The signal shape is
+  kept compatible with the action-based fallback (range roughly
+  ``[0, 1.5]``).
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping, Optional
+
+from autonomy_tms_heuristics.library import (
+    DockSchedulingState,
+    EquipmentRepositionState,
+    IntermodalTransferState,
+    LoadBuildState,
+    TMSHeuristicDecision,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Action constants — mirror ``autonomy_tms_heuristics.library.Actions``
+# inline to avoid the heuristic-library import cycle when this module
+# is loaded at corpus-generation time.
+# ─────────────────────────────────────────────────────────────────────
+
+_ACCEPT = 0
+_REJECT = 1
+_DEFER = 2
+_ESCALATE = 3
+_MODIFY = 4
+_CONSOLIDATE = 7
+_SPLIT = 8
+_REPOSITION = 9
+_HOLD = 10
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Reward-weight tables. Sum of components is 1.0 per TRM; reward output
+# lies roughly in ``[0, 1.5]`` to align with the generic action-based
+# reward range in ``compute_reward``.
+# ─────────────────────────────────────────────────────────────────────
+
+TMS_TRM_REWARD_WEIGHTS: Mapping[str, Mapping[str, float]] = {
+    "dock_scheduling": {
+        # Throughput alignment — does the action fit the current
+        # dock-door utilisation envelope (50-85 % is the sweet spot).
+        "throughput_alignment": 0.35,
+        # Detention avoidance — does the action keep carrier dwell
+        # under the free-time window (FMCSA detention study, 2018).
+        "detention_avoidance": 0.35,
+        # Dwell efficiency — live-load vs drop-trailer call matches
+        # facility congestion.
+        "dwell_efficiency": 0.20,
+        # Priority alignment — P1 / P2 shipments served first.
+        "priority_alignment": 0.10,
+    },
+    "intermodal_transfer": {
+        # Mode-shift savings — captured economic gap (% off the
+        # truck-only rate). AAR intermodal economic studies.
+        "mode_shift_savings": 0.40,
+        # On-time intermodal — does the proposed mode fit the
+        # delivery window (BNSF / CSX service-level floors).
+        "on_time_intermodal": 0.25,
+        # Delivery-window slack — remaining margin after intermodal
+        # transit; bigger is safer.
+        "delivery_window_slack": 0.20,
+        # Reliability bonus — scales by intermodal_reliability_pct.
+        "reliability_bonus": 0.15,
+    },
+    "equipment_reposition": {
+        # ROI — avoided spot premium / reposition cost (capped at 3×).
+        "reposition_roi": 0.40,
+        # Fleet utilisation gain — high when repositioning a
+        # high-utilisation network with a clear deficit.
+        "fleet_utilization_gain": 0.30,
+        # Network balance — credit grows with deficit-location count.
+        "network_balance_improvement": 0.20,
+        # Empty-mile transit cost — penalty grows with reposition miles.
+        "transit_cost_penalty": 0.10,
+    },
+    "load_build": {
+        # Fill rate — binding constraint (max of weight & volume
+        # utilisation). Operations research consolidation literature.
+        "fill_rate": 0.40,
+        # Consolidation savings — LTL → FTL economic capture.
+        "consolidation_savings": 0.30,
+        # Stops efficiency — multi-stop coordination penalty.
+        "stops_efficiency": 0.15,
+        # Priority alignment — refuse consolidation on hazmat /
+        # temperature conflict; honour priority shipments otherwise.
+        "priority_alignment": 0.15,
+    },
+}
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Per-TRM native reward functions.
+# ─────────────────────────────────────────────────────────────────────
+
+
+def dock_scheduling_reward(
+    state: DockSchedulingState,
+    decision: TMSHeuristicDecision,
+) -> float:
+    """Native dock-scheduling reward.
+
+    Signals: throughput (utilisation at decision time), detention
+    avoidance (carrier dwell vs free time), live-load vs drop-trailer
+    fit, priority alignment.
+    """
+    w = TMS_TRM_REWARD_WEIGHTS["dock_scheduling"]
+    util = state.utilization_pct()
+    risk = state.detention_risk_score()
+    action = decision.action
+
+    # Throughput alignment.
+    if action == _ACCEPT:
+        throughput = 1.0 if util < 0.85 else max(0.0, 1.0 - (util - 0.85) * 2)
+    elif action == _DEFER:
+        throughput = 0.8 if util > 0.85 else 0.3
+    elif action == _MODIFY:
+        throughput = 0.7
+    else:
+        throughput = 0.5
+
+    # Detention avoidance.
+    if action == _ACCEPT and risk < 0.3:
+        detention = 1.0
+    elif action == _MODIFY and risk > 0.5:
+        detention = 1.0
+    elif action == _ACCEPT and risk > 0.7:
+        detention = 0.0
+    else:
+        detention = max(0.0, 1.0 - risk)
+
+    # Live-load vs drop-trailer fit.
+    if action == _MODIFY and state.is_live_load and util > 0.85:
+        dwell = 1.0
+    elif state.is_live_load and util > 0.85 and action == _ACCEPT:
+        dwell = 0.4
+    else:
+        dwell = 0.7
+
+    # Priority alignment.
+    if state.shipment_priority <= 2 and action == _ACCEPT:
+        priority = 1.0
+    elif state.shipment_priority <= 2 and action == _DEFER:
+        priority = 0.0
+    else:
+        priority = 0.8
+
+    return (
+        w["throughput_alignment"] * throughput
+        + w["detention_avoidance"] * detention
+        + w["dwell_efficiency"] * dwell
+        + w["priority_alignment"] * priority
+    )
+
+
+def intermodal_transfer_reward(
+    state: IntermodalTransferState,
+    decision: TMSHeuristicDecision,
+) -> float:
+    """Native intermodal-transfer reward.
+
+    Signals: cost-savings vs truck baseline, on-time feasibility,
+    delivery-window slack, intermodal reliability.
+    """
+    w = TMS_TRM_REWARD_WEIGHTS["intermodal_transfer"]
+    savings_pct = state.cost_savings_pct()
+    has_time = state.has_time_for_intermodal()
+    action = decision.action
+
+    # Mode-shift savings — full credit at 20 %+ savings; penalty for
+    # rejecting a clearly profitable shift.
+    if action == _ACCEPT:
+        mode_shift = max(0.0, min(1.0, savings_pct / 0.20))
+    else:  # REJECT
+        if savings_pct > 0.15 and has_time:
+            mode_shift = 0.0
+        else:
+            mode_shift = 0.8
+
+    # On-time feasibility.
+    if action == _ACCEPT and has_time:
+        ontime = 1.0
+    elif action == _ACCEPT and not has_time:
+        ontime = 0.0
+    elif action == _REJECT and not has_time:
+        ontime = 1.0
+    else:
+        ontime = 0.7
+
+    # Delivery-window slack.
+    slack_days = state.delivery_window_days - state.transit_time_penalty_days()
+    if action == _ACCEPT and slack_days > 1:
+        window = 1.0
+    elif action == _ACCEPT and slack_days < 0:
+        window = 0.0
+    else:
+        window = max(0.0, min(1.0, slack_days / 3.0))
+
+    # Reliability.
+    if action == _ACCEPT:
+        reliability = state.intermodal_reliability_pct
+    else:
+        reliability = 0.7
+
+    return (
+        w["mode_shift_savings"] * mode_shift
+        + w["on_time_intermodal"] * ontime
+        + w["delivery_window_slack"] * window
+        + w["reliability_bonus"] * reliability
+    )
+
+
+def equipment_reposition_reward(
+    state: EquipmentRepositionState,
+    decision: TMSHeuristicDecision,
+) -> float:
+    """Native equipment-reposition reward.
+
+    Signals: avoided-spot-premium ROI, fleet utilisation lift, network
+    deficit-balance improvement, empty-mile transit cost.
+    """
+    w = TMS_TRM_REWARD_WEIGHTS["equipment_reposition"]
+    raw_roi = state.reposition_roi()
+    if raw_roi == float("inf"):
+        roi_capped = 1.0
+    else:
+        roi_capped = min(raw_roi, 3.0) / 3.0
+    action = decision.action
+
+    # ROI signal.
+    if action == _REPOSITION:
+        roi_signal = roi_capped if raw_roi >= 1.0 else 0.0
+    else:  # HOLD
+        roi_signal = 1.0 if raw_roi < 1.0 else max(0.0, 1.0 - roi_capped)
+
+    # Fleet utilisation gain.
+    util = state.fleet_utilization_pct
+    if action == _REPOSITION and util > 0.85 and state.target_deficit() > 0:
+        util_gain = 1.0
+    elif action == _HOLD and util < 0.60:
+        util_gain = 1.0
+    else:
+        util_gain = 0.5
+
+    # Network balance.
+    if action == _REPOSITION:
+        balance = 1.0 if state.network_deficit_locations > 0 else 0.3
+    else:
+        balance = 0.8 if state.network_deficit_locations == 0 else 0.3
+
+    # Transit cost penalty (full credit at 0 miles, zero at 1000+ miles).
+    if action == _REPOSITION:
+        cost_pen = max(0.0, 1.0 - state.reposition_miles / 1000.0)
+    else:
+        cost_pen = 1.0
+
+    return (
+        w["reposition_roi"] * roi_signal
+        + w["fleet_utilization_gain"] * util_gain
+        + w["network_balance_improvement"] * balance
+        + w["transit_cost_penalty"] * cost_pen
+    )
+
+
+def load_build_reward(
+    state: LoadBuildState,
+    decision: TMSHeuristicDecision,
+) -> float:
+    """Native load-build reward.
+
+    Signals: fill rate (binding of weight / volume), consolidation
+    savings, multi-stop efficiency, priority alignment.
+
+    Hazmat / temperature conflicts are a **hard gate**: REJECT earns
+    full credit, all other actions earn near-zero. Once consolidated
+    you can't unconsolidate, and shipping incompatible loads has
+    regulatory (FMCSA hazmat, FDA temp) cost that swamps any
+    economic gain from the other signals.
+    """
+    w = TMS_TRM_REWARD_WEIGHTS["load_build"]
+    fill = max(state.weight_utilization(), state.volume_utilization())
+    action = decision.action
+    has_conflict = state.has_hazmat_conflict or state.has_temp_conflict
+
+    # Hard gate on hazmat / temperature conflict.
+    if has_conflict:
+        return 1.0 if action == _REJECT else 0.1
+
+    # Fill-rate signal — ACCEPT above 95% is a capacity violation.
+    if action == _CONSOLIDATE:
+        fill_sig = 1.0 if 0.5 <= fill <= 0.95 else 0.5
+    elif action == _ACCEPT:
+        fill_sig = 0.2 if fill > 0.95 else fill
+    elif action == _SPLIT:
+        fill_sig = 1.0 if fill > 0.95 else 0.3
+    elif action == _DEFER:
+        fill_sig = 0.8 if fill < 0.50 else 0.3
+    else:  # REJECT without conflict — usually the wrong call.
+        fill_sig = 0.3
+
+    # Consolidation savings.
+    if state.ftl_rate > 0:
+        savings_ratio = state.consolidation_savings / state.ftl_rate
+    else:
+        savings_ratio = 0.0
+    if action == _CONSOLIDATE:
+        cons = min(1.0, max(0.0, savings_ratio * 2.0))
+    else:
+        cons = 0.5
+
+    # Stops efficiency.
+    if (
+        action in (_ACCEPT, _CONSOLIDATE, _SPLIT)
+        and state.stop_count <= state.max_stops
+    ):
+        stops_sig = 1.0
+    elif action == _CONSOLIDATE and state.stop_count > state.max_stops:
+        stops_sig = 0.0
+    else:
+        stops_sig = 0.7
+
+    # Priority alignment (no conflict path).
+    priority = 0.8
+
+    return (
+        w["fill_rate"] * fill_sig
+        + w["consolidation_savings"] * cons
+        + w["stops_efficiency"] * stops_sig
+        + w["priority_alignment"] * priority
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Dispatch — corpus generator and future RL trainer entry point.
+# ─────────────────────────────────────────────────────────────────────
+
+_REWARD_FNS: Mapping[str, Callable[[Any, TMSHeuristicDecision], float]] = {
+    "dock_scheduling": dock_scheduling_reward,
+    "intermodal_transfer": intermodal_transfer_reward,
+    "equipment_reposition": equipment_reposition_reward,
+    "load_build": load_build_reward,
+}
+
+
+def has_native_reward(trm_name: str) -> bool:
+    """Whether ``trm_name`` has a native TMS reward function."""
+    return trm_name in _REWARD_FNS
+
+
+def compute_native_tms_reward(
+    trm_name: str,
+    state: Any,
+    decision: TMSHeuristicDecision,
+) -> Optional[float]:
+    """Compute the native TMS reward for ``trm_name`` if defined.
+
+    Returns ``None`` when ``trm_name`` is not one of the four TMS-native
+    TRMs; callers fall back to the generic action-based reward.
+    """
+    fn = _REWARD_FNS.get(trm_name)
+    if fn is None:
+        return None
+    return fn(state, decision)

--- a/backend/scripts/pretraining/generate_tms_corpus.py
+++ b/backend/scripts/pretraining/generate_tms_corpus.py
@@ -67,6 +67,7 @@ from autonomy_tms_heuristics.library.base import (
     EquipmentRepositionState,
     LaneVolumeForecastState,
 )
+from app.services.powell.tms_reward_weights import compute_native_tms_reward
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger("generate_tms_corpus")
@@ -687,7 +688,12 @@ def generate_corpus(
         row["urgency"] = decision.urgency
         row["confidence"] = decision.confidence
         row["reasoning"] = decision.reasoning
-        row["reward"] = compute_reward(decision.action, decision.urgency, decision.quantity)
+        native = compute_native_tms_reward(trm_type, state, decision)
+        row["reward"] = (
+            native
+            if native is not None
+            else compute_reward(decision.action, decision.urgency, decision.quantity)
+        )
         rows.append(row)
 
         if (i + 1) % 10000 == 0:

--- a/backend/tests/services/powell/test_tms_reward_weights.py
+++ b/backend/tests/services/powell/test_tms_reward_weights.py
@@ -1,0 +1,312 @@
+"""Tests for native TMS TRM reward weights (Open Item #1 of
+TMS_TRM_TRAINING_DATA_SPECIFICATION.md).
+
+The module under test sits inside ``app.services.powell.*`` whose
+package ``__init__.py`` transitively imports ``torch``. To keep these
+tests runnable in a torch-less sandbox, we load the target module
+directly via ``importlib.util`` with stubbed parent packages.
+"""
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from autonomy_tms_heuristics.library import (
+    DockSchedulingState,
+    EquipmentRepositionState,
+    IntermodalTransferState,
+    LoadBuildState,
+    TMSHeuristicDecision,
+)
+
+
+# Stub the parent packages so the target module's ``app.services.powell.*``
+# fully-qualified name resolves without triggering the real heavy
+# ``__init__.py`` chain (which pulls in torch via metrics_hierarchy).
+for _name in ("app", "app.services", "app.services.powell"):
+    sys.modules.setdefault(_name, ModuleType(_name))
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "app" / "services" / "powell" / "tms_reward_weights.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "app.services.powell.tms_reward_weights", _MODULE_PATH,
+)
+_module = importlib.util.module_from_spec(_spec)
+sys.modules["app.services.powell.tms_reward_weights"] = _module
+_spec.loader.exec_module(_module)
+
+TMS_TRM_REWARD_WEIGHTS = _module.TMS_TRM_REWARD_WEIGHTS
+compute_native_tms_reward = _module.compute_native_tms_reward
+dock_scheduling_reward = _module.dock_scheduling_reward
+equipment_reposition_reward = _module.equipment_reposition_reward
+has_native_reward = _module.has_native_reward
+intermodal_transfer_reward = _module.intermodal_transfer_reward
+load_build_reward = _module.load_build_reward
+
+
+def _decision(action: int, urgency: float = 0.5, quantity: float = 0.0) -> TMSHeuristicDecision:
+    return TMSHeuristicDecision(
+        trm_type="test",
+        action=action,
+        quantity=quantity,
+        reasoning="test",
+        confidence=1.0,
+        urgency=urgency,
+        params_used={},
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Weight-table invariants
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("trm_name", sorted(TMS_TRM_REWARD_WEIGHTS))
+def test_weights_sum_to_one(trm_name: str) -> None:
+    total = sum(TMS_TRM_REWARD_WEIGHTS[trm_name].values())
+    assert math.isclose(total, 1.0, abs_tol=1e-6), f"{trm_name} weights sum to {total}"
+
+
+def test_native_reward_keys_match_dispatch_table() -> None:
+    for trm in TMS_TRM_REWARD_WEIGHTS:
+        assert has_native_reward(trm)
+
+
+def test_has_native_reward_false_for_unknown_trm() -> None:
+    assert not has_native_reward("capacity_promise")
+    assert not has_native_reward("nonexistent")
+
+
+def test_compute_native_returns_none_for_non_native_trm() -> None:
+    assert compute_native_tms_reward(
+        "capacity_promise",
+        state=None,
+        decision=_decision(0),
+    ) is None
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Dock scheduling — directional tests
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_dock_scheduling_accept_low_util_low_risk_is_high_reward() -> None:
+    state = DockSchedulingState(
+        total_dock_doors=10, available_dock_doors=8,  # 20% util
+        carrier_avg_dwell_minutes=60, free_time_minutes=120,  # no detention risk
+        shipment_priority=3, is_live_load=False,
+    )
+    r = dock_scheduling_reward(state, _decision(action=0))  # ACCEPT
+    assert r > 0.85
+
+
+def test_dock_scheduling_accept_high_detention_risk_penalised() -> None:
+    state = DockSchedulingState(
+        total_dock_doors=10, available_dock_doors=8,
+        carrier_avg_dwell_minutes=300, free_time_minutes=120,  # high risk
+        shipment_priority=3,
+    )
+    r_accept = dock_scheduling_reward(state, _decision(action=0))  # ACCEPT
+    r_modify = dock_scheduling_reward(state, _decision(action=4))  # MODIFY
+    assert r_modify > r_accept
+
+
+def test_dock_scheduling_defer_for_low_priority_at_high_util() -> None:
+    state = DockSchedulingState(
+        total_dock_doors=10, available_dock_doors=1,  # 90% util
+        carrier_avg_dwell_minutes=60, free_time_minutes=120,
+        shipment_priority=5,
+    )
+    r_defer = dock_scheduling_reward(state, _decision(action=2))  # DEFER
+    r_accept = dock_scheduling_reward(state, _decision(action=0))
+    assert r_defer > r_accept
+
+
+def test_dock_scheduling_p1_defer_is_penalised() -> None:
+    state = DockSchedulingState(
+        total_dock_doors=10, available_dock_doors=2,
+        carrier_avg_dwell_minutes=60, free_time_minutes=120,
+        shipment_priority=1,  # CRITICAL
+    )
+    r_defer = dock_scheduling_reward(state, _decision(action=2))
+    r_accept = dock_scheduling_reward(state, _decision(action=0))
+    assert r_accept > r_defer
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Intermodal transfer — directional tests
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_intermodal_accept_with_strong_savings_and_slack() -> None:
+    state = IntermodalTransferState(
+        truck_rate=1000.0, intermodal_rate=750.0,  # 25% savings
+        truck_transit_days=3.0, intermodal_transit_days=5.0,
+        delivery_window_days=4.0,  # plenty of slack
+        intermodal_reliability_pct=0.92,
+    )
+    r = intermodal_transfer_reward(state, _decision(action=0))  # ACCEPT
+    assert r > 0.85
+
+
+def test_intermodal_reject_when_no_time() -> None:
+    state = IntermodalTransferState(
+        truck_rate=1000.0, intermodal_rate=750.0,
+        truck_transit_days=3.0, intermodal_transit_days=6.0,
+        delivery_window_days=1.0,  # blown
+        intermodal_reliability_pct=0.85,
+    )
+    r_accept = intermodal_transfer_reward(state, _decision(action=0))
+    r_reject = intermodal_transfer_reward(state, _decision(action=1))
+    assert r_reject > r_accept
+
+
+def test_intermodal_reject_missing_savings_is_penalised() -> None:
+    state = IntermodalTransferState(
+        truck_rate=1000.0, intermodal_rate=780.0,  # 22% savings
+        truck_transit_days=3.0, intermodal_transit_days=4.0,
+        delivery_window_days=3.0,
+        intermodal_reliability_pct=0.85,
+    )
+    r_accept = intermodal_transfer_reward(state, _decision(action=0))
+    r_reject = intermodal_transfer_reward(state, _decision(action=1))
+    assert r_accept > r_reject
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Equipment reposition — directional tests
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_equipment_reposition_high_roi_high_util_deficit() -> None:
+    state = EquipmentRepositionState(
+        source_equipment_count=20, source_demand_next_7d=5,
+        target_equipment_count=2, target_demand_next_7d=10,
+        reposition_miles=150.0, reposition_cost=300.0,
+        cost_of_not_repositioning=900.0,  # ROI = 3.0
+        network_deficit_locations=2, network_surplus_locations=3,
+        fleet_utilization_pct=0.90,
+    )
+    r_repos = equipment_reposition_reward(state, _decision(action=9))  # REPOSITION
+    r_hold = equipment_reposition_reward(state, _decision(action=10))  # HOLD
+    assert r_repos > r_hold
+    assert r_repos > 0.85
+
+
+def test_equipment_hold_when_no_deficit_low_util() -> None:
+    state = EquipmentRepositionState(
+        source_equipment_count=20, source_demand_next_7d=5,
+        target_equipment_count=15, target_demand_next_7d=8,
+        reposition_miles=500.0, reposition_cost=900.0,
+        cost_of_not_repositioning=200.0,  # ROI < 1
+        network_deficit_locations=0,
+        fleet_utilization_pct=0.50,
+    )
+    r_hold = equipment_reposition_reward(state, _decision(action=10))
+    r_repos = equipment_reposition_reward(state, _decision(action=9))
+    assert r_hold > r_repos
+
+
+def test_equipment_long_repos_penalised_by_transit_cost() -> None:
+    short = EquipmentRepositionState(
+        source_equipment_count=20, source_demand_next_7d=5,
+        target_equipment_count=2, target_demand_next_7d=10,
+        reposition_miles=100.0, reposition_cost=300.0,
+        cost_of_not_repositioning=900.0,
+        network_deficit_locations=1,
+        fleet_utilization_pct=0.90,
+    )
+    long = EquipmentRepositionState(
+        source_equipment_count=20, source_demand_next_7d=5,
+        target_equipment_count=2, target_demand_next_7d=10,
+        reposition_miles=950.0, reposition_cost=300.0,
+        cost_of_not_repositioning=900.0,
+        network_deficit_locations=1,
+        fleet_utilization_pct=0.90,
+    )
+    r_short = equipment_reposition_reward(short, _decision(action=9))
+    r_long = equipment_reposition_reward(long, _decision(action=9))
+    assert r_short > r_long
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Load build — directional tests
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_load_build_consolidate_with_savings_in_band() -> None:
+    state = LoadBuildState(
+        max_weight=44000.0, max_volume=2700.0,
+        total_weight=30000.0, total_volume=2000.0,  # ~70% fill
+        ftl_rate=1000.0, ltl_rate_sum=1400.0,
+        consolidation_savings=400.0,  # 40% of ftl_rate
+        shipment_count=3, stop_count=2, max_stops=3,
+    )
+    r_cons = load_build_reward(state, _decision(action=7))  # CONSOLIDATE
+    r_accept = load_build_reward(state, _decision(action=0))
+    assert r_cons > r_accept
+
+
+def test_load_build_split_when_over_capacity() -> None:
+    state = LoadBuildState(
+        max_weight=44000.0, max_volume=2700.0,
+        total_weight=43500.0, total_volume=2680.0,  # ~98% fill
+        ftl_rate=1000.0, ltl_rate_sum=1000.0, consolidation_savings=0.0,
+        shipment_count=4, stop_count=1, max_stops=3,
+    )
+    r_split = load_build_reward(state, _decision(action=8))  # SPLIT
+    r_accept = load_build_reward(state, _decision(action=0))
+    assert r_split > r_accept
+
+
+def test_load_build_reject_required_on_hazmat_conflict() -> None:
+    state = LoadBuildState(
+        max_weight=44000.0, max_volume=2700.0,
+        total_weight=20000.0, total_volume=1500.0,
+        ftl_rate=1000.0, ltl_rate_sum=1300.0, consolidation_savings=300.0,
+        shipment_count=2, stop_count=1, max_stops=3,
+        has_hazmat_conflict=True,
+    )
+    r_reject = load_build_reward(state, _decision(action=1))  # REJECT
+    r_cons = load_build_reward(state, _decision(action=7))
+    assert r_reject > r_cons
+
+
+def test_load_build_defer_when_underfilled_single_shipment() -> None:
+    state = LoadBuildState(
+        max_weight=44000.0, max_volume=2700.0,
+        total_weight=10000.0, total_volume=600.0,  # ~23% fill
+        ftl_rate=1000.0, ltl_rate_sum=900.0, consolidation_savings=0.0,
+        shipment_count=1, stop_count=1, max_stops=3,
+    )
+    r_defer = load_build_reward(state, _decision(action=2))  # DEFER
+    r_accept = load_build_reward(state, _decision(action=0))
+    assert r_defer > r_accept
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Output range invariants
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "trm_name,state",
+    [
+        ("dock_scheduling", DockSchedulingState()),
+        ("intermodal_transfer", IntermodalTransferState()),
+        ("equipment_reposition", EquipmentRepositionState()),
+        ("load_build", LoadBuildState()),
+    ],
+)
+def test_reward_lies_in_expected_range(trm_name: str, state) -> None:
+    for action in (0, 1, 2, 3, 4, 7, 8, 9, 10):
+        r = compute_native_tms_reward(trm_name, state, _decision(action=action))
+        assert r is not None
+        assert 0.0 <= r <= 1.5, f"{trm_name} action={action} reward={r}"

--- a/docs/TMS_TRM_TRAINING_DATA_SPECIFICATION.md
+++ b/docs/TMS_TRM_TRAINING_DATA_SPECIFICATION.md
@@ -709,27 +709,40 @@ state builders on top of the transport-oriented scenario archetypes.
 
 ## Reward Functions
 
-TMS TRMs currently inherit SCP-analogue reward weights from
-`DEFAULT_TRM_REWARD_WEIGHTS`. Mappings:
+Four TMS TRMs have **native transport-KPI reward weights** in
+[`backend/app/services/powell/tms_reward_weights.py`](../backend/app/services/powell/tms_reward_weights.py)
+— `TMS_TRM_REWARD_WEIGHTS`. The other seven retain SCP-analogue
+weights from `DEFAULT_TRM_REWARD_WEIGHTS` (spec §6 considers those
+mappings appropriate; revisit if SCP-shape signal semantics drift
+from TMS reality).
 
-| TMS TRM | SC Proxy | Weights |
-|---------|----------|---------|
-| Capacity Promise | ATP_EXECUTOR | fill_rate (0.4) + on_time_bonus (0.2) + priority_weight (0.2) + fairness_penalty (0.2) |
-| Exception Management | ORDER_TRACKING | detection (0.4) + resolution_speed (0.3) + escalation (0.3) |
-| Intermodal Transfer | TO_EXECUTION | on_time_delivery (0.4) + consolidation_bonus (0.3) + cost_efficiency (0.3) |
-| Equipment Reposition | REBALANCING | service_improvement (0.5) + transfer_cost_penalty (0.3) + balance_improvement (0.2) |
-| Freight Procurement | PO_CREATION | stockout_penalty (0.4) + target_coverage (0.3) + cost (0.2) + timing (0.1) |
-| Load Build | ATP_EXECUTOR | fill_rate emphasized; consolidation savings as bonus |
-| Dock Scheduling | — | TODO: native TMS weights (dwell, detention, throughput) |
-| Broker Routing | PO_CREATION | cost + reliability blend |
-| Capacity Buffer | SAFETY_STOCK | service_level_deviation (0.5) + holding_cost (0.3) + excess (0.2) |
-| Shipment Tracking | ORDER_TRACKING | detection + resolution + escalation |
-| Demand Sensing | FORECAST_ADJUSTMENT | bias_reduction (0.5) + MAPE_improvement (0.3) + stability (0.2) |
-| Forecast Baseline | FORECAST_BASELINE | MAPE (0.5) + FVA (0.3) + conformal_coverage (0.2) |
+| TMS TRM | Source | Weights |
+|---------|--------|---------|
+| Capacity Promise | SCP proxy (ATP_EXECUTOR) | fill_rate (0.4) + on_time_bonus (0.2) + priority_weight (0.2) + fairness_penalty (0.2) |
+| Exception Management | SCP proxy (ORDER_TRACKING) | detection (0.4) + resolution_speed (0.3) + escalation (0.3) |
+| **Intermodal Transfer** | **NATIVE TMS** | mode_shift_savings (0.40) + on_time_intermodal (0.25) + delivery_window_slack (0.20) + reliability_bonus (0.15) |
+| **Equipment Reposition** | **NATIVE TMS** | reposition_roi (0.40) + fleet_utilization_gain (0.30) + network_balance_improvement (0.20) + transit_cost_penalty (0.10) |
+| Freight Procurement | SCP proxy (PO_CREATION) | stockout_penalty (0.4) + target_coverage (0.3) + cost (0.2) + timing (0.1) |
+| **Load Build** | **NATIVE TMS** | fill_rate (0.40) + consolidation_savings (0.30) + stops_efficiency (0.15) + priority_alignment (0.15); hazmat / temp conflicts hard-gate to REJECT |
+| **Dock Scheduling** | **NATIVE TMS** | throughput_alignment (0.35) + detention_avoidance (0.35) + dwell_efficiency (0.20) + priority_alignment (0.10) |
+| Broker Routing | SCP proxy (PO_CREATION) | cost + reliability blend |
+| Capacity Buffer | SCP proxy (SAFETY_STOCK) | service_level_deviation (0.5) + holding_cost (0.3) + excess (0.2) |
+| Shipment Tracking | SCP proxy (ORDER_TRACKING) | detection + resolution + escalation |
+| Demand Sensing | SCP proxy (FORECAST_ADJUSTMENT) | bias_reduction (0.5) + MAPE_improvement (0.3) + stability (0.2) |
+| Forecast Baseline | SCP proxy (FORECAST_BASELINE) | MAPE (0.5) + FVA (0.3) + conformal_coverage (0.2) |
 
-**Open action:** Native TMS reward weights for Dock Scheduling,
-Intermodal Transfer, Equipment Reposition, and Load Build should
-replace the SC proxies once real transport KPI data is collected.
+Native-weight provenance — domain thresholds and weight magnitudes
+follow §6 industry references (DAT, AAR, FMCSA, BNSF / CSX service
+floors, operations-research consolidation literature). Each native
+reward function is unit-tested for directional correctness against
+clear-case scenarios in
+[`backend/tests/services/powell/test_tms_reward_weights.py`](../backend/tests/services/powell/test_tms_reward_weights.py).
+
+The native reward functions are invoked from
+[`generate_tms_corpus.py`](../backend/scripts/pretraining/generate_tms_corpus.py)
+via `compute_native_tms_reward(trm_name, state, decision)`. When this
+returns `None` (the seven SCP-proxy TRMs) the corpus generator falls
+back to the generic action-based `compute_reward()`.
 
 ---
 
@@ -807,7 +820,7 @@ replace the SC proxies once real transport KPI data is collected.
 
 ## Open Items
 
-1. **Native TMS reward weights** — Dock Scheduling, Intermodal Transfer, Equipment Reposition, Load Build currently inherit SC proxies. Need transport-specific KPIs (dwell time, detention dollars, intermodal OTD, fleet utilization).
+1. **Native TMS reward weights** — ~~Dock Scheduling, Intermodal Transfer, Equipment Reposition, Load Build currently inherit SC proxies.~~ **Closed 2026-05-10.** Native transport-KPI weights live in [`tms_reward_weights.py`](../backend/app/services/powell/tms_reward_weights.py); see the table above. Future revisit: replace any of the remaining seven SCP-proxy mappings if real TMS KPI data shows the proxy is misleading the training signal.
 
 2. **Phase 2 teachers** — TMS currently uses single-teacher labels. Add secondary teachers (e.g. DAT-benchmark based freight procurement, regulatory-first exception escalation) to introduce multi-teacher consensus matching SCP's approach.
 


### PR DESCRIPTION
## Summary

Closes Open Item #1 from `TMS_TRM_TRAINING_DATA_SPECIFICATION.md §8` — replaces SCP-proxy reward weights for **Dock Scheduling**, **Intermodal Transfer**, **Equipment Reposition**, and **Load Build** with native transport KPIs.

## Reward weight tables

| TRM | Weights |
|---|---|
| Dock Scheduling | throughput_alignment (0.35) + detention_avoidance (0.35) + dwell_efficiency (0.20) + priority_alignment (0.10) |
| Intermodal Transfer | mode_shift_savings (0.40) + on_time_intermodal (0.25) + delivery_window_slack (0.20) + reliability_bonus (0.15) |
| Equipment Reposition | reposition_roi (0.40) + fleet_utilization_gain (0.30) + network_balance_improvement (0.20) + transit_cost_penalty (0.10) |
| Load Build | fill_rate (0.40) + consolidation_savings (0.30) + stops_efficiency (0.15) + priority_alignment (0.15); hazmat / temp conflicts hard-gate to REJECT |

Weight magnitudes grounded in industry references (DAT, AAR, FMCSA, BNSF/CSX service-level floors, operations-research consolidation literature) per spec §6.

The other seven TMS TRMs continue with SCP-proxy weights — spec §6 considers those mappings appropriate. Revisit if real TMS KPI data shows a proxy is misleading the training signal.

## Files

- **New:** [`backend/app/services/powell/tms_reward_weights.py`](backend/app/services/powell/tms_reward_weights.py) — `TMS_TRM_REWARD_WEIGHTS` table + four reward functions + `compute_native_tms_reward()` dispatch
- **New:** [`backend/tests/services/powell/test_tms_reward_weights.py`](backend/tests/services/powell/test_tms_reward_weights.py) — 25 tests
- **Wiring:** [`backend/scripts/pretraining/generate_tms_corpus.py`](backend/scripts/pretraining/generate_tms_corpus.py) — try native reward first, fall back to action-based `compute_reward()` on `None`
- **Spec:** [`docs/TMS_TRM_TRAINING_DATA_SPECIFICATION.md`](docs/TMS_TRM_TRAINING_DATA_SPECIFICATION.md) — table updated to mark the four NATIVE entries; Open Item #1 closed

## Test plan

- [x] **25/25 unit tests passing** — weight-table invariants (sums to 1.0, dispatch table consistent), per-TRM directional cases, output-range bounds `[0, 1.5]` for every action × TRM combination
- [x] Two real defects caught and fixed during test development:
  - Load build: ACCEPT at >95% fill was equal-rewarded with SPLIT — now penalised as a capacity violation
  - Load build: hazmat / temperature conflict didn't strongly enough force REJECT — now a hard gate (only REJECT earns full credit)
- [ ] Re-run a corpus generation cycle (`generate_tms_corpus.py --trm load_build --samples 50000`) and confirm reward distribution shifts as expected vs the pre-patch corpus (manual verification before training)

## Open follow-ups

- Phase 2 secondary teachers for the 4 native TRMs (would let consensus check the native reward against a different label source)
- Re-evaluate SCP-proxy mappings for the other 7 TRMs after first real-data backtest
- RL fine-tune via the lane-flow twin will use these weights as the live training signal once PPO lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)