### PR TITLE
§3.8.2 — TMS self-registers MCP URL on startup

### DIFF
--- a/backend/app/services/mcp_self_register.py
+++ b/backend/app/services/mcp_self_register.py
@@ -1,0 +1,123 @@
+"""§3.8.2 — TMS MCP self-registration on app startup.
+
+TMS runs an MCP server (``app/mcp_server/``) as a sidecar to the
+modular monolith. Peer planes (SCP, DP) discover TMS's MCP URL
+through the plane registry (``plane_registration.mcp_endpoint_url``
+added by Core migration ``0048``) — *not* through hard-coded env
+vars on the peer's side. This module is TMS's contribution to that
+contract: on startup, sync every active Transport-plane
+registration to the currently-configured public MCP URL.
+
+Why sync on every startup rather than at provisioning time:
+
+  * Idempotent. Re-running the registration is harmless.
+  * URL changes (port shift, host migration, customer-managed
+    DNS) propagate without touching provisioning code.
+  * Doesn't require coordinated provisioning + sidecar deployment
+    timing — provisioning creates the row, the next TMS restart
+    populates the URL.
+
+Env var contract:
+
+  * ``TMS_MCP_PUBLIC_URL`` — the URL peers should call. Required to
+    activate self-registration. When unset, the function logs INFO
+    and exits cleanly (deployments that don't expose MCP externally
+    legitimately leave this empty).
+
+Mirror of the SCP-side ``mcp_self_register.py`` in Autonomy-SCP
+commit 31c5b320; differs only in plane (``Plane.TRANSPORT`` vs
+``Plane.SUPPLY``) and env var name. Two distinct copies, not a
+shared module — each plane registers its own endpoint, and the
+trivial difference between the two doesn't justify a Core-side
+shared service.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+_ENV_VAR = "TMS_MCP_PUBLIC_URL"
+
+
+def _resolve_public_url() -> Optional[str]:
+    """Read the publicly-resolvable MCP URL from env, or return None.
+
+    Two env-var spellings are accepted for backward compatibility:
+    ``TMS_MCP_PUBLIC_URL`` (preferred — explicit "public") and
+    ``MCP_PUBLIC_URL`` (generic fallback for deployments that set
+    a single value per plane).
+    """
+    url = os.getenv(_ENV_VAR) or os.getenv("MCP_PUBLIC_URL")
+    return url.strip() if url else None
+
+
+def self_register_mcp_endpoint(session_factory) -> int:
+    """Sync the TMS MCP URL into every active Transport-plane registration.
+
+    :param session_factory: a zero-arg callable returning a new
+        synchronous SQLAlchemy ``Session``. Same pattern as the
+        existing startup hooks (``sync_session_factory``) — we hold
+        the session only as long as the sync takes.
+    :returns: number of registrations updated. ``0`` when the env
+        var is unset (deployment opts out) or when no Transport-plane
+        registrations exist yet (fresh install).
+    """
+    url = _resolve_public_url()
+    if not url:
+        logger.info(
+            "§3.8.2: TMS MCP self-registration skipped — %s is unset. "
+            "Cross-plane peers will see Plane.TRANSPORT mcp_endpoint_url "
+            "as NULL and drop into solo-mode.",
+            _ENV_VAR,
+        )
+        return 0
+
+    # Lazy imports — keep service-module load time cheap.
+    from azirella_data_model.planes import Plane, PlaneRegistration, PlaneRegistry
+
+    updated = 0
+    skipped = 0
+    db = session_factory()
+    try:
+        rows = (
+            db.query(PlaneRegistration)
+            .filter(
+                PlaneRegistration.plane == Plane.TRANSPORT,
+                PlaneRegistration.deregistered_at.is_(None),
+            )
+            .all()
+        )
+        for row in rows:
+            if row.mcp_endpoint_url == url:
+                skipped += 1
+                continue
+            ok = PlaneRegistry.set_mcp_endpoint(
+                db,
+                tenant_id=row.tenant_id,
+                plane=Plane.TRANSPORT,
+                mcp_endpoint_url=url,
+                config_id=row.config_id,
+            )
+            if ok:
+                updated += 1
+        db.commit()
+    except Exception as exc:  # noqa: BLE001 — best-effort startup hook
+        db.rollback()
+        logger.warning(
+            "§3.8.2: TMS MCP self-registration failed (will retry on next "
+            "startup): %s", exc,
+        )
+        return 0
+    finally:
+        db.close()
+
+    logger.info(
+        "§3.8.2: TMS MCP self-registration synced %d registration(s) to %s "
+        "(%d already up-to-date).",
+        updated, url, skipped,
+    )
+    return updated

--- a/backend/main.py
+++ b/backend/main.py
@@ -641,6 +641,17 @@ async def startup_event():
             except Exception as e:
                 logger.debug(f"MCP writeback executor registration skipped: {e}")
 
+            # §3.8.2: Self-register TMS's MCP URL into every active
+            # Transport-plane registration so peer planes (SCP, DP) can
+            # discover it through the plane registry instead of
+            # hard-coded env-var config. No-ops when TMS_MCP_PUBLIC_URL
+            # is unset (deployments that don't expose MCP externally).
+            try:
+                from app.services.mcp_self_register import self_register_mcp_endpoint
+                self_register_mcp_endpoint(sync_session_factory)
+            except Exception as e:
+                logger.warning("§3.8.2 TMS MCP self-registration skipped: %s", e)
+
             # CDT startup: load existing calibration from DB into memory.
             # Fast (< 5s) — reads decision-outcome pairs already stored.
             # Simulation bootstrap only runs during provisioning (conformal step)

--- a/backend/tests/services/test_mcp_self_register.py
+++ b/backend/tests/services/test_mcp_self_register.py
@@ -1,0 +1,152 @@
+"""§3.8.2 — TMS MCP self-registration unit tests.
+
+Mirror of the SCP-side test_mcp_self_register; pinned to
+``Plane.TRANSPORT`` + ``TMS_MCP_PUBLIC_URL`` env var. Uses an
+in-memory SQLite session pointed at a minimal
+``PlaneRegistration``-only schema with stubbed FK targets.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import Column, Integer, MetaData, Table, create_engine
+from sqlalchemy.orm import sessionmaker
+
+import azirella_data_model.base as _dm_base
+from azirella_data_model.planes.plane import Plane
+from azirella_data_model.planes.tier import Tier
+from azirella_data_model.planes.producer_tier import ProducerTier
+
+for _stub in ("tenants", "supply_chain_configs"):
+    if _stub not in _dm_base.Base.metadata.tables:
+        Table(
+            _stub,
+            _dm_base.Base.metadata,
+            Column("id", Integer, primary_key=True),
+        )
+
+from azirella_data_model.planes.registry import PlaneRegistration  # noqa: E402
+
+from app.services.mcp_self_register import self_register_mcp_endpoint  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    for k in ("TMS_MCP_PUBLIC_URL", "MCP_PUBLIC_URL"):
+        monkeypatch.delenv(k, raising=False)
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite:///:memory:")
+    PlaneRegistration.metadata.create_all(
+        engine, tables=[PlaneRegistration.__table__]
+    )
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    yield SessionLocal
+    engine.dispose()
+
+
+def _insert(session_factory, tenant_id, plane, *, mcp_url=None, deregistered=False):
+    db = session_factory()
+    row = PlaneRegistration(
+        tenant_id=tenant_id,
+        applies_to_all_configs=True,
+        plane=plane,
+        tier=Tier.T1_EXECUTION,
+        cross_plane_intersection=False,
+        skills_narration=False,
+        premium_narration=False,
+        producer_tier=ProducerTier.AZIRELLA,
+        mcp_endpoint_url=mcp_url,
+    )
+    if deregistered:
+        from datetime import datetime
+        row.deregistered_at = datetime.utcnow()
+    db.add(row)
+    db.commit()
+    db.close()
+
+
+def test_env_unset_is_no_op(session_factory, caplog):
+    _insert(session_factory, 1, Plane.TRANSPORT)
+    with caplog.at_level(logging.INFO):
+        n = self_register_mcp_endpoint(session_factory)
+    assert n == 0
+    assert any("TMS_MCP_PUBLIC_URL is unset" in r.message for r in caplog.records)
+
+
+def test_env_set_updates_active_transport_rows(session_factory, monkeypatch):
+    monkeypatch.setenv("TMS_MCP_PUBLIC_URL", "http://tms.local/mcp")
+    _insert(session_factory, 1, Plane.TRANSPORT)
+    _insert(session_factory, 2, Plane.TRANSPORT)
+
+    n = self_register_mcp_endpoint(session_factory)
+    assert n == 2
+
+    db = session_factory()
+    rows = db.query(PlaneRegistration).filter_by(plane=Plane.TRANSPORT).all()
+    assert {r.mcp_endpoint_url for r in rows} == {"http://tms.local/mcp"}
+    db.close()
+
+
+def test_already_up_to_date_rows_not_rewritten(session_factory, monkeypatch):
+    monkeypatch.setenv("TMS_MCP_PUBLIC_URL", "http://tms.local/mcp")
+    _insert(session_factory, 1, Plane.TRANSPORT, mcp_url="http://tms.local/mcp")
+    _insert(session_factory, 2, Plane.TRANSPORT)  # needs update
+
+    n = self_register_mcp_endpoint(session_factory)
+    assert n == 1
+
+
+def test_non_transport_plane_rows_untouched(session_factory, monkeypatch):
+    monkeypatch.setenv("TMS_MCP_PUBLIC_URL", "http://tms.local/mcp")
+    _insert(session_factory, 1, Plane.TRANSPORT)
+    _insert(session_factory, 1, Plane.SUPPLY)
+    _insert(session_factory, 1, Plane.DEMAND)
+
+    n = self_register_mcp_endpoint(session_factory)
+    assert n == 1  # only TRANSPORT row touched
+
+    db = session_factory()
+    scp_row = db.query(PlaneRegistration).filter_by(plane=Plane.SUPPLY).one()
+    dp_row = db.query(PlaneRegistration).filter_by(plane=Plane.DEMAND).one()
+    assert scp_row.mcp_endpoint_url is None
+    assert dp_row.mcp_endpoint_url is None
+    db.close()
+
+
+def test_deregistered_rows_skipped(session_factory, monkeypatch):
+    monkeypatch.setenv("TMS_MCP_PUBLIC_URL", "http://tms.local/mcp")
+    _insert(session_factory, 1, Plane.TRANSPORT, deregistered=True)
+
+    n = self_register_mcp_endpoint(session_factory)
+    assert n == 0
+
+
+def test_generic_mcp_public_url_fallback(session_factory, monkeypatch):
+    monkeypatch.delenv("TMS_MCP_PUBLIC_URL", raising=False)
+    monkeypatch.setenv("MCP_PUBLIC_URL", "http://tms.local/mcp")
+    _insert(session_factory, 1, Plane.TRANSPORT)
+
+    n = self_register_mcp_endpoint(session_factory)
+    assert n == 1
+
+
+def test_db_exception_returns_zero_and_warns(session_factory, monkeypatch, caplog):
+    monkeypatch.setenv("TMS_MCP_PUBLIC_URL", "http://tms.local/mcp")
+
+    failing_factory = MagicMock()
+    failing_db = MagicMock()
+    failing_db.query.side_effect = RuntimeError("connection lost")
+    failing_factory.return_value = failing_db
+
+    with caplog.at_level(logging.WARNING):
+        n = self_register_mcp_endpoint(failing_factory)
+    assert n == 0
+    assert failing_db.rollback.called
+    assert failing_db.close.called
+    assert any("self-registration failed" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- Adds `app/services/mcp_self_register.py` — on startup, reads `TMS_MCP_PUBLIC_URL` and syncs every active `Plane.TRANSPORT` registration to that URL via `PlaneRegistry.set_mcp_endpoint(...)`.
- Wires the self-register call into the existing `@app.on_event(\"startup\")` hook in `backend/main.py`, right after the MCP writeback executor.
- 7 unit tests covering env-unset / env-set / idempotent re-run / non-TRANSPORT untouched / deregistered skipped / generic env-var fallback / DB-exception path.

Mirror of [Autonomy-SCP PR #347](https://github.com/azirella-ltd/Autonomy-SCP/pull/347) — same shape, pinned to `Plane.TRANSPORT` + `TMS_MCP_PUBLIC_URL`. Two distinct services (this + the SCP twin), not a shared Core module — the (plane, env-var) tuple is the only difference and a shared service would have to over-parameterise for a 100-line × 2 file split.

This closes the **TMS half** of [MIGRATION_REGISTER §3.8.2](https://github.com/azirella-ltd/Autonomy-Core/blob/main/docs/MIGRATION_REGISTER.md#382--scp-mcp-server-productionisation--plane-registry-mcp-url-field). Core substrate landed in [Autonomy-Core/9a71cd1](https://github.com/azirella-ltd/Autonomy-Core/commit/9a71cd1) (`resolve_peer_mcp_url` + `build_peer_mcp_params`) and [Autonomy-Core/1cf8298](https://github.com/azirella-ltd/Autonomy-Core/commit/1cf8298) (`plane_registration.mcp_endpoint_url` column + helpers).

## Behaviour

| State | Behaviour |
|---|---|
| `TMS_MCP_PUBLIC_URL` unset | INFO log, no-op. `mcp_endpoint_url` stays NULL; peer planes drop into solo-mode per `cross-plane-mcp-only`. |
| `TMS_MCP_PUBLIC_URL` set, fresh tenant | Sets the URL on the `Plane.TRANSPORT` row. |
| `TMS_MCP_PUBLIC_URL` set, already-up-to-date | Skipped. Idempotent. |
| `TMS_MCP_PUBLIC_URL` set, DB hiccup | Rollback, WARN logged, startup continues. Next restart retries. |

## Deployment

Set `TMS_MCP_PUBLIC_URL` in any environment where peer planes (SCP, DP) need to call TMS's MCP sidecar (the URL peers should hit, e.g. `https://tms.customer.com/mcp`). Single-tenant dev typically leaves this empty.

## Test plan

- [x] 7 unit tests pass
- [ ] Manual smoke: set env var, restart TMS backend, verify `plane_registration.mcp_endpoint_url` populated for every active TRANSPORT row
- [ ] After SCP PR #347 + this PR merge: end-to-end smoke of SCP calling `resolve_peer_mcp_url(...)` for `Plane.TRANSPORT` and getting TMS's URL back

🤖 Generated with [Claude Code](https://claude.com/claude-code)