### PR TITLE
chore(deps): bump Core pins to 8c6cd00 + adopt azirella-powell-core

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,18 +1,24 @@
 absl-py==2.3.1
 aiofiles==0.7.0
-azirella-data-model @ git+https://github.com/azirella-ltd/Autonomy-Core.git@37d22c7#subdirectory=packages/data-model
-azirella-integrations @ git+https://github.com/azirella-ltd/Autonomy-Core.git@37d22c7#subdirectory=packages/integrations
-azirella-demand-planning-contract @ git+https://github.com/azirella-ltd/Autonomy-Core.git@37d22c7#subdirectory=packages/demand-planning-contract
-azirella-transfer-order-envelope-contract @ git+https://github.com/azirella-ltd/Autonomy-Core.git@37d22c7#subdirectory=packages/transfer-order-envelope-contract
-azirella-a2a-client @ git+https://github.com/azirella-ltd/Autonomy-Core.git@37d22c7#subdirectory=packages/a2a-client
+azirella-data-model @ git+https://github.com/azirella-ltd/Autonomy-Core.git@8c6cd00#subdirectory=packages/data-model
+azirella-integrations @ git+https://github.com/azirella-ltd/Autonomy-Core.git@8c6cd00#subdirectory=packages/integrations
+azirella-demand-planning-contract @ git+https://github.com/azirella-ltd/Autonomy-Core.git@8c6cd00#subdirectory=packages/demand-planning-contract
+azirella-transfer-order-envelope-contract @ git+https://github.com/azirella-ltd/Autonomy-Core.git@8c6cd00#subdirectory=packages/transfer-order-envelope-contract
+azirella-a2a-client @ git+https://github.com/azirella-ltd/Autonomy-Core.git@8c6cd00#subdirectory=packages/a2a-client
 # AD-12 v3 router substrate (CONSUMER_ADOPTION_LOG 2026-05-04 §3.48). Used by
 # lifecycle_reactor_factory.py for cross-plane DP calls; supports HEURISTIC +
 # AZIRELLA tier dispatch transparently. heuristics-common is a router dep.
-azirella-router @ git+https://github.com/azirella-ltd/Autonomy-Core.git@37d22c7#subdirectory=packages/azirella-router
+azirella-router @ git+https://github.com/azirella-ltd/Autonomy-Core.git@8c6cd00#subdirectory=packages/azirella-router
 # azirella-heuristics-common — warning regime + exception substrate. Dep
 # of autonomy-tms-heuristics' cross-plane handlers; canonical home for
 # AZIRELLA-STUB-WARNING marker + HeuristicWriteRefused.
-azirella-heuristics-common @ git+https://github.com/azirella-ltd/Autonomy-Core.git@37d22c7#subdirectory=packages/azirella-heuristics-common
+azirella-heuristics-common @ git+https://github.com/azirella-ltd/Autonomy-Core.git@8c6cd00#subdirectory=packages/azirella-heuristics-common
+# azirella-powell-core — Powell GNN substrate (POWELL_GNN_SUBSTRATE.md
+# §4). Provides SignalBus, CheckpointStorage, SchedulerHook, TrainingLoop,
+# GraphSAGEScaffolding, tGNNScaffolding. Used by GNN-3 / GNN-4 / GNN-5 /
+# GNN-6 in TMS_POWELL_GNN_REWRITE.md; without it the TMS-shape heads
+# can't be built. ``gnn`` extra pulls torch + torch-geometric.
+azirella-powell-core[gnn,scheduler] @ git+https://github.com/azirella-ltd/Autonomy-Core.git@8c6cd00#subdirectory=packages/powell-core
 # autonomy-tms-heuristics — single authoritative source of TMS conservative-
 # default heuristic math (PR-LOCK, 2026-05-04, §3.52). Used by (1) internal
 # TRM runtime fallback via compute_tms_decision, (2) BC training-corpus


### PR DESCRIPTION
Catches up TMS to msi-stealth's recent Core deliveries. **Infrastructure-only** — nothing in TMS imports from `powell-core` yet; the first consumer ships with GNN-3.

## What's in the bump

| From | To |
|---|---|
| `37d22c7` | `8c6cd00` (HEAD of Core main, 2026-05-11) |

Bumped (all to `8c6cd00`):
- `azirella-data-model`
- `azirella-integrations`
- `azirella-demand-planning-contract`
- `azirella-transfer-order-envelope-contract`
- `azirella-a2a-client`
- `azirella-router`
- `azirella-heuristics-common`

Newly added:
- **`azirella-powell-core[gnn,scheduler]`** — the Powell substrate from [POWELL_GNN_SUBSTRATE.md](../../Autonomy-Core/docs/architecture/POWELL_GNN_SUBSTRATE.md). `[gnn]` pulls torch + torch-geometric (for `GraphSAGEScaffolding` / `tGNNScaffolding`); `[scheduler]` pulls APScheduler (for `APSchedulerHook`).

## Notable Core changes consumed by this bump

- **`powell-core` v0.4.0** — 5 commits delivered `GraphSAGEScaffolding`, `tGNNScaffolding`, `TrainingLoop`, `SignalBus` / `CheckpointStorage` / `SchedulerHook` protocols + default implementations. Unblocks GNN-3 + GNN-4 + GNN-5 + GNN-6 on the TMS side.
- **AD-5** — `ForecastAdjustment` + `ForecastPipeline` ORMs moved into Core; re-export paths unchanged so TMS imports keep working.
- **MIGRATION_REGISTER §1.17** — plane-licensing awareness (Tier 1). Phase 3 (~1 day) is on acer-nitro's plate once Core's Phase 1 lands the `@requires_plane` decorator.
- **AD-13 §3.56** — unified-backend rollout continues; not directly consumed by TMS yet.

## Test plan

- [x] All `@37d22c7` → `@8c6cd00` substitutions verified — only the pin-set lines changed
- [x] `azirella-powell-core[gnn,scheduler]` extras confirmed defined in [`Autonomy-Core/packages/powell-core/pyproject.toml`](../../Autonomy-Core/packages/powell-core/pyproject.toml)
- [ ] `pip install -r backend/requirements.txt` in a clean venv — deferred to CI / deployment verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)