### PR TITLE
chore(env): adopt mss1-max MoE model renames (CHAT + NARRATION)

### DIFF
--- a/.env.dev.template
+++ b/.env.dev.template
@@ -30,9 +30,9 @@ LLM_LAB_API_KEY=
 
 # Workload-split endpoints (preferred — see LLM_ARCHITECTURE.md §3.2).
 LLM_NARRATION_API_BASE=http://mss1-max.local:8080/v1/narration
-LLM_NARRATION_MODEL_NAME=llama-3.3-70b-q5
+LLM_NARRATION_MODEL_NAME=gpt-oss-120b
 LLM_CHAT_API_BASE=http://mss1-max.local:8080/v1/chat
-LLM_CHAT_MODEL_NAME=qwen3-32b-q5
+LLM_CHAT_MODEL_NAME=qwen3-30b-a3b
 LLM_EMBEDDINGS_API_BASE=http://mss1-max.local:8080/v1/embeddings
 LLM_EMBEDDINGS_MODEL_NAME=nomic-embed-text-v1.5
 
@@ -40,6 +40,6 @@ LLM_EMBEDDINGS_MODEL_NAME=nomic-embed-text-v1.5
 # (MIGRATION_REGISTER §3.16). Point at the same gateway.
 LLM_API_BASE=http://mss1-max.local:8080/v1/chat
 LLM_API_KEY=${LLM_LAB_API_KEY}
-LLM_MODEL_NAME=qwen3-32b-q5
+LLM_MODEL_NAME=qwen3-30b-a3b
 AUTONOMY_ENABLE_SUPERVISOR=true
 AUTONOMY_ENABLE_GLOBAL_AGENT=false


### PR DESCRIPTION
## Summary

Pick up the Core 2026-05-14 + 2026-05-15 lab gateway model swaps. Both renames in one diff per Core's CONSUMER_ADOPTION_LOG guidance.

| Env var | Before | After |
|---|---|---|
| `LLM_CHAT_MODEL_NAME` | `qwen3-32b-q5` | `qwen3-30b-a3b` |
| `LLM_NARRATION_MODEL_NAME` | `llama-3.3-70b-q5` | `gpt-oss-120b` |
| `LLM_MODEL_NAME` (legacy alias) | `qwen3-32b-q5` | `qwen3-30b-a3b` |

Gateway URL, API key, embeddings model unchanged.

## Why

Core swapped both lab models to MoE variants because Strix Halo's 256 GB/s UMA was capping the dense models at ~5-10 tok/s. MoE moves only the activated experts through memory per token. Throughput on Strix Halo Vulkan (measured by Core):

| Workload | Old (dense) | New (MoE) | Gain |
|---|---|---|---|
| CHAT generation | 9.5 tok/s | 83 tok/s | 7.8× |
| NARRATION generation | ~5 tok/s | 53 tok/s | 10.6× |

## Refs

- [Autonomy-Core PR #77](https://github.com/azirella-ltd/Autonomy-Core/pull/77) — CHAT model swap
- [Autonomy-Core PR #78](https://github.com/azirella-ltd/Autonomy-Core/pull/78) — NARRATION model swap
- `Autonomy-Core/docs/CONSUMER_ADOPTION_LOG.md` 2026-05-14 + 2026-05-15 entries

## Test plan

- [x] `.env.dev.template` updated; diff is 3 lines.
- [ ] (Operator) Re-source dev `.env` in any running TMS backend container.
- [ ] (Operator) Smoke-test Assistant chat panel and executive-briefing generation; expect ~7-10× faster than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)